### PR TITLE
fix: graduate PET configure timeout to avoid killing process prematurely (Fixes #1274)

### DIFF
--- a/src/test/managers/common/nativePythonFinder.configureTimeout.unit.test.ts
+++ b/src/test/managers/common/nativePythonFinder.configureTimeout.unit.test.ts
@@ -1,5 +1,9 @@
 import assert from 'node:assert';
-import { RpcTimeoutError, getConfigureTimeoutMs } from '../../../managers/common/nativePythonFinder';
+import {
+    ConfigureRetryState,
+    RpcTimeoutError,
+    getConfigureTimeoutMs,
+} from '../../../managers/common/nativePythonFinder';
 
 suite('RpcTimeoutError', () => {
     test('has correct name property', () => {
@@ -41,5 +45,75 @@ suite('getConfigureTimeoutMs', () => {
         // 30_000 * 2^3 = 240_000, but capped at 120_000
         assert.strictEqual(getConfigureTimeoutMs(3), 120_000);
         assert.strictEqual(getConfigureTimeoutMs(10), 120_000);
+    });
+});
+
+suite('ConfigureRetryState', () => {
+    let state: ConfigureRetryState;
+
+    setup(() => {
+        state = new ConfigureRetryState();
+    });
+
+    test('initial timeout count is 0', () => {
+        assert.strictEqual(state.timeoutCount, 0);
+    });
+
+    test('initial timeout is base (30s)', () => {
+        assert.strictEqual(state.getTimeoutMs(), 30_000);
+    });
+
+    test('onSuccess resets timeout count', () => {
+        state.onTimeout(); // count = 1
+        state.onSuccess();
+        assert.strictEqual(state.timeoutCount, 0);
+        assert.strictEqual(state.getTimeoutMs(), 30_000);
+    });
+
+    test('first timeout does not kill (returns false)', () => {
+        const shouldKill = state.onTimeout();
+        assert.strictEqual(shouldKill, false);
+        assert.strictEqual(state.timeoutCount, 1);
+    });
+
+    test('first timeout increases next timeout to 60s', () => {
+        state.onTimeout();
+        assert.strictEqual(state.getTimeoutMs(), 60_000);
+    });
+
+    test('second consecutive timeout kills (returns true)', () => {
+        state.onTimeout(); // count = 1
+        const shouldKill = state.onTimeout(); // count = 2 → kill → reset to 0
+        assert.strictEqual(shouldKill, true);
+        assert.strictEqual(state.timeoutCount, 0); // Reset after kill
+    });
+
+    test('non-timeout error resets counter via reset()', () => {
+        state.onTimeout(); // count = 1
+        state.reset(); // simulates non-timeout error
+        assert.strictEqual(state.timeoutCount, 0);
+        // Next timeout should not trigger kill
+        const shouldKill = state.onTimeout();
+        assert.strictEqual(shouldKill, false);
+    });
+
+    test('interleaved non-timeout error prevents premature kill', () => {
+        state.onTimeout(); // count = 1
+        state.reset(); // non-timeout error resets
+        state.onTimeout(); // count = 1 again (not 2)
+        assert.strictEqual(state.timeoutCount, 1);
+        // Still shouldn't kill — only 1 consecutive timeout
+        assert.strictEqual(state.getTimeoutMs(), 60_000);
+    });
+
+    test('reset after kill allows fresh retry cycle', () => {
+        state.onTimeout();
+        state.onTimeout(); // kill → reset
+        // Counter was reset by onTimeout when it returned true
+        assert.strictEqual(state.timeoutCount, 0);
+        assert.strictEqual(state.getTimeoutMs(), 30_000);
+        // First timeout of new cycle should not kill
+        const shouldKill = state.onTimeout();
+        assert.strictEqual(shouldKill, false);
     });
 });


### PR DESCRIPTION
Fix PET configure timeout killing the process prematurely, which prevents recovery on large workspaces.

## Changes

- Introduce `RpcTimeoutError` class with a `method` property for type-safe timeout detection instead of fragile string matching
- Graduate configure timeouts with exponential backoff on timeout duration: 1st attempt 30s, retry 60s, then kill — giving PET up to 90s total before restart
- Move `lastConfiguration` cache write to after successful response — previously a failed configure would cache the options, causing subsequent calls to skip the configure request entirely
- Clear `lastConfiguration` on any configure failure to ensure retries are not skipped by `configurationEquals`
- Prevent double-kill: `resolve()` and `doRefresh()` no longer kill the process on configure timeouts (already handled inside `configure()`)
- Reset `configureTimeoutCount` on successful configure and on process restart

## Root Cause

When PET takes >30s to process configuration (e.g., large filesystem with glob patterns like `**/.venv` in dev containers), the extension immediately killed it and restarted. PET then had to re-process the same configuration from scratch, hitting the same timeout again, burning through all 3 restart attempts and leaving PET permanently dead.

Fixes #1274
Fixes #1266