### PR TITLE
fix venvFolder injection in search path for nativeFinder

### DIFF
--- a/src/managers/common/nativePythonFinder.ts
+++ b/src/managers/common/nativePythonFinder.ts
@@ -196,10 +196,9 @@ class NativePythonFinderImpl implements NativePythonFinder {
                 uriSearchPaths.push(...venvFolders);
                 return { searchPaths: uriSearchPaths };
             }
-        } else {
-            // if no options, then search venvFolders
-            return { searchPaths: venvFolders };
         }
+        // return undefined to use configured defaults (for nativeFinder refresh)
+        return undefined;
     }
 
     private start(): rpc.MessageConnection {


### PR DESCRIPTION
wrong:
<img width="1330" height="922" alt="image" src="https://github.com/user-attachments/assets/f998b5e4-f54d-4ea6-b20d-7ac1fb97faa3" />

correct:
<img width="678" height="320" alt="image" src="https://github.com/user-attachments/assets/d7e3f7b7-7c23-49e2-a835-ba83be029a69" />


here you see the pipenv env shows up correctly