### PR TITLE
remove not implemented create function

### DIFF
--- a/src/managers/pipenv/pipenvManager.ts
+++ b/src/managers/pipenv/pipenvManager.ts
@@ -1,7 +1,5 @@
 import { EventEmitter, MarkdownString, ProgressLocation, Uri } from 'vscode';
 import {
-    CreateEnvironmentOptions,
-    CreateEnvironmentScope,
     DidChangeEnvironmentEventArgs,
     DidChangeEnvironmentsEventArgs,
     EnvironmentChangeKind,
@@ -113,14 +111,6 @@ export class PipenvManager implements EnvironmentManager {
         return this.collection.find(
             (env) => env.environmentPath.fsPath === fsPath || env.execInfo?.run.executable === fsPath,
         );
-    }
-
-    async create?(
-        _scope: CreateEnvironmentScope,
-        _options?: CreateEnvironmentOptions,
-    ): Promise<PythonEnvironment | undefined> {
-        // To be implemented
-        return undefined;
     }
 
     async refresh(scope: RefreshEnvironmentsScope): Promise<void> {


### PR DESCRIPTION
<img width="665" height="461" alt="image" src="https://github.com/user-attachments/assets/6fefb586-064d-4779-bbb7-74bbd53f4e4c" />
This is incorrect as it should not have the "click to create" part of the message under pipenv