### PR TITLE
Add watcher for pip installs

### DIFF
--- a/src/managers/builtin/main.ts
+++ b/src/managers/builtin/main.ts
@@ -50,7 +50,7 @@ export async function registerSystemPythonFeatures(
                 try {
                     await api.refreshPackages(env);
                 } catch (ex) {
-                    log.error(`Failed to refresh packages for environment ${env.id}: ${ex instanceof Error ? ex.message : String(ex)}`);
+                    log.error(`Failed to refresh packages for environment ${env.envId}: ${ex instanceof Error ? ex.message : String(ex)}`);
                 }
             }
         }

--- a/src/managers/builtin/main.ts
+++ b/src/managers/builtin/main.ts
@@ -27,17 +27,48 @@ export async function registerSystemPythonFeatures(
     const venvDebouncedRefresh = createSimpleDebounce(500, () => {
         venvManager.watcherRefresh();
     });
-    const watcher = createFileSystemWatcher('{**/activate}', false, true, false);
+    const activationWatcher = createFileSystemWatcher('{**/activate}', false, true, false);
     disposables.push(
-        watcher,
-        watcher.onDidCreate(() => {
+        activationWatcher,
+        activationWatcher.onDidCreate(() => {
             venvDebouncedRefresh.trigger();
         }),
-        watcher.onDidDelete(() => {
+        activationWatcher.onDidDelete(() => {
             venvDebouncedRefresh.trigger();
         }),
         onDidDeleteFiles(() => {
             venvDebouncedRefresh.trigger();
+        }),
+    );
+
+    const packageDebouncedRefresh = createSimpleDebounce(500, async () => {
+        // Get all projects and refresh their packages
+        const projects = await api.getPythonProjects();
+        for (const project of projects) {
+            const env = await api.getEnvironment(project.uri);
+            if (env) {
+                try {
+                    await api.refreshPackages(env);
+                } catch (ex) {
+                    log.error(`Failed to refresh packages for environment ${env.id}: ${ex instanceof Error ? ex.message : String(ex)}`);
+                }
+            }
+        }
+    });
+    const packageWatcher = createFileSystemWatcher(
+        '**/site-packages/*.dist-info/METADATA', 
+        false, // don't ignore create events    (pip install)
+        true,  // ignore change events          (content changes in METADATA don't affect package list)
+        false  // don't ignore delete events    (pip uninstall)
+    );
+    disposables.push(
+        packageDebouncedRefresh,
+        packageWatcher,
+        packageWatcher.onDidCreate(() => {
+            packageDebouncedRefresh.trigger();
+        }),
+        packageWatcher.onDidDelete(() => {
+            packageDebouncedRefresh.trigger();
         }),
     );
 }

--- a/src/managers/builtin/main.ts
+++ b/src/managers/builtin/main.ts
@@ -42,18 +42,22 @@ export async function registerSystemPythonFeatures(
     );
 
     const packageDebouncedRefresh = createSimpleDebounce(500, async () => {
-        // Get all projects and refresh their packages
         const projects = await api.getPythonProjects();
-        for (const project of projects) {
-            const env = await api.getEnvironment(project.uri);
-            if (env) {
+        await Promise.all(
+            projects.map(async (project) => {
+                const env = await api.getEnvironment(project.uri);
+                if (!env) {
+                    return;
+                }
                 try {
                     await api.refreshPackages(env);
                 } catch (ex) {
-                    log.error(`Failed to refresh packages for environment ${env.envId}: ${ex instanceof Error ? ex.message : String(ex)}`);
+                    log.error(
+                        `Failed to refresh packages for environment ${env.envId}: ${ex instanceof Error ? ex.message : String(ex)}`,
+                    );
                 }
-            }
-        }
+            }),
+        );
     });
     const packageWatcher = createFileSystemWatcher(
         '**/site-packages/*.dist-info/METADATA', 


### PR DESCRIPTION
Fixes #548 

This pull request enhances the Python environment management by improving how changes to virtual environments and installed packages are detected and handled. The main focus is on ensuring that updates to the environment and package lists are automatically and efficiently refreshed when relevant files are created or deleted.

**Improvements to environment and package monitoring:**

* Renamed the `watcher` for `activate` files to `activationWatcher` for clarity and consistency.
* Added a new `packageWatcher` that monitors `METADATA` files within `site-packages/*.dist-info` directories to detect package installations and uninstallations, triggering a debounced refresh of the package list for all Python projects.
* Introduced `packageDebouncedRefresh`, which efficiently refreshes package lists across all environments when relevant changes are detected, and logs errors if package refresh fails.