### PR TITLE
Remove redundant shell activation and deactivation for FISH in getShellActivationCommands

### DIFF
--- a/src/managers/common/utils.ts
+++ b/src/managers/common/utils.ts
@@ -176,9 +176,6 @@ export async function getShellActivationCommands(binDir: string): Promise<{
     if (await fs.pathExists(path.join(binDir, 'activate.csh'))) {
         shellActivation.set(ShellConstants.CSH, [{ executable: 'source', args: [path.join(binDir, `activate.csh`)] }]);
         shellDeactivation.set(ShellConstants.CSH, [{ executable: 'deactivate' }]);
-
-        shellActivation.set(ShellConstants.FISH, [{ executable: 'source', args: [path.join(binDir, `activate.csh`)] }]);
-        shellDeactivation.set(ShellConstants.FISH, [{ executable: 'deactivate' }]);
     }
 
     if (await fs.pathExists(path.join(binDir, 'activate.fish'))) {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python-environments/issues/1096