### PR TITLE
remove ability to reference get_packages from prompting

### DIFF
--- a/package.json
+++ b/package.json
@@ -466,8 +466,7 @@
                     "required": [
                         "filePath"
                     ]
-                },
-                "canBeReferencedInPrompt": true
+                }
             }
         ]
     },


### PR DESCRIPTION
as we determine the best use of this tool, do not expose it as reference-able in copilot chat.