### PR TITLE
Add notification for active virtual environment selection

### DIFF
--- a/src/common/localize.ts
+++ b/src/common/localize.ts
@@ -96,6 +96,10 @@ export namespace VenvManagerStrings {
     export const venvErrorNoBasePython = l10n.t('No base Python found');
     export const venvErrorNoPython3 = l10n.t('Did not find any base Python 3');
 
+    export const venvVirtualEnvActive = l10n.t(
+        'VIRTUAL_ENV is set for this VS Code session. Selection saved for new terminals only.',
+    );
+
     export const venvName = l10n.t('Enter a name for the virtual environment');
     export const venvNameErrorEmpty = l10n.t('Name cannot be empty');
     export const venvNameErrorExists = l10n.t('A folder with the same name already exists');


### PR DESCRIPTION
Notify users when attempting to select a different virtual environment while one is already active. This is the case where VS Code was launched from an activated environment (i.e, VIRTUAL_ENV is set) . This enhances user awareness and prevents confusion regarding the current environment in use.