### PR TITLE
fix: revert workspaceSearchPaths default - Large Repo/Remote env recognition is now instant

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
                 "python-envs.workspaceSearchPaths": {
                     "type": "array",
                     "description": "%python-envs.workspaceSearchPaths.description%",
-                    "default": ["./**/.venv"],
+                    "default": [],
                     "scope": "resource",
                     "items": {
                         "type": "string"


### PR DESCRIPTION
After some debugging, I located the culprit of so many issues, @eleanorjboyd (tagging you, we discussed in https://github.com/microsoft/vscode-python-environments/issues/1335 and https://github.com/microsoft/vscode-python-environments/issues/1316), in addition to the PR that changed this (https://github.com/microsoft/vscode-python-environments/pull/1191), so you would know best why this was changed. 
Per my understanding, the workspaceSearchPaths should be extended by users for non-default paths, but it's being broadly applied to everyone. A temporary fix for affected versions could be to override the default, but in general, it makes more sense for the integrated default searches to find conda/pyenv, etc. (as they do so in milliseconds).  

People who are using affected versions just need to change .vscode/settings.json:
```
{
      "python-envs.workspaceSearchPaths": []
}
```
Additionally tagging @karthiknadig as you did https://github.com/microsoft/vscode-python-environments/pull/1154/

The default workspaceSearchPaths of `["./**/.venv"]` introduced in https://github.com/microsoft/vscode-python-environments/pull/1191/ (2026-02-06) causes the PET server to recursively walk the entire workspace during `configure`, which exceeds the 30s timeout (https://github.com/microsoft/vscode-python-environments/pull/1154/ on 2026-02-03) on large workspaces. PET's built-in Venv locator already discovers `.venv` directories at workspace roots without needing extra search paths. In addition to affecting Conda/Mamba users, who likely don't even need this search (pip files are usually installed under a predefined folder structure in conda/mamba). 

Affected versions on vscode extensions: v1.18.0, v1.18.1, v1.20.0, v1.20.1, v1.22.0, and preview/main (v1.16.0 and earlier used an empty default and are not affected).

Fixes an environment discovery failure in workspaces with deep directory trees (e.g., ML projects with datasets, checkpoints, and other large repos). As this is my first open-source commit, feel free to guide me if you need anything else. 

Issues likely fixed with this PR: https://github.com/microsoft/vscode-python-environments/issues/1330, https://github.com/microsoft/vscode-python-environments/issues/1319, https://github.com/microsoft/vscode-python-environments/issues/1313, https://github.com/microsoft/vscode-python-environments/issues/1310, https://github.com/microsoft/vscode-python-environments/issues/1286, https://github.com/microsoft/vscode-python-environments/issues/1407, https://github.com/microsoft/vscode-python-environments/issues/1316, https://github.com/microsoft/vscode-python-environments/issues/1309
New issues that are likely the same problem: https://github.com/microsoft/vscode-python-environments/issues/1357, https://github.com/microsoft/vscode-python-environments/issues/1354, https://github.com/microsoft/vscode-python-environments/issues/1335

Not sure how to check if this issue is reported by https://github.com/microsoft/vscode-python-environments/issues/1361, https://github.com/microsoft/vscode-python-environments/issues/1360 and https://github.com/microsoft/vscode-python-environments/issues/1358 I leave that to you. 

I think the first reported issue of this is actually your issue https://github.com/microsoft/vscode-python-environments/issues/1206 @eleanorjboyd, sounds to me like this, as in my tests, when I reload the window, it tries to force refresh conda envs because of PET configuration update, see below:
```
2026-03-16 15:07:47.814 [info] [pet] configure: Sending configuration update: {"workspaceDirectories":["<project_path>"],"environmentDirectories":["<project_path>/**/.venv"],"pipenvExecutable":"pipenv","poetryExecutable":"poetry","cacheDirectory":"/home/<username>/.vscode-server/data/User/globalStorage/ms-python.vscode-python-envs/pythonLocator"}
2026-03-16 15:07:48.340 [info] Refreshing conda environments (hardRefresh=false)
2026-03-16 15:07:48.379 [info] Refreshing Conda Environments
2026-03-16 15:07:48.379 [info] Refreshing conda environments (hardRefresh=true)
```

I used conda-forge's nodejs 24.14.0 (h3d65ac4_0) for the tests, and both for main and your commit (https://github.com/microsoft/vscode-python-environments/pull/1344), I get the following attached files for `npm run compile-tests` followed by `npm run unittest`, which should also be mentioned in the Contribution nodes see below, and I primarily deal with Python. 
https://github.com/microsoft/vscode-python-environments/blob/ecbcdacf414215477dd312d38914f80ca6611530/CONTRIBUTING.md?plain=1#L27-L35

[unittest_logs_my_fix.txt](https://github.com/user-attachments/files/26024818/unittest_logs_my_fix.txt)
[unittest_logs_with_1344PR.txt](https://github.com/user-attachments/files/26024820/unittest_logs_with_1344PR.txt)

Additional notes: not sure if doing a full subdirectory file search is the way to go; I leave those design choices up to you guys, but it shouldn't be the default for sure. As in my experimenting, this causes crashes in remote VS Code, unresponsive VS Code, PyLance not working at all, and other tools that rely on this fast discovery. Even if by miracle it resolves the issue in my setup (in some of the versions I tested), it still takes 5 minutes instead of 3 seconds.  