### PR TITLE
Check profiles for conda init before adding conda sourcing

### DIFF
--- a/src/features/terminal/shells/bash/bashStartup.ts
+++ b/src/features/terminal/shells/bash/bashStartup.ts
@@ -27,14 +27,14 @@ async function isGitBashInstalled(): Promise<boolean> {
     return false;
 }
 
-async function getBashProfiles(): Promise<string> {
+export async function getBashProfiles(): Promise<string> {
     const homeDir = os.homedir();
     const profile: string = path.join(homeDir, '.bashrc');
 
     return profile;
 }
 
-async function getZshProfiles(): Promise<string> {
+export async function getZshProfiles(): Promise<string> {
     const homeDir = os.homedir();
     const profile: string = path.join(homeDir, '.zshrc');
 

--- a/src/features/terminal/shells/fish/fishStartup.ts
+++ b/src/features/terminal/shells/fish/fishStartup.ts
@@ -19,7 +19,7 @@ async function isFishInstalled(): Promise<boolean> {
     }
 }
 
-async function getFishProfile(): Promise<string> {
+export async function getFishProfile(): Promise<string> {
     const homeDir = os.homedir();
     // Fish configuration is typically at ~/.config/fish/config.fish
     const profilePath = path.join(homeDir, '.config', 'fish', 'config.fish');
@@ -154,5 +154,9 @@ export class FishStartupProvider implements ShellStartupScriptProvider {
 
     clearCache(): Promise<void> {
         return Promise.resolve();
+    }
+
+    getProfilePath(): Promise<string | undefined> {
+        return getFishProfile();
     }
 }

--- a/src/features/terminal/shells/pwsh/pwshStartup.ts
+++ b/src/features/terminal/shells/pwsh/pwshStartup.ts
@@ -52,7 +52,7 @@ async function isPowerShellInstalled(shell: string): Promise<boolean> {
     }
 }
 
-async function getProfileForShell(shell: 'powershell' | 'pwsh'): Promise<string> {
+export async function getProfileForShell(shell: 'powershell' | 'pwsh'): Promise<string> {
     const cachedPath = getProfilePathCache(shell);
     if (cachedPath) {
         traceInfo(`SHELL: ${shell} profile path from cache: ${cachedPath}`);

--- a/src/features/terminal/shells/sh/shStartup.ts
+++ b/src/features/terminal/shells/sh/shStartup.ts
@@ -1,0 +1,10 @@
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Returns an array of possible sh profile paths in order of preference.
+ */
+export async function getShProfiles(): Promise<string> {
+    const home = os.homedir();
+    return path.join(home, '.profile');
+}

--- a/src/managers/conda/condaUtils.ts
+++ b/src/managers/conda/condaUtils.ts
@@ -418,20 +418,6 @@ async function readProfile(profilePath: string): Promise<boolean> {
     return false;
 }
 
-// async function readCmdCondaInit(): Promise<boolean> {
-//     if (!isWindows()) {
-//         return false;
-//     }
-//     try {
-//         const { stdout } = await exec('reg query "HKCU\\Software\\Microsoft\\Command Processor" /v AutoRun', {
-//             windowsHide: true,
-//         });
-//         return stdout.includes('conda') && stdout.includes('activate');
-//     } catch {
-//         return false;
-//     }
-// }
-
 async function getPrefixesCondaPythonInfo(
     prefix: string,
     executable: string,


### PR DESCRIPTION
add support so all shell profiles are checked for conda init flag before adding the sourcing script the activation commands for the environment extension. If user already has conda init in their profile then the sourcing script is redundant and introduces more opportunity for errors