### PR TITLE
Fix a bug with Quick Create not installing workspace dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5035,7 +5035,8 @@
         "node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "peer": true
         },
         "node_modules/tunnel": {
             "version": "0.0.6",
@@ -9109,7 +9110,8 @@
         "tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "peer": true
         },
         "tunnel": {
             "version": "0.0.6",
@@ -9168,7 +9170,7 @@
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
             "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-            "dev": true,
+            "dev": true
         },
         "uc.micro": {
             "version": "1.0.6",


### PR DESCRIPTION
There are two ways user can do `Quick Create`.

1. When user goes from `Create Virtual Environment -> Quick Create`, the workspace dependencies are installed in the newly created virtual environment.

2. When user goes from `Create Virtual Environment -> venv -> Quick Create`, the workspace dependencies are NOT installed in the newly created virtual environment. This is because the packages are not collected in the code flow. This PR adds that step back.

<img width="607" height="133" alt="image" src="https://github.com/user-attachments/assets/a76a14e5-33da-41d8-ab01-993ff471182a" />

fixes https://github.com/microsoft/vscode-python-environments/issues/1080
