### PR TITLE
fix: cannot register tools starting with `vscode_`

### DIFF
--- a/package.json
+++ b/package.json
@@ -489,9 +489,7 @@
                 "displayName": "Get Python Packages",
                 "modelDescription": "Returns the packages installed in the given Python file's environment. You should call this when you want to generate Python code to determine the users preferred packages. Also call this to determine if you need to provide installation instructions in a response.",
                 "toolReferenceName": "pythonGetPackages",
-                "tags": [
-                    "vscode_editing"
-                ],
+                "tags": [],
                 "icon": "$(files)",
                 "inputSchema": {
                     "type": "object",


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python-environments/issues/208

fix for this:
![image](https://github.com/user-attachments/assets/4244103a-e388-4b5e-89f1-f1635d8bc759)
