### PR TITLE
Fix `python.defaultInterpreterPath`0. setting not being applied to new workspaces

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,7 +1,6 @@
 import { ExtensionContext, extensions, QuickInputButtons, Uri, window, workspace } from 'vscode';
 import { PythonEnvironment, PythonEnvironmentApi } from './api';
 import { traceError, traceInfo, traceWarn } from './common/logging';
-import { normalizePath } from './common/utils/pathUtils';
 import { isWindows } from './common/utils/platformUtils';
 import { createTerminal, showInputBoxWithButtons } from './common/window.apis';
 import { getConfiguration } from './common/workspace.apis';
@@ -271,10 +270,6 @@ export async function resolveDefaultInterpreter(
         try {
             const resolved: NativeEnvInfo = await nativeFinder.resolve(userSetdefaultInterpreter);
             if (resolved && resolved.executable) {
-                if (normalizePath(resolved.executable) === normalizePath(userSetdefaultInterpreter)) {
-                    // no action required, the path is already correct
-                    return;
-                }
                 const resolvedEnv = await api.resolveEnvironment(Uri.file(resolved.executable));
                 traceInfo(`[resolveDefaultInterpreter] API resolved environment: ${JSON.stringify(resolvedEnv)}`);
 
@@ -294,7 +289,7 @@ export async function resolveDefaultInterpreter(
                         version: resolved.version ?? '',
                         displayPath: userSetdefaultInterpreter ?? '',
                         environmentPath: userSetdefaultInterpreter ? Uri.file(userSetdefaultInterpreter) : Uri.file(''),
-                        sysPrefix: resolved.arch ?? '',
+                        sysPrefix: resolved.prefix ?? '',
                         execInfo: {
                             run: {
                                 executable: userSetdefaultInterpreter ?? '',


### PR DESCRIPTION
The PR is a follow-up task to the sync meeting and the discussion in https://github.com/microsoft/vscode-python-environments/issues/861#issuecomment-3726530434

The PR fixes a bug where the `python.defaultInterpreterPath` setting was not being respected when opening new workspaces. Users who configured a specific Python interpreter path would see a different Python version selected instead. 

The root cause is that the early return prevented `api.setEnvironment()` from ever being called, so the workspace environment was never actually set.

When the extension later queried for the workspace environment, the `venvManager.get()` method found nothing in the workspace-to-environment map and fell back to `globalEnv`.

Verified now the default is being used.
<img width="681" height="214" alt="image" src="https://github.com/user-attachments/assets/19ec4e44-2f14-4331-9e6c-e7221475843a" />


Also fixed wrong field used for `sysPrefix`.

