### PR TITLE
bug: hide duplicate command from the command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -305,6 +305,10 @@
                 {
                     "command": "python-envs.copyProjectPath",
                     "when": "false"
+                },
+                {
+                    "command": "python-envs.createAny",
+                    "when": "false"
                 }
             ],
             "view/item/context": [


### PR DESCRIPTION
Hides the second one:
![image](https://github.com/user-attachments/assets/03bdf89a-56ba-4737-8715-def8bc0d8f82)

