### PR TITLE
feat: pre-warm environment manager caches during activation and background refresh

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ import {
     window,
 } from 'vscode';
 import { PythonEnvironment, PythonEnvironmentApi, PythonProjectCreator } from './api';
-import { ENVS_EXTENSION_ID } from './common/constants';
+import { ENVS_EXTENSION_ID, SYSTEM_MANAGER_ID, VENV_MANAGER_ID } from './common/constants';
 import { ensureCorrectVersion } from './common/extVersion';
 import { registerLogger, traceError, traceInfo, traceWarn } from './common/logging';
 import { clearPersistentState, setPersistentState } from './common/persistentState';
@@ -545,6 +545,18 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
                     registerPoetryFeatures(nativeFinder, context.subscriptions, outputChannel, projectManager),
                 ),
                 safeRegister('shellStartupVars', shellStartupVarsMgr.initialize()),
+            ]);
+
+            // Pre-warm system and venv manager caches before initial environment selection.
+            await Promise.all([
+                envManagers
+                    .getEnvironmentManager(SYSTEM_MANAGER_ID)
+                    ?.getEnvironments('all')
+                    .catch(() => {}),
+                envManagers
+                    .getEnvironmentManager(VENV_MANAGER_ID)
+                    ?.getEnvironments('all')
+                    .catch(() => {}),
             ]);
 
             await applyInitialEnvironmentSelection(envManagers, projectManager, nativeFinder, api);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -549,14 +549,16 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
 
             // Pre-warm system and venv manager caches before initial environment selection.
             await Promise.all([
-                envManagers
-                    .getEnvironmentManager(SYSTEM_MANAGER_ID)
-                    ?.getEnvironments('all')
-                    .catch(() => {}),
-                envManagers
-                    .getEnvironmentManager(VENV_MANAGER_ID)
-                    ?.getEnvironments('all')
-                    .catch(() => {}),
+                (
+                    envManagers.getEnvironmentManager(SYSTEM_MANAGER_ID)?.getEnvironments('all') ?? Promise.resolve()
+                ).catch((err) => {
+                    traceWarn('[pre-warm] System manager cache warm-up failed:', err);
+                }),
+                (envManagers.getEnvironmentManager(VENV_MANAGER_ID)?.getEnvironments('all') ?? Promise.resolve()).catch(
+                    (err) => {
+                        traceWarn('[pre-warm] Venv manager cache warm-up failed:', err);
+                    },
+                ),
             ]);
 
             await applyInitialEnvironmentSelection(envManagers, projectManager, nativeFinder, api);

--- a/src/managers/common/nativePythonFinder.ts
+++ b/src/managers/common/nativePythonFinder.ts
@@ -238,6 +238,11 @@ class NativePythonFinderImpl implements NativePythonFinder {
             1,
             'NativeRefresh-task',
         );
+
+        // Start discovery immediately so the cache is warm before managers call initialize().
+        void this.refresh(false).catch((err) => {
+            traceWarn('[pet] Background pre-warm refresh failed:', err);
+        });
     }
 
     public async resolve(executable: string): Promise<NativeEnvInfo> {


### PR DESCRIPTION
Managers don't scan on registration- `initialize()` only runs when a consumer first calls `getEnvironments()` making the whole discovery process lengthly. Every step is sequential and lazy. On a large filesystem or slow disk this is 10–30 seconds of real time with the user watching an empty interpreter picker.

The Python extension avoids this by starting discovery in the `NativePythonFinderImpl` **constructor**, so results begin streaming before other exts makes its first call.