### PR TITLE
Handle all shells’ de/activation

### DIFF
--- a/src/common/utils/unsafeEntries.ts
+++ b/src/common/utils/unsafeEntries.ts
@@ -1,0 +1,5 @@
+/** Converts an object from a trusted source (i.e. without unknown entries) to a typed array */
+export default function entries<T extends { [key: string]: object }, K extends keyof T>(o: T): [keyof T, T[K]][] {
+    return Object.entries(o) as [keyof T, T[K]][]
+}
+ 

--- a/src/common/utils/unsafeEntries.ts
+++ b/src/common/utils/unsafeEntries.ts
@@ -1,5 +1,5 @@
 /** Converts an object from a trusted source (i.e. without unknown entries) to a typed array */
-export default function entries<T extends { [key: string]: object }, K extends keyof T>(o: T): [keyof T, T[K]][] {
-    return Object.entries(o) as [keyof T, T[K]][]
+export default function unsafeEntries<T extends { [key: string]: object }, K extends keyof T>(o: T): [keyof T, T[K]][] {
+    return Object.entries(o) as [keyof T, T[K]][];
 }
  

--- a/src/features/common/shellDetector.ts
+++ b/src/features/common/shellDetector.ts
@@ -3,6 +3,7 @@ import { isWindows } from '../../managers/common/utils';
 import * as os from 'os';
 import { vscodeShell } from '../../common/vscodeEnv.apis';
 import { getConfiguration } from '../../common/workspace.apis';
+import unsafeEntries from '../../common/utils/unsafeEntries';
 import { TerminalShellType } from '../../api';
 
 /*
@@ -30,20 +31,23 @@ const IS_TCSHELL = /(tcsh$)/i;
 const IS_NUSHELL = /(nu$)/i;
 const IS_XONSH = /(xonsh$)/i;
 
-const detectableShells = new Map<TerminalShellType, RegExp>();
-detectableShells.set(TerminalShellType.powershell, IS_POWERSHELL);
-detectableShells.set(TerminalShellType.gitbash, IS_GITBASH);
-detectableShells.set(TerminalShellType.bash, IS_BASH);
-detectableShells.set(TerminalShellType.wsl, IS_WSL);
-detectableShells.set(TerminalShellType.zsh, IS_ZSH);
-detectableShells.set(TerminalShellType.ksh, IS_KSH);
-detectableShells.set(TerminalShellType.commandPrompt, IS_COMMAND);
-detectableShells.set(TerminalShellType.fish, IS_FISH);
-detectableShells.set(TerminalShellType.tcshell, IS_TCSHELL);
-detectableShells.set(TerminalShellType.cshell, IS_CSHELL);
-detectableShells.set(TerminalShellType.nushell, IS_NUSHELL);
-detectableShells.set(TerminalShellType.powershellCore, IS_POWERSHELL_CORE);
-detectableShells.set(TerminalShellType.xonsh, IS_XONSH);
+type KnownShellType = Exclude<TerminalShellType, TerminalShellType.unknown>;
+const detectableShells = new Map<KnownShellType, RegExp>(unsafeEntries({
+    [TerminalShellType.powershell]: IS_POWERSHELL,
+    [TerminalShellType.gitbash]: IS_GITBASH,
+    [TerminalShellType.bash]: IS_BASH,
+    [TerminalShellType.wsl]: IS_WSL,
+    [TerminalShellType.zsh]: IS_ZSH,
+    [TerminalShellType.ksh]: IS_KSH,
+    [TerminalShellType.commandPrompt]: IS_COMMAND,
+    [TerminalShellType.fish]: IS_FISH,
+    [TerminalShellType.tcshell]: IS_TCSHELL,
+    [TerminalShellType.cshell]: IS_CSHELL,
+    [TerminalShellType.nushell]: IS_NUSHELL,
+    [TerminalShellType.powershellCore]: IS_POWERSHELL_CORE,
+    [TerminalShellType.xonsh]: IS_XONSH,
+// This `satisfies` makes sure all shells are covered
+} satisfies Record<KnownShellType, RegExp>));
 
 function identifyShellFromShellPath(shellPath: string): TerminalShellType {
     // Remove .exe extension so shells can be more consistently detected

--- a/src/managers/builtin/venvUtils.ts
+++ b/src/managers/builtin/venvUtils.ts
@@ -130,13 +130,13 @@ async function getPythonInfo(env: NativeEnvInfo): Promise<PythonEnvironmentInfo>
         const cmdMgr = (suffix = ''): VenvManager => ({
             activate: { executable: path.join(binDir, `activate${suffix}`) },
             deactivate: { executable: path.join(binDir, `deactivate${suffix}`) },
-            supportsStdlib: true,
+            supportsStdlib: ['', '.bat'].includes(suffix),
         });
         /** Venv activation/deactivation for a POSIXy shell */
         const sourceMgr = (suffix = '', executable = 'source'): VenvManager => ({
             activate: { executable, args: [path.join(binDir, `activate${suffix}`)] },
             deactivate: { executable: 'deactivate' },
-            supportsStdlib: ['', '.ps1'].includes(suffix)
+            supportsStdlib: ['', '.ps1'].includes(suffix),
         });
         // satisfies `Record` to make sure all shells are covered
         const venvManagers: Record<TerminalShellType, VenvManager> = {


### PR DESCRIPTION
Fixes #138

This adds shell activation for

- gitbash
- wsl
- ksh
- tcshell
- xonsh
- nushell

and fixes shell activation for C shell.

it also makes sure that it’s impossible to add a terminal to the enum without also adding shell activation/deactivation commands by using a `Record` type that needs to be exhaustive.