### PR TITLE
bug: fix gitignore add for more scenarios

### DIFF
--- a/src/managers/builtin/venvManager.ts
+++ b/src/managers/builtin/venvManager.ts
@@ -191,8 +191,9 @@ export class VenvManager implements EnvironmentManager {
                     try {
                         const stat = await fs.stat(envPath.fsPath);
                         if (!stat.isDirectory()) {
-                            // If the env path is a file (likely the python binary), use its parent directory
-                            envPath = Uri.file(path.dirname(envPath.fsPath));
+                            // If the env path is a file (likely the python binary), use parent-parent as the env path
+                            // following format of .venv/bin/python or .venv\Scripts\python.exe
+                            envPath = Uri.file(path.dirname(path.dirname(envPath.fsPath)));
                         }
                     } catch (err) {
                         // If stat fails, fallback to original envPath

--- a/src/managers/builtin/venvManager.ts
+++ b/src/managers/builtin/venvManager.ts
@@ -187,23 +187,23 @@ export class VenvManager implements EnvironmentManager {
                 // Add .gitignore to the .venv folder
                 try {
                     // determine if env path is python binary or environment folder
-                    let envPath = environment.environmentPath;
+                    let envPath = environment.environmentPath.fsPath;
                     try {
-                        const stat = await fs.stat(envPath.fsPath);
+                        const stat = await fs.stat(envPath);
                         if (!stat.isDirectory()) {
                             // If the env path is a file (likely the python binary), use parent-parent as the env path
                             // following format of .venv/bin/python or .venv\Scripts\python.exe
-                            envPath = Uri.file(path.dirname(path.dirname(envPath.fsPath)));
+                            envPath = Uri.file(path.dirname(path.dirname(envPath))).fsPath;
                         }
                     } catch (err) {
                         // If stat fails, fallback to original envPath
                         traceWarn(
-                            `Failed to stat environment path: ${envPath.fsPath}. Error: ${
+                            `Failed to stat environment path: ${envPath}. Error: ${
                                 err instanceof Error ? err.message : String(err)
                             }, continuing to attempt to create .gitignore.`,
                         );
                     }
-                    const gitignorePath = path.join(envPath.fsPath, '.gitignore');
+                    const gitignorePath = path.join(envPath, '.gitignore');
                     await fs.writeFile(gitignorePath, '*\n', { flag: 'w' });
                 } catch (err) {
                     traceError(


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python-environments/issues/619

since environmentPath for an environment can be "Path to the python binary or environment folder." need to update code to support if the path is directly to a python binary. If so get the parent, parent of the binary to get the venv folder