### PR TITLE
Choose project for terminal

### DIFF
--- a/src/features/envCommands.ts
+++ b/src/features/envCommands.ts
@@ -30,7 +30,6 @@ import { removePythonProjectSetting, setEnvironmentManager, setPackageManager } 
 
 import { executeCommand } from '../common/command.api';
 import { clipboardWriteText } from '../common/env.apis';
-import { } from '../common/errors/utils';
 import { Pickers } from '../common/localize';
 import { pickEnvironment } from '../common/pickers/environments';
 import {


### PR DESCRIPTION
Fixes #291 

<img width="1224" height="286" alt="image" src="https://github.com/user-attachments/assets/05bf5783-8f0f-4479-9b0e-e838ccc85aa2" />


This pull request updates the logic for creating terminal commands related to Python environments, focusing on how Python projects are retrieved and passed to the `pickProject` function. The changes improve consistency and clarity in how project lists are handled.

**Improvements to project selection logic:**

* The list of Python projects is now retrieved once and reused in both the undefined context and tree item context branches, ensuring consistency and avoiding redundant API calls. [[1]](diffhunk://#diff-aed4c8c8194da21783959fe3536c5b86f48d4c0755e2ef4092501dbc5e849419L609-R611) [[2]](diffhunk://#diff-aed4c8c8194da21783959fe3536c5b86f48d4c0755e2ef4092501dbc5e849419L644-R645)
* The condition for prompting the user to pick a project has been updated to check if the list of Python projects is non-empty, which prevents unnecessary prompts when there are no projects available.