### PR TITLE
Revert "fix as-any linting warnings"

### DIFF
--- a/.github/instructions/generic.instructions.md
+++ b/.github/instructions/generic.instructions.md
@@ -30,7 +30,3 @@ Provide project context and coding guidelines that AI should follow when generat
 ## Documentation
 
 -   Add clear docstrings to public functions, describing their purpose, parameters, and behavior.
-
-## Learnings
-
--   Avoid using 'any' types in TypeScript; import proper types from VS Code API and use specific interfaces for mocks and test objects (1)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,6 @@ export default [{
         eqeqeq: "warn",
         "no-throw-literal": "warn",
         semi: "warn",
-        "@typescript-eslint/no-explicit-any": "error",
+        "@typescript-eslint/no-explicit-any": "warn",
     },
 }];


### PR DESCRIPTION
Reverts microsoft/vscode-python-environments#891

the tests weren't passing and I didn't realize it would merge it in without that criteria met