### PR TITLE
Remove .vscode-test.mjs from bundled extension

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,6 +4,7 @@ out/**
 node_modules/**
 src/**
 .gitignore
+.vscode-test.mjs
 .yarnrc
 webpack.config.js
 vsc-extension-quickstart.md


### PR DESCRIPTION
When running an extension test using VS Code test explorer extension, the installed Python env extension gets picked up as well due to the presence of this file