### PR TITLE
Fixing GDPR telemetry naming for package management

### DIFF
--- a/src/common/telemetry/constants.ts
+++ b/src/common/telemetry/constants.ts
@@ -77,7 +77,7 @@ export interface IEventNamePropertyMapping {
     };
 
     /* __GDPR__
-        "package.install": {
+        "package_management": {
             "managerId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "karthiknadig" },
             "result": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "karthiknadig" }
         }


### PR DESCRIPTION
We are sending the following event locally `ms-python.vscode-python-envs/PACKAGE_MANAGEMENT` but this is not classified in our GDPR tool due to the mismatched GDPR tag. 

The following is cleared in the GDPR tool based on the GDPR tag 
![image](https://github.com/user-attachments/assets/267d5fa5-72c5-4423-9357-8ef982e848d5)

I think this small change will suffice to align the two 
