### PR TITLE
Inject Environment Variables on Terminal Create

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,12 @@
     "contributes": {
         "configuration": {
             "properties": {
+                "python-envs.injectEnvVarsInTerminals": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%python-envs.injectEnvVarsInTerminals.description%",
+                    "scope": "window"
+                },
                 "python-envs.defaultEnvManager": {
                     "type": "string",
                     "description": "%python-envs.defaultEnvManager.description%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,6 @@
 {
     "python-envs.defaultEnvManager.description": "The default environment manager for creating and managing environments.",
-    "python-envs.injectEnvVarsInTerminals.description": "This setting defaults to false and toggles if environment variables found in the workspace are set for new terminals.",
+    "python-envs.injectEnvVarsInTerminals.description": "Whether to inject environment variables into terminals on creating new terminals through the environments extension, defaults to false.",
     "python-envs.defaultPackageManager.description": "The default package manager for installing packages in environments.",
     "python-envs.pythonProjects.description": "The list of Python projects.",
     "python-envs.pythonProjects.path.description": "The path to a folder or file in the workspace to be treated as a Python project.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,6 @@
 {
     "python-envs.defaultEnvManager.description": "The default environment manager for creating and managing environments.",
+    "python-envs.injectEnvVarsInTerminals.description": "This setting defaults to false and toggles if environment variables found in the workspace are set for new terminals.",
     "python-envs.defaultPackageManager.description": "The default package manager for installing packages in environments.",
     "python-envs.pythonProjects.description": "The list of Python projects.",
     "python-envs.pythonProjects.path.description": "The path to a folder or file in the workspace to be treated as a Python project.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,7 +205,6 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
         terminalActivation,
         shellEnvsProviders,
         shellStartupProviders,
-        context,
     );
     context.subscriptions.push(terminalActivation, terminalManager);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,6 +205,7 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
         terminalActivation,
         shellEnvsProviders,
         shellStartupProviders,
+        context,
     );
     context.subscriptions.push(terminalActivation, terminalManager);
 


### PR DESCRIPTION
fixes: https://github.com/microsoft/vscode-python-environments/issues/625


adds setting `python-envs.injectEnvVarsInTerminals` with default value `false` to set if envVars will be injected

added call to inject env vars into ONLY create terminal function done through the environments extension