### PR TITLE
Do not activate for task terminal 

### DIFF
--- a/src/common/tasks.apis.ts
+++ b/src/common/tasks.apis.ts
@@ -1,5 +1,13 @@
-import { Task, TaskExecution, tasks } from 'vscode';
-
+import { Disposable, Task, TaskExecution, TaskProcessStartEvent, tasks } from 'vscode';
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export async function executeTask(task: Task): Promise<TaskExecution> {
     return tasks.executeTask(task);
+}
+
+export function onDidStartTaskProcess(
+    listener: (e: TaskProcessStartEvent) => any,
+    thisArgs?: any,
+    disposables?: Disposable[],
+): Disposable {
+    return tasks.onDidStartTaskProcess(listener, thisArgs, disposables);
 }


### PR DESCRIPTION
Resolves: https://github.com/microsoft/vscode/issues/275667 

We'd probably want to switch over to more reliable long term approach like https://github.com/microsoft/vscode/issues/234440 in the future though. /cc @meganrogge  I think we can either add the api to tell if terminal is task terminal, or just straight up block extension from contributing commands to task terminal. 

I don't know how aggressive the later would be, maybe some extension actually wants to contribute to task terminal via input? 
