### PR TITLE
prioritize workspace selected env over process.env.CONDA_PREFIX

### DIFF
--- a/src/managers/conda/condaUtils.ts
+++ b/src/managers/conda/condaUtils.ts
@@ -84,15 +84,11 @@ export function getCondaPathSetting(): string | undefined {
 export async function getCondaForWorkspace(fsPath: string): Promise<string | undefined> {
     // Check persisted user selection first so explicit choices survive restarts
     const state = await getWorkspacePersistentState();
-    const data: { [key: string]: string } | undefined = await state.get(CONDA_WORKSPACE_KEY);
-    if (data) {
-        try {
-            const saved = data[fsPath];
-            if (saved) {
-                return saved;
-            }
-        } catch {
-            // fall through to CONDA_PREFIX fallback
+    const data = await state.get<unknown>(CONDA_WORKSPACE_KEY);
+    if (data && typeof data === 'object') {
+        const workspaceSelections = data as { [key: string]: string };
+        if (Object.prototype.hasOwnProperty.call(workspaceSelections, fsPath)) {
+            return workspaceSelections[fsPath];
         }
     }
 

--- a/src/test/managers/conda/condaUtils.getCondaForWorkspace.unit.test.ts
+++ b/src/test/managers/conda/condaUtils.getCondaForWorkspace.unit.test.ts
@@ -91,4 +91,17 @@ suite('Conda Utils - getCondaForWorkspace prioritization', () => {
 
         assert.strictEqual(result, userSelectedEnv);
     });
+
+    test('Returns persisted empty string without falling back to CONDA_PREFIX', async () => {
+        const workspacePath = '/home/user/project';
+        process.env.CONDA_PREFIX = '/home/user/miniconda3';
+
+        mockState.get.withArgs(CONDA_WORKSPACE_KEY).resolves({
+            [workspacePath]: '',
+        });
+
+        const result = await getCondaForWorkspace(workspacePath);
+
+        assert.strictEqual(result, '');
+    });
 });


### PR DESCRIPTION
`getCondaForWorkspace()` prioritizes `process.env.CONDA_PREFIX` over the persisted workspace selection (commit `b546ac4`, PR #1243). This is at `src/managers/conda/condaUtils.ts#L85-L87`. Fix: swap the order so Memento state is checked first, `CONDA_PREFIX` is fallback only.

fixes https://github.com/microsoft/vscode-python-environments/issues/1347