### PR TITLE
feat: add ENVIRONMENT_DISCOVERY telemetry event and update related telemetry

### DIFF
--- a/src/common/telemetry/constants.ts
+++ b/src/common/telemetry/constants.ts
@@ -32,6 +32,15 @@ export enum EventNames {
      * - projectUnderRoot: number (count of projects nested under workspace roots)
      */
     PROJECT_STRUCTURE = 'PROJECT_STRUCTURE',
+    /**
+     * Telemetry event for environment discovery per manager.
+     * Properties:
+     * - managerId: string (the id of the environment manager)
+     * - result: 'success' | 'error' | 'timeout'
+     * - envCount: number (environments found, on success only)
+     * - errorType: string (error class name, on failure only)
+     */
+    ENVIRONMENT_DISCOVERY = 'ENVIRONMENT_DISCOVERY',
 }
 
 // Map all events to their properties
@@ -134,12 +143,17 @@ export interface IEventNamePropertyMapping {
     /* __GDPR__
         "package_management": {
             "managerId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
-            "result": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" }
+            "result": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "errorType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "triggerSource": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "<duration>": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" }
         }
     */
     [EventNames.PACKAGE_MANAGEMENT]: {
         managerId: string;
         result: 'success' | 'error' | 'cancelled';
+        errorType?: string;
+        triggerSource: 'ui' | 'requirements' | 'package' | 'uninstall';
     };
 
     /* __GDPR__
@@ -179,5 +193,21 @@ export interface IEventNamePropertyMapping {
         totalProjectCount: number;
         uniqueInterpreterCount: number;
         projectUnderRoot: number;
+    };
+
+    /* __GDPR__
+        "environment_discovery": {
+            "managerId": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "result": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "envCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
+            "errorType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "<duration>": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" }
+        }
+    */
+    [EventNames.ENVIRONMENT_DISCOVERY]: {
+        managerId: string;
+        result: 'success' | 'error' | 'timeout';
+        envCount?: number;
+        errorType?: string;
     };
 }


### PR DESCRIPTION
extra telemetry to track success and errors for both environment discovery and package installations. Use to help identify if there are trends in error data.