### PR TITLE
remove button for creating terminal in project view

### DIFF
--- a/package.json
+++ b/package.json
@@ -510,11 +510,6 @@
                     "when": "view == python-projects && viewItem =~ /.*python-workspace.*/"
                 },
                 {
-                    "command": "python-envs.createTerminal",
-                    "group": "inline",
-                    "when": "view == python-projects && viewItem =~ /.*python-workspace.*/"
-                },
-                {
                     "command": "python-envs.copyProjectPath",
                     "group": "inline",
                     "when": "view == python-projects && viewItem =~ /.*python-workspace.*/ && viewItem =~ /^((?!copied).)*$/"


### PR DESCRIPTION
For environments that are not "activatable" the terminal button is removed from the list (since it doesn't make sense) in the environment manager view. This is not possible with the project manager view since the terminal button is attached to the project instead of the environment. It also is a duplicate button so doesn't really add much. Remove for these reasons


fixes https://github.com/microsoft/vscode-python-environments/issues/1035