### PR TITLE
Fix Regression: interpreter selection status bar not working when switching environments 

### DIFF
--- a/src/features/envCommands.ts
+++ b/src/features/envCommands.ts
@@ -341,7 +341,7 @@ export async function setEnvManagerCommand(em: EnvironmentManagers, wm: PythonPr
     if (projects && projects.length > 0) {
         const manager = await pickEnvironmentManager(em.managers);
         if (manager) {
-            await setEnvironmentManager(projects.map((p) => ({ project: p, envManager: manager })));
+            await setEnvironmentManager(projects.map((p) => ({ project: p, envManager: manager, forceWrite: true })));
         }
     }
 }
@@ -351,7 +351,7 @@ export async function setPackageManagerCommand(em: EnvironmentManagers, wm: Pyth
     if (projects && projects.length > 0) {
         const manager = await pickPackageManager(em.packageManagers);
         if (manager) {
-            await setPackageManager(projects.map((p) => ({ project: p, packageManager: manager })));
+            await setPackageManager(projects.map((p) => ({ project: p, packageManager: manager, forceWrite: true })));
         }
     }
 }

--- a/src/features/envManagers.ts
+++ b/src/features/envManagers.ts
@@ -292,6 +292,7 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
                         project,
                         envManager: manager.id,
                         packageManager: packageManager.id,
+                        forceWrite: true,
                     },
                 ]);
             }
@@ -336,6 +337,7 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
                             project: this.pm.get(uri),
                             envManager: manager.id,
                             packageManager: manager.preferredPackageManagerId,
+                            forceWrite: true,
                         });
                     }
 
@@ -355,6 +357,7 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
                         project: undefined,
                         envManager: manager.id,
                         packageManager: manager.preferredPackageManagerId,
+                        forceWrite: true,
                     });
                 }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python-environments/issues/1124

The changes made in https://github.com/microsoft/vscode-python-environments/pull/1120 introduced logic to avoid writing unnecessary settings when the selected environment manager is the implicit default (system manager). This was intended to prevent polluting `settings.json`.

However, this optimization broke manual interpreter selection. When a user clicks the status bar and explicitly selects a global/system interpreter in a workspace with an empty `settings.json`, the selection is silently ignored because the code determines "this is the default, so don't write it."

This PR added an optional `forceWrite` flag to `EditAllManagerSettings`, `EditEnvManagerSettings`, and `EditPackageManagerSettings` interfaces and updated all user-initiated callers in `envManagers.ts` and `envCommands.ts` to pass `forceWrite: true`.


<img width="848" height="175" alt="image" src="https://github.com/user-attachments/assets/bc02d07a-d6fd-4dc1-998a-407de7046eb9" />



