### PR TITLE
revert: remove unnecessary refresh call for environment managers on expansion

### DIFF
--- a/src/features/views/envManagersView.ts
+++ b/src/features/views/envManagersView.ts
@@ -95,10 +95,6 @@ export class EnvManagerView implements TreeDataProvider<EnvTreeItem>, Disposable
         if (element.kind === EnvTreeItemKind.manager) {
             const manager = (element as EnvManagerTreeItem).manager;
             const views: EnvTreeItem[] = [];
-            
-            // Refresh manager when expanded to pick up newly created environments
-            await manager.refresh(undefined);
-            
             const envs = await manager.getEnvironments('all');
             envs.filter((e) => !e.group).forEach((env) => {
                 const view = new PythonEnvTreeItem(env, element as EnvManagerTreeItem, this.selected.get(env.envId.id));


### PR DESCRIPTION
reverting https://github.com/microsoft/vscode-python-environments/commit/5b2966955a257fa1bf5b884fd2a54ae6619650a7 as it is not the right way to do it and causes endless refresh looping