### PR TITLE
Fix where activation goes missing after user modifying rc scripts

### DIFF
--- a/src/features/terminal/shells/bash/bashStartup.ts
+++ b/src/features/terminal/shells/bash/bashStartup.ts
@@ -61,14 +61,12 @@ function getActivationContent(key: string): string {
 async function isStartupSetup(profile: string, key: string): Promise<ShellSetupState> {
     if (await fs.pathExists(profile)) {
         const content = await fs.readFile(profile, 'utf8');
-        return hasStartupCode(content, regionStart, regionEnd, [key])
-            ? ShellSetupState.Setup
-            : ShellSetupState.NotSetup;
-    } else {
-        return ShellSetupState.NotSetup;
+        if (hasStartupCode(content, regionStart, regionEnd, [key])) {
+            return ShellSetupState.Setup;
+        }
     }
+    return ShellSetupState.NotSetup;
 }
-
 async function setupStartup(profile: string, key: string, name: string): Promise<boolean> {
     if (shellIntegrationForActiveTerminal(name, profile)) {
         removeStartup(profile, key);

--- a/src/features/terminal/terminalManager.ts
+++ b/src/features/terminal/terminalManager.ts
@@ -148,14 +148,24 @@ export class TerminalManagerImpl implements TerminalManager {
             await Promise.all(
                 providers.map(async (p) => {
                     if (this.shellSetup.has(p.shellType)) {
-                        traceVerbose(`Shell profile for ${p.shellType} already checked.`);
-                        return;
+                        // This ensures modified scripts are detected even after initial setup
+                        const currentState = await p.isSetup();
+                        const cachedSetup = this.shellSetup.get(p.shellType);
+
+                        if ((currentState === ShellSetupState.Setup) !== cachedSetup) {
+                            traceVerbose(`Shell profile for ${p.shellType} state changed, updating cache.`);
+                            // State changed - clear cache and re-evaluate
+                            this.shellSetup.delete(p.shellType);
+                        } else {
+                            traceVerbose(`Shell profile for ${p.shellType} already checked.`);
+                            return;
+                        }
                     }
                     traceVerbose(`Checking shell profile for ${p.shellType}.`);
                     const state = await p.isSetup();
                     if (state === ShellSetupState.NotSetup) {
-                        // Check if shell integration is available before marking for setup
                         if (shellIntegrationForActiveTerminal(p.name)) {
+                            await p.teardownScripts();
                             this.shellSetup.set(p.shellType, true);
                             traceVerbose(
                                 `Shell integration available for ${p.shellType}, skipping prompt, and profile modification.`,
@@ -169,6 +179,12 @@ export class TerminalManagerImpl implements TerminalManager {
                             );
                         }
                     } else if (state === ShellSetupState.Setup) {
+                        if (shellIntegrationForActiveTerminal(p.name)) {
+                            await p.teardownScripts();
+                            traceVerbose(
+                                `Shell integration available for ${p.shellType}, removed profile script in favor of shell integration.`,
+                            );
+                        }
                         this.shellSetup.set(p.shellType, true);
                         traceVerbose(`Shell profile for ${p.shellType} is setup.`);
                     } else if (state === ShellSetupState.NotInstalled) {
@@ -228,6 +244,7 @@ export class TerminalManagerImpl implements TerminalManager {
         let actType = getAutoActivationType();
         const shellType = identifyTerminalShell(terminal);
         if (actType === ACT_TYPE_SHELL) {
+            await this.handleSetupCheck(shellType);
             actType = await this.getEffectiveActivationType(shellType);
         }
 

--- a/src/features/terminal/terminalManager.ts
+++ b/src/features/terminal/terminalManager.ts
@@ -147,12 +147,11 @@ export class TerminalManagerImpl implements TerminalManager {
             const shellsToSetup: ShellStartupScriptProvider[] = [];
             await Promise.all(
                 providers.map(async (p) => {
+                    const state = await p.isSetup();
                     if (this.shellSetup.has(p.shellType)) {
                         // This ensures modified scripts are detected even after initial setup
-                        const currentState = await p.isSetup();
                         const cachedSetup = this.shellSetup.get(p.shellType);
-
-                        if ((currentState === ShellSetupState.Setup) !== cachedSetup) {
+                        if ((state === ShellSetupState.Setup) !== cachedSetup) {
                             traceVerbose(`Shell profile for ${p.shellType} state changed, updating cache.`);
                             // State changed - clear cache and re-evaluate
                             this.shellSetup.delete(p.shellType);
@@ -162,7 +161,6 @@ export class TerminalManagerImpl implements TerminalManager {
                         }
                     }
                     traceVerbose(`Checking shell profile for ${p.shellType}.`);
-                    const state = await p.isSetup();
                     if (state === ShellSetupState.NotSetup) {
                         if (shellIntegrationForActiveTerminal(p.name)) {
                             await p.teardownScripts();


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode-python-environments/issues/865 
If user modifies already existing shell profile script needed for shell startup, they get stuck into not activating state because they still have auto activation guard, which blocks shell integration from core from activating.

This also means because they have wrong env var in profile script, it won't activate there either.
We should better track this, and properly clean up profile script when relying on shell integration for activation. 

/cc @karthiknadig 
