### PR TITLE
bug fix: Stricter pip list Package Parsing

### DIFF
--- a/src/managers/builtin/pipListUtils.ts
+++ b/src/managers/builtin/pipListUtils.ts
@@ -4,6 +4,11 @@ export interface PipPackage {
     displayName: string;
     description: string;
 }
+export function isValidVersion(version: string): boolean {
+    return /^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$/.test(
+        version,
+    );
+}
 export function parsePipList(data: string): PipPackage[] {
     const collection: PipPackage[] = [];
 
@@ -13,9 +18,12 @@ export function parsePipList(data: string): PipPackage[] {
             continue;
         }
         const parts = line.split(' ').filter((e) => e);
-        if (parts.length > 1) {
+        if (parts.length === 2) {
             const name = parts[0].trim();
             const version = parts[1].trim();
+            if (!isValidVersion(version)) {
+                break;
+            }
             const pkg = {
                 name,
                 version,

--- a/src/managers/builtin/pipListUtils.ts
+++ b/src/managers/builtin/pipListUtils.ts
@@ -22,7 +22,7 @@ export function parsePipList(data: string): PipPackage[] {
             const name = parts[0].trim();
             const version = parts[1].trim();
             if (!isValidVersion(version)) {
-                break;
+                continue;
             }
             const pkg = {
                 name,

--- a/src/test/managers/builtin/pipListUtils.unit.test.ts
+++ b/src/test/managers/builtin/pipListUtils.unit.test.ts
@@ -1,13 +1,13 @@
+import assert from 'assert';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { EXTENSION_TEST_ROOT } from '../../constants';
 import { parsePipList } from '../../../managers/builtin/pipListUtils';
-import assert from 'assert';
+import { EXTENSION_TEST_ROOT } from '../../constants';
 
 const TEST_DATA_ROOT = path.join(EXTENSION_TEST_ROOT, 'managers', 'builtin');
 
 suite('Pip List Parser tests', () => {
-    const testNames = ['piplist1', 'piplist2'];
+    const testNames = ['piplist1', 'piplist2', 'piplist3'];
 
     testNames.forEach((testName) => {
         test(`Test parsing pip list output ${testName}`, async () => {

--- a/src/test/managers/builtin/piplist3.actual.txt
+++ b/src/test/managers/builtin/piplist3.actual.txt
@@ -1,0 +1,11 @@
+Package    Version
+---------- -------
+altgraph   0.17.2
+future     0.18.2
+macholib   1.15.2
+pip        21.2.4
+setuptools 58.0.4
+six        1.15.0
+wheel      0.37.0
+WARNING: You are using pip version 21.2.4; however, version 25.2 is available.
+You should consider upgrading via the '/Library/Developer/CommandLineTools/usr/bin/python3 -m pip install --upgrade pip' command.

--- a/src/test/managers/builtin/piplist3.expected.json
+++ b/src/test/managers/builtin/piplist3.expected.json
@@ -1,0 +1,11 @@
+{
+    "packages": [
+        { "name": "altgraph", "version": "0.17.2" },
+        { "name": "future", "version": "0.18.2" },
+        { "name": "macholib", "version": "1.15.2" },
+        { "name": "pip", "version": "21.2.4" },
+        { "name": "setuptools", "version": "58.0.4" },
+        { "name": "six", "version": "1.15.0" },
+        { "name": "wheel", "version": "0.37.0" }
+    ]
+}


### PR DESCRIPTION
Addressing bug #697.

When parsing the output of pip list for packages, two checks were added. First, does the line contain exactly two space-separated keywords? The assumption being we will exactly see "[package name] [package version]" in a valid package list. Secondly, it uses the [regex in the PEP 440 docs](https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions) to verify a valid pip version. Adding these checks will help ensure we only parse valid packages and don't pick up any other information, such as warning messages. Lastly, added a unit test for the situation described in the bug.