### PR TITLE
fix: timeout handling for JSON-RPC requests in NativePythonFinder

### DIFF
--- a/src/managers/common/nativePythonFinder.ts
+++ b/src/managers/common/nativePythonFinder.ts
@@ -425,7 +425,7 @@ class NativePythonFinderImpl implements NativePythonFinder {
                             // Attempt graceful shutdown by closing stdin before killing
                             // This gives the process a chance to clean up
                             this.outputChannel.debug('[pet] Shutting down Python Locator server');
-                            proc.stdin.end();
+                            proc.stdin?.end();
                             // Give process a moment to exit gracefully, then force kill
                             setTimeout(() => {
                                 if (proc.exitCode === null) {


### PR DESCRIPTION
Fixes #1140 - Root Cause Analysis: Discovery stuck indefinitely
Fixes #1081 - VS Code stuck on "Discovering Python Interpreters" on fresh Windows install
Fixes #956 -  Perpetually "Refreshing virtual environments"