### PR TITLE
fix: clarify that `showSkipOption` also applies to uninstallations

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -708,12 +708,12 @@ export interface DidChangePythonProjectsEventArgs {
 export type PackageManagementOptions =
     | {
           /**
-           * Upgrade the packages if it is already installed.
+           * Upgrade the packages if they are already installed.
            */
           upgrade?: boolean;
 
           /**
-           * Show option to skip package installation
+           * Show option to skip package installation or uninstallation.
            */
           showSkipOption?: boolean;
           /**
@@ -728,12 +728,12 @@ export type PackageManagementOptions =
       }
     | {
           /**
-           * Upgrade the packages if it is already installed.
+           * Upgrade the packages if they are already installed.
            */
           upgrade?: boolean;
 
           /**
-           * Show option to skip package installation
+           * Show option to skip package installation or uninstallation.
            */
           showSkipOption?: boolean;
           /**


### PR DESCRIPTION
The descriptions seem to be leftovers from #279.