### PR TITLE
Modify Azure pipeline for Azure Artifacts publishing

### DIFF
--- a/build/azure-pipeline.npm.yml
+++ b/build/azure-pipeline.npm.yml
@@ -56,7 +56,6 @@ variables:
       value: next
     ${{ else }}:
       value: latest
-  # TODO: Replace with your actual Azure Artifacts feed URL
   - name: AzureArtifactsFeedUrl
     value: 'https://pkgs.dev.azure.com/azure-public/vside/_packaging/python-environments/npm/registry/'
   # Same URL without the https:// prefix (used in .npmrc auth lines)


### PR DESCRIPTION
Updated Azure pipeline to publish to Azure Artifacts instead of npm. Added Managed Identity for authentication and created .npmrc files for Azure Artifacts.