### PR TITLE
add check for already set project environments and add documentation

### DIFF
--- a/src/features/envCommands.ts
+++ b/src/features/envCommands.ts
@@ -74,6 +74,9 @@ export async function refreshPackagesCommand(context: unknown, managers?: Enviro
     }
 }
 
+/**
+ * Creates a Python environment using the manager implied by the context (no user prompt).
+ */
 export async function createEnvironmentCommand(
     context: unknown,
     em: EnvironmentManagers,
@@ -94,7 +97,7 @@ export async function createEnvironmentCommand(
                 const scope = selected.length === 0 ? 'global' : selected.map((p) => p.uri);
                 const env = await manager.create(scope, undefined);
                 if (env) {
-                    await em.setEnvironments(scope, env);
+                    await em.setEnvironmentsIfUnset(scope, env);
                 }
                 return env;
             } else {
@@ -114,6 +117,9 @@ export async function createEnvironmentCommand(
     }
 }
 
+/**
+ * Prompts the user to pick the environment manager and project(s) for environment creation.
+ */
 export async function createAnyEnvironmentCommand(
     em: EnvironmentManagers,
     pm: PythonProjectManager,

--- a/src/internal.api.ts
+++ b/src/internal.api.ts
@@ -1,35 +1,35 @@
 import { CancellationError, Disposable, Event, LogOutputChannel, MarkdownString, Uri } from 'vscode';
 import {
-    PythonEnvironment,
-    EnvironmentManager,
-    PackageManager,
-    Package,
-    IconPath,
+    CreateEnvironmentOptions,
+    CreateEnvironmentScope,
     DidChangeEnvironmentEventArgs,
     DidChangeEnvironmentsEventArgs,
     DidChangePackagesEventArgs,
-    PythonProject,
-    RefreshEnvironmentsScope,
-    GetEnvironmentsScope,
-    CreateEnvironmentScope,
-    SetEnvironmentScope,
+    EnvironmentGroupInfo,
+    EnvironmentManager,
     GetEnvironmentScope,
-    PythonEnvironmentId,
-    PythonEnvironmentExecutionInfo,
-    PythonEnvironmentInfo,
+    GetEnvironmentsScope,
+    IconPath,
+    Package,
     PackageChangeKind,
     PackageId,
     PackageInfo,
-    PythonProjectCreator,
-    ResolveEnvironmentContext,
     PackageManagementOptions,
-    EnvironmentGroupInfo,
+    PackageManager,
+    PythonEnvironment,
+    PythonEnvironmentExecutionInfo,
+    PythonEnvironmentId,
+    PythonEnvironmentInfo,
+    PythonProject,
+    PythonProjectCreator,
     QuickCreateConfig,
-    CreateEnvironmentOptions,
+    RefreshEnvironmentsScope,
+    ResolveEnvironmentContext,
+    SetEnvironmentScope,
 } from './api';
 import { CreateEnvironmentNotSupported, RemoveEnvironmentNotSupported } from './common/errors/NotSupportedError';
-import { sendTelemetryEvent } from './common/telemetry/sender';
 import { EventNames } from './common/telemetry/constants';
+import { sendTelemetryEvent } from './common/telemetry/sender';
 
 export type EnvironmentManagerScope = undefined | string | Uri | PythonEnvironment;
 export type PackageManagerScope = undefined | string | Uri | PythonEnvironment | Package;
@@ -111,6 +111,7 @@ export interface EnvironmentManagers extends Disposable {
 
     setEnvironment(scope: SetEnvironmentScope, environment?: PythonEnvironment): Promise<void>;
     setEnvironments(scope: Uri[] | string, environment?: PythonEnvironment): Promise<void>;
+    setEnvironmentsIfUnset(scope: Uri[] | string, environment?: PythonEnvironment): Promise<void>;
     getEnvironment(scope: GetEnvironmentScope): Promise<PythonEnvironment | undefined>;
 
     getProjectEnvManagers(uris: Uri[]): InternalEnvironmentManager[];


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python-environments/issues/507

introduce `setEnvironmentsIfUnset` so that newer environments when created do not override existing settings