### PR TITLE
switch to optimistic + lazy registration for pipenv, pyenv and poetry managers

### DIFF
--- a/docs/startup-flow.md
+++ b/docs/startup-flow.md
@@ -18,13 +18,22 @@ ASYNC (setImmediate callback, still in extension.ts):
 1. spawn PET process (`createNativePythonFinder`)
    1. sets up a JSON-RPC connection to it over stdin/stdout
 2. register all built-in managers in parallel (Promise.all):
-   - for each manager (system, conda, pyenv, pipenv, poetry):
-     1. check if tool exists (e.g. `getConda(nativeFinder)` asks PET for the conda binary)
-     2. if tool not found → log, return early (manager not registered)
-     3. if tool found → create manager, call `api.registerEnvironmentManager(manager)`
-        - this adds it to the `EnvironmentManagers` map
-        - fires `onDidChangeEnvironmentManager` → `ManagerReady` deferred resolves for this manager
-3. all registrations complete (Promise.all resolves)
+   - system: create SysPythonManager + VenvManager + PipPackageManager, register immediately
+     - ✅ NO PET call — managers are created and registered with no tool detection
+     - sets up file watcher for venv activation scripts
+   - conda: `getConda(nativeFinder)` checks settings → cache → persistent state → PATH
+     - if found → register CondaEnvManager + CondaPackageManager
+     - if not found → PET fallback as last resort (rarely hit, conda is usually on PATH)
+     - if not found at all → skip, send MANAGER_REGISTRATION.SKIPPED telemetry
+   - pyenv: create PyEnvManager, register immediately
+     - ✅ NO PET call — always registers unconditionally (lazy discovery)
+   - pipenv: create PipenvManager, register immediately
+     - ✅ NO PET call — always registers unconditionally (lazy discovery)
+   - poetry: create PoetryManager + PoetryPackageManager, register immediately
+     - ✅ NO PET call — always registers unconditionally (lazy discovery)
+   - shellStartupVars: initialize
+   - all managers fire `onDidChangeEnvironmentManager` → ManagerReady resolves
+3. all registrations complete (Promise.all resolves) — fast, typically milliseconds
 
 --- gate point: `applyInitialEnvironmentSelection` ---
    📊 TELEMETRY: ENV_SELECTION.STARTED { duration (activation→here), registeredManagerCount, registeredManagerIds, workspaceFolderCount }
@@ -55,10 +64,10 @@ ASYNC (setImmediate callback, still in extension.ts):
    managerDiscovery — P1, P2, or P4 won (manager → interpreter):
      `resolvePriorityChainCore` returns { manager, environment: undefined }
        → result.environment is undefined → falls through to `await result.manager.get(scope)`
-     `manager.get(scope)` (e.g. `CondaEnvManager.get()`):
+     `manager.get(scope)` (e.g. `CondaEnvManager.get()`, `PyEnvManager.get()`):
        4. `initialize()` — lazy, once-only per manager (guarded by deferred)
           a. `nativeFinder.refresh(hardRefresh=false)`:
-             → `handleSoftRefresh()` checks in-memory cache (Map) for key 'all' (bc one big scan, shared cache, all managers benefit)
+             → `handleSoftRefresh()` checks in-memory cache (Map) for key 'all'
                - on reload: cache is empty (Map was destroyed) → cache miss
                - falls through to `handleHardRefresh()`
              → `handleHardRefresh()`:
@@ -66,15 +75,18 @@ ASYNC (setImmediate callback, still in extension.ts):
                - when its turn comes, calls `doRefresh()`:
                  1. `configure()` — JSON-RPC to PET with search paths, conda/poetry/pipenv paths, cache dir
                  2. `refresh` — JSON-RPC to PET, PET scans filesystem
+                    - PET has had time to warm up since spawn (registration was fast)
                     - PET may use its own on-disk cache (cacheDirectory) to speed this up
                     - PET streams back results as 'environment' and 'manager' notifications
                     - envs missing version/prefix get an inline resolve() call
                  3. returns NativeInfo[] (all envs of all types)
                - result stored in in-memory cache under key 'all'
              → subsequent managers calling nativeFinder.refresh(false) get cache hit → instant
-          b. filter results to this manager's env type (e.g. conda filters to kind=conda)
-          c. convert NativeEnvInfo → PythonEnvironment objects → populate collection
-          d. `loadEnvMap()` — reads persisted env path from workspace state
+          b. filter results to this manager's env type (e.g. conda filters to kind=conda, pyenv to kind=pyenv)
+          c. for pipenv/poetry/pyenv: if tool CLI was not found via PATH during registration,
+             extract tool executable from PET's manager info in the refresh results
+          d. convert NativeEnvInfo → PythonEnvironment objects → populate collection
+          e. `loadEnvMap()` — reads persisted env path from workspace state
              → matches path against freshly discovered collection via `findEnvironmentByPath()`
              → populates `fsPathToEnv` map
        5. look up scope in `fsPathToEnv` → return the matched env
@@ -85,6 +97,15 @@ ASYNC (setImmediate callback, still in extension.ts):
 4. Python extension / status bar can now get the selected env via `api.getEnvironment(scope)`
 
    📊 TELEMETRY: EXTENSION.MANAGER_REGISTRATION_DURATION { duration (activation→here), result, failureStage?, errorType? }
+
+SIDEBAR ACCESS (on-demand, if user opens Python environments panel):
+- view iterates `providers.managers` → all registered managers appear (including pyenv/pipenv/poetry)
+- user expands a manager node → `getChildren()` → `manager.getEnvironments('all')`
+  → `initialize()` (lazy, once-only) → `nativeFinder.refresh(false)`:
+    - if cache populated from earlier env selection → instant cache hit
+    - if first access → warm PET call (no concurrent pressure, single caller)
+  → environments appear under the manager node
+  → if no environments found → "No environments" placeholder shown
 
 POST-INIT:
 1. register terminal package watcher

--- a/docs/startup-flow.md
+++ b/docs/startup-flow.md
@@ -20,18 +20,9 @@ python environments extension begins activation
 1. spawn PET process (`createNativePythonFinder`)
    1. sets up a JSON-RPC connection to it over stdin/stdout
 2. register all built-in managers in parallel (Promise.all):
-   - system: create SysPythonManager + VenvManager + PipPackageManager, register immediately
-     - ✅ NO PET call — managers are created and registered with no tool detection
-     - sets up file watcher for venv activation scripts
+   - system: create SysPythonManager + VenvManager + PipPackageManager, register immediately (✅ NO PET call, sets up file watcher)
    - conda: `getConda(nativeFinder)` checks settings → cache → persistent state → PATH
-     - if found → register CondaEnvManager + CondaPackageManager
-     - if not found → PET fallback as last resort (rarely hit, conda is usually on PATH)
-     - if not found at all → skip, send MANAGER_REGISTRATION.SKIPPED telemetry
-   - pyenv: create PyEnvManager, register immediately
-     - ✅ NO PET call — always registers unconditionally (lazy discovery)
-   - pipenv: create PipenvManager, register immediately
-     - ✅ NO PET call — always registers unconditionally (lazy discovery)
-   - poetry: create PoetryManager + PoetryPackageManager, register immediately
+   - pyenv & pipenv & poetry: create PyEnvManager, register immediately
      - ✅ NO PET call — always registers unconditionally (lazy discovery)
    - shellStartupVars: initialize
    - all managers fire `onDidChangeEnvironmentManager` → ManagerReady resolves
@@ -40,99 +31,65 @@ python environments extension begins activation
 
 **--- gate point: `applyInitialEnvironmentSelection` ---**
 
-   📊 TELEMETRY: ENV_SELECTION.STARTED { duration (activation→here), registeredManagerCount, registeredManagerIds, workspaceFolderCount }
+   📊 TELEMETRY: ENV_SELECTION.STARTED { duration, registeredManagerCount, registeredManagerIds, workspaceFolderCount }
 
-1. for each workspace folder + global scope (no workspace case), run `resolvePriorityChainCore` to find manager:
-   - P1: pythonProjects[] setting → specific manager for this project
-   - P2: user-configured defaultEnvManager setting
-   - P3: user-configured python.defaultInterpreterPath → nativeFinder.resolve(path)
-   - P4: auto-discovery → try venv manager, fall back to system python
-     - for workspace scope: call `venvManager.get(scope)`
-       - if venv found (local .venv/venv) → use venv manager with that env
-       - if no local venv → venv manager may still return its `globalEnv` (system Python)
-       - if venvManager.get returns undefined → fall back to system python manager
-     - for global scope: use system python manager directly
+**Step 1 — pick a manager** (`resolvePriorityChainCore`, per workspace folder + global):
 
-2. get the environment from the winning priority level:
+| Priority | Source | Returns |
+|----------|--------|---------|
+| P1 | `pythonProjects[]` setting | manager only |
+| P2 | `defaultEnvManager` setting | manager only |
+| P3 | `python.defaultInterpreterPath` → `nativeFinder.resolve(path)` | manager **+ environment** |
+| P4 | auto-discovery: venv → system python fallback | manager only |
 
-   --- fork point: `result.environment ?? await result.manager.get(folder.uri)` ---
-   left side truthy = envPreResolved | left side undefined = managerDiscovery
+**Step 2 — get the environment** (`result.environment ?? await result.manager.get(scope)`):
 
-   envPreResolved — P3 won (interpreter → manager):
-     `resolvePriorityChainCore` calls `tryResolveInterpreterPath()`:
-       1. `nativeFinder.resolve(path)` — single PET call, resolves just this one binary
-       2. find which manager owns the resolved env (by managerId)
-       3. return { manager, environment } — BOTH are known
-     → result.environment is set → the `??` short-circuits
-     → no `manager.get()` called, no `initialize()`, no full discovery
+- **If P3 won:** environment is already resolved → done, no `get()` call needed.
+- **Otherwise:** calls `manager.get(scope)`, which has two internal paths:
 
-   managerDiscovery — P1, P2, or P4 won (manager → interpreter):
-     `resolvePriorityChainCore` returns { manager, environment: undefined }
-       → falls through to `await result.manager.get(scope)`
+  **Fast path** (`tryFastPathGet` in `fastPath.ts`) — entered when `_initialized` hasn't completed and scope is a `Uri`:
+  1. Synchronously create `_initialized` deferred + kick off `startBackgroundInit()` (fire-and-forget full PET discovery)
+  2. Read persisted env path from workspace state
+  3. If persisted path exists → `resolve(path)` → return immediately (background init continues in parallel)
+  4. If no persisted path or resolve fails → fall through to slow path
+  - *On background init failure:* clears `_initialized` so next `get()` retries
 
-       **--- inner fork: fast path vs slow path (tryFastPathGet in fastPath.ts) ---**
-      Conditions checked before entering fast path:
-         a. `_initialized` deferred is undefined (never created) OR has not yet completed
-         b. scope is a `Uri` (not global/undefined)
+  **Slow path** — fast path skipped or failed:
+  1. `initialize()` — lazy, once-only (guarded by `_initialized` deferred, concurrent callers await it)
+     - `nativeFinder.refresh(false)` → PET scan (cached across managers after first call)
+     - Filter results to this manager's type → populate `collection`
+     - `loadEnvMap()` → match persisted paths against discovered envs
+  2. Look up scope in `fsPathToEnv` → return matched env
 
-         FAST PATH (background init kickoff + optional early return):
-         **Race-condition safety (runs before any await):**
-         1. if `_initialized` doesn't exist yet:
-            - create deferred and **register immediately** via `setInitialized()` callback
-            - this blocks concurrent callers from spawning duplicate background inits
-              - kick off `startBackgroundInit()` as fire-and-forget
-                 - this happens as soon as (a) and (b) are true, **even if** no persisted path exists
-         2. get project fsPath: `getProjectFsPathForScope(api, scope)` 
-            - prefers resolved project path if available, falls back to scope.fsPath
-            - shared across all managers to avoid lambda duplication
-           3. read persisted path (only if scope is a `Uri`; may return undefined)
-           4. if a persisted path exists:
-              - attempt `resolve(persistedPath)`
-              - failure (no env, mismatched manager, etc.) → fall through to SLOW PATH
-              - success → return env immediately (background init continues in parallel)
-         **Failure recovery (in startBackgroundInit error handler):**
-         - if background init throws: `setInitialized(undefined)` — clear deferred so next `get()` call retries init
+   📊 TELEMETRY: ENV_SELECTION.RESULT (per scope) { duration, scope, prioritySource, managerId, path, hasPersistedSelection }
 
-       SLOW PATH — fast path conditions not met, or fast path failed:
-         4. `initialize()` — lazy, once-only per manager (guarded by `_initialized` deferred)
-            **Once-only guarantee:**
-            - first caller creates `_initialized` deferred (if not already created by fast path)
-            - concurrent callers see the existing deferred and await it instead of re-running init
-            - deferred is **not cleared on failure** here (unlike in fast-path background handler)
-              so only one init attempt runs, but subsequent calls still await the same failed init
-            **Note:** In the fast path, if background init fails, the deferred is cleared to allow retry
-            a. `nativeFinder.refresh(hardRefresh=false)`:
-               → internally calls `handleSoftRefresh()` → computes cache key from options
-                 - on reload: cache is empty (Map was destroyed) → cache miss
-                 - falls through to `handleHardRefresh()`
-               → `handleHardRefresh()` adds request to WorkerPool queue (concurrency 1):
-                   1. run `configure()` to setup PET search paths
-                   2. run `refresh` — PET scans filesystem
-                      - PET may use its own on-disk cache
-                   3. returns NativeInfo[] (all envs of all types)
-                      - result stored in in-memory cache so subsequent managers get instant cache hit
-            b. filter results to this manager's env type (e.g. conda filters to kind=conda)
-            c. convert NativeEnvInfo → PythonEnvironment objects → populate collection
-            d. `loadEnvMap()` — reads persisted env path from workspace state
-               → matches path against PET discovery results
-               → populates `fsPathToEnv` map
-         5. look up scope in `fsPathToEnv` → return the matched env
+**Step 3 — done:**
+- env cached in memory (no settings.json write)
+- available via `api.getEnvironment(scope)`
 
-   📊 TELEMETRY: ENV_SELECTION.RESULT (per scope) { duration (priority chain + manager.get), scope, prioritySource, managerId, path, hasPersistedSelection }
+   📊 TELEMETRY: EXTENSION.MANAGER_REGISTRATION_DURATION { duration, result, failureStage?, errorType? }
 
-3. env is cached in memory (no settings.json write)
-4. Python extension / status bar can now get the selected env via `api.getEnvironment(scope)`
+---
 
-   📊 TELEMETRY: EXTENSION.MANAGER_REGISTRATION_DURATION { duration (activation→here), result, failureStage?, errorType? }
+### Other entry points to `initialize()`
 
-SIDEBAR ACCESS (on-demand, if user opens Python environments panel):
-- view iterates `providers.managers` → all registered managers appear (including pyenv/pipenv/poetry)
-- user expands a manager node → `getChildren()` → `manager.getEnvironments('all')`
-  → `initialize()` (lazy, once-only) → `nativeFinder.refresh(false)`:
-    - if cache populated from earlier env selection → instant cache hit
-    - if first access → warm PET call (no concurrent pressure, single caller)
-  → environments appear under the manager node
-  → if no environments found → "No environments" placeholder shown
+All three trigger `initialize()` lazily (once-only, guarded by `_initialized` deferred). After the first call completes, subsequent calls are no-ops.
+
+**`manager.get(scope)`** — environment selection (Step 2 above):
+- Called during `applyInitialEnvironmentSelection` or when settings change triggers re-selection
+- Fast path may resolve immediately; slow path awaits `initialize()`
+
+**`manager.getEnvironments(scope)`** — sidebar / listing:
+- Called when user expands a manager node in the Python environments panel
+- Also called by any API consumer requesting the full environment list
+- If PET cache populated from earlier `get()` → instant hit; otherwise warm PET call
+
+**`manager.resolve(context)`** — path resolution:
+- Called when resolving a specific Python binary path to check if it belongs to this manager
+- Used by `tryResolveInterpreterPath()` in the priority chain (P3) and by external API consumers
+- Awaits `initialize()`, then delegates to manager-specific resolve (e.g., `resolvePipenvPath`)
+
+---
 
 POST-INIT:
 1. register terminal package watcher

--- a/src/common/telemetry/constants.ts
+++ b/src/common/telemetry/constants.ts
@@ -101,6 +101,18 @@ export enum EventNames {
      * - hasPersistedSelection: boolean (whether a persisted env path existed in workspace state)
      */
     ENV_SELECTION_RESULT = 'ENV_SELECTION.RESULT',
+    /**
+     * Telemetry event fired when a lazily-registered manager completes its first initialization.
+     * Replaces MANAGER_REGISTRATION_SKIPPED and MANAGER_REGISTRATION_FAILED for managers
+     * that now register unconditionally (pipenv, poetry, pyenv).
+     * Properties:
+     * - managerName: string (e.g. 'pipenv', 'poetry', 'pyenv')
+     * - result: 'success' | 'tool_not_found' | 'error'
+     * - envCount: number (environments discovered)
+     * - toolSource: string (how the CLI was found: 'settings', 'cache', 'persistentState', 'path', 'pet', 'none')
+     * - errorType: string (classified error category, on failure only)
+     */
+    MANAGER_LAZY_INIT = 'MANAGER.LAZY_INIT',
 }
 
 // Map all events to their properties
@@ -372,5 +384,23 @@ export interface IEventNamePropertyMapping {
         managerId: string;
         resolutionPath: string;
         hasPersistedSelection: boolean;
+    };
+
+    /* __GDPR__
+        "manager.lazy_init": {
+            "managerName": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "result": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "envCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
+            "toolSource": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "errorType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "<duration>": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" }
+        }
+    */
+    [EventNames.MANAGER_LAZY_INIT]: {
+        managerName: string;
+        result: 'success' | 'tool_not_found' | 'error';
+        envCount: number;
+        toolSource: string;
+        errorType?: string;
     };
 }

--- a/src/common/telemetry/constants.ts
+++ b/src/common/telemetry/constants.ts
@@ -109,7 +109,7 @@ export enum EventNames {
      * - managerName: string (e.g. 'pipenv', 'poetry', 'pyenv')
      * - result: 'success' | 'tool_not_found' | 'error'
      * - envCount: number (environments discovered)
-     * - toolSource: string (how the CLI was found: 'settings', 'cache', 'persistentState', 'path', 'pet', 'none')
+     * - toolSource: string (how the CLI was found: 'settings', 'local', 'pet', 'none')
      * - errorType: string (classified error category, on failure only)
      */
     MANAGER_LAZY_INIT = 'MANAGER.LAZY_INIT',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -603,7 +603,10 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
                 ),
                 safeRegister('pyenv', registerPyenvFeatures(nativeFinder, context.subscriptions, projectManager)),
                 safeRegister('pipenv', registerPipenvFeatures(nativeFinder, context.subscriptions, projectManager)),
-                safeRegister('poetry', registerPoetryFeatures(nativeFinder, context.subscriptions, outputChannel, projectManager)),
+                safeRegister(
+                    'poetry',
+                    registerPoetryFeatures(nativeFinder, context.subscriptions, outputChannel, projectManager),
+                ),
                 safeRegister('shellStartupVars', shellStartupVarsMgr.initialize()),
             ]);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -601,9 +601,9 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
                     'conda',
                     registerCondaFeatures(nativeFinder, context.subscriptions, outputChannel, projectManager),
                 ),
-                safeRegister('pyenv', registerPyenvFeatures(nativeFinder, context.subscriptions)),
-                safeRegister('pipenv', registerPipenvFeatures(nativeFinder, context.subscriptions)),
-                safeRegister('poetry', registerPoetryFeatures(nativeFinder, context.subscriptions, outputChannel)),
+                safeRegister('pyenv', registerPyenvFeatures(nativeFinder, context.subscriptions, projectManager)),
+                safeRegister('pipenv', registerPipenvFeatures(nativeFinder, context.subscriptions, projectManager)),
+                safeRegister('poetry', registerPoetryFeatures(nativeFinder, context.subscriptions, outputChannel, projectManager)),
                 safeRegister('shellStartupVars', shellStartupVarsMgr.initialize()),
             ]);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -601,12 +601,9 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
                     'conda',
                     registerCondaFeatures(nativeFinder, context.subscriptions, outputChannel, projectManager),
                 ),
-                safeRegister('pyenv', registerPyenvFeatures(nativeFinder, context.subscriptions, projectManager)),
-                safeRegister('pipenv', registerPipenvFeatures(nativeFinder, context.subscriptions, projectManager)),
-                safeRegister(
-                    'poetry',
-                    registerPoetryFeatures(nativeFinder, context.subscriptions, outputChannel, projectManager),
-                ),
+                safeRegister('pyenv', registerPyenvFeatures(nativeFinder, context.subscriptions)),
+                safeRegister('pipenv', registerPipenvFeatures(nativeFinder, context.subscriptions)),
+                safeRegister('poetry', registerPoetryFeatures(nativeFinder, context.subscriptions, outputChannel)),
                 safeRegister('shellStartupVars', shellStartupVarsMgr.initialize()),
             ]);
 

--- a/src/managers/common/fastPath.ts
+++ b/src/managers/common/fastPath.ts
@@ -3,7 +3,7 @@
 
 import { Uri } from 'vscode';
 import { GetEnvironmentScope, PythonEnvironment, PythonEnvironmentApi } from '../../api';
-import { traceError, traceWarn } from '../../common/logging';
+import { traceError, traceVerbose, traceWarn } from '../../common/logging';
 import { createDeferred, Deferred } from '../../common/utils/deferred';
 
 /**
@@ -62,7 +62,6 @@ export async function tryFastPathGet(opts: FastPathOptions): Promise<FastPathRes
 
     let deferred = opts.initialized;
     if (!deferred) {
-        // Register deferred before any await to avoid concurrent callers starting duplicate inits.
         deferred = createDeferred<void>();
         opts.setInitialized(deferred);
         const deferredRef = deferred;
@@ -93,8 +92,13 @@ export async function tryFastPathGet(opts: FastPathOptions): Promise<FastPathRes
                 return { env: resolved };
             }
         } catch (err) {
-            traceWarn(`[${opts.label}] Fast path resolve failed for '${persistedPath}', falling back to full init:`, err);
+            traceWarn(
+                `[${opts.label}] Fast path resolve failed for '${persistedPath}', falling back to full init:`,
+                err,
+            );
         }
+    } else {
+        traceVerbose(`[${opts.label}] Fast path: no persisted path, falling through to slow path`);
     }
 
     return undefined;

--- a/src/managers/pipenv/main.ts
+++ b/src/managers/pipenv/main.ts
@@ -1,65 +1,17 @@
 import { Disposable } from 'vscode';
 import { PythonEnvironmentApi } from '../../api';
 import { traceInfo } from '../../common/logging';
-import { EventNames } from '../../common/telemetry/constants';
-import { classifyError } from '../../common/telemetry/errorClassifier';
-import { sendTelemetryEvent } from '../../common/telemetry/sender';
 import { getPythonApi } from '../../features/pythonApi';
-import { PythonProjectManager } from '../../internal.api';
 import { NativePythonFinder } from '../common/nativePythonFinder';
 import { PipenvManager } from './pipenvManager';
-import { getPipenv, hasPipenvEnvironments } from './pipenvUtils';
-
-import { notifyMissingManagerIfDefault } from '../common/utils';
 
 export async function registerPipenvFeatures(
     nativeFinder: NativePythonFinder,
     disposables: Disposable[],
-    projectManager: PythonProjectManager,
 ): Promise<void> {
-    let stage = 'getPythonApi';
     const api: PythonEnvironmentApi = await getPythonApi();
 
-    try {
-        stage = 'getPipenv';
-        const pipenv = await getPipenv(nativeFinder);
-
-        // Register the manager if the CLI is found, or if there are existing pipenv environments.
-        // This allows users with existing pipenv environments to still see and use them.
-        stage = 'hasPipenvEnvironments';
-        const hasPipenvEnvs = !pipenv && (await hasPipenvEnvironments(nativeFinder));
-
-        if (pipenv || hasPipenvEnvs) {
-            stage = 'createManager';
-            const mgr = new PipenvManager(nativeFinder, api);
-            stage = 'registerManager';
-            disposables.push(mgr, api.registerEnvironmentManager(mgr));
-            if (!pipenv) {
-                traceInfo(
-                    'Pipenv CLI not found, but pipenv environments were discovered. Registering manager for read-only environment management. To enable full pipenv features, set the "python.pipenvPath" setting to the path of your pipenv executable.',
-                );
-            }
-        } else {
-            traceInfo(
-                'Pipenv not found, turning off pipenv features. If you have pipenv installed in a non-standard location, set the "python.pipenvPath" setting.',
-            );
-            sendTelemetryEvent(EventNames.MANAGER_REGISTRATION_SKIPPED, undefined, {
-                managerName: 'pipenv',
-                reason: 'tool_not_found',
-            });
-            await notifyMissingManagerIfDefault('ms-python.python:pipenv', projectManager, api);
-        }
-    } catch (ex) {
-        const failureStage = (ex as Error & { failureStage?: string })?.failureStage ?? stage;
-        traceInfo(
-            'Pipenv not found, turning off pipenv features. If you have pipenv installed in a non-standard location, set the "python.pipenvPath" setting.',
-            ex,
-        );
-        sendTelemetryEvent(EventNames.MANAGER_REGISTRATION_FAILED, undefined, {
-            managerName: 'pipenv',
-            errorType: classifyError(ex),
-            failureStage,
-        });
-        await notifyMissingManagerIfDefault('ms-python.python:pipenv', projectManager, api);
-    }
+    traceInfo('Registering pipenv manager (environments will be discovered lazily)');
+    const mgr = new PipenvManager(nativeFinder, api);
+    disposables.push(mgr, api.registerEnvironmentManager(mgr));
 }

--- a/src/managers/pipenv/main.ts
+++ b/src/managers/pipenv/main.ts
@@ -2,16 +2,18 @@ import { Disposable } from 'vscode';
 import { PythonEnvironmentApi } from '../../api';
 import { traceInfo } from '../../common/logging';
 import { getPythonApi } from '../../features/pythonApi';
+import { PythonProjectManager } from '../../internal.api';
 import { NativePythonFinder } from '../common/nativePythonFinder';
 import { PipenvManager } from './pipenvManager';
 
 export async function registerPipenvFeatures(
     nativeFinder: NativePythonFinder,
     disposables: Disposable[],
+    projectManager: PythonProjectManager,
 ): Promise<void> {
     const api: PythonEnvironmentApi = await getPythonApi();
 
     traceInfo('Registering pipenv manager (environments will be discovered lazily)');
-    const mgr = new PipenvManager(nativeFinder, api);
+    const mgr = new PipenvManager(nativeFinder, api, projectManager);
     disposables.push(mgr, api.registerEnvironmentManager(mgr));
 }

--- a/src/managers/pipenv/pipenvManager.ts
+++ b/src/managers/pipenv/pipenvManager.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, MarkdownString, ProgressLocation, Uri } from 'vscode';
+import { Disposable, EventEmitter, MarkdownString, ProgressLocation, Uri, workspace } from 'vscode';
 import {
     DidChangeEnvironmentEventArgs,
     DidChangeEnvironmentsEventArgs,
@@ -15,6 +15,7 @@ import {
     SetEnvironmentScope,
 } from '../../api';
 import { PipenvStrings } from '../../common/localize';
+import { traceError, traceInfo } from '../../common/logging';
 import { StopWatch } from '../../common/stopWatch';
 import { EventNames } from '../../common/telemetry/constants';
 import { classifyError } from '../../common/telemetry/errorClassifier';
@@ -22,8 +23,10 @@ import { sendTelemetryEvent } from '../../common/telemetry/sender';
 import { createDeferred, Deferred } from '../../common/utils/deferred';
 import { normalizePath } from '../../common/utils/pathUtils';
 import { withProgress } from '../../common/window.apis';
+import { PythonProjectManager } from '../../internal.api';
 import { getProjectFsPathForScope, tryFastPathGet } from '../common/fastPath';
 import { NativePythonFinder } from '../common/nativePythonFinder';
+import { notifyMissingManagerIfDefault } from '../common/utils';
 import {
     clearPipenvCache,
     getPipenv,
@@ -36,7 +39,7 @@ import {
     setPipenvForWorkspaces,
 } from './pipenvUtils';
 
-export class PipenvManager implements EnvironmentManager {
+export class PipenvManager implements EnvironmentManager, Disposable {
     private collection: PythonEnvironment[] = [];
     private fsPathToEnv: Map<string, PythonEnvironment> = new Map();
     private globalEnv: PythonEnvironment | undefined;
@@ -59,6 +62,7 @@ export class PipenvManager implements EnvironmentManager {
     constructor(
         public readonly nativeFinder: NativePythonFinder,
         public readonly api: PythonEnvironmentApi,
+        private readonly projectManager?: PythonProjectManager,
     ) {
         this.name = 'pipenv';
         this.displayName = 'Pipenv';
@@ -77,7 +81,6 @@ export class PipenvManager implements EnvironmentManager {
         if (this._initialized) {
             return this._initialized.promise;
         }
-
         this._initialized = createDeferred();
         const stopWatch = new StopWatch();
         let result: 'success' | 'tool_not_found' | 'error' = 'success';
@@ -87,9 +90,10 @@ export class PipenvManager implements EnvironmentManager {
 
         try {
             // Check if tool is findable before PET refresh (settings/cache/PATH only, no PET)
+            const hasExplicitSetting = !!workspace.getConfiguration('python').get<string>('pipenvPath');
             const preRefreshTool = await getPipenv();
             if (preRefreshTool) {
-                toolSource = 'path';
+                toolSource = hasExplicitSetting ? 'settings' : 'local';
             }
 
             await withProgress(
@@ -117,10 +121,14 @@ export class PipenvManager implements EnvironmentManager {
 
             if (toolSource === 'none') {
                 result = 'tool_not_found';
+                if (this.projectManager) {
+                    await notifyMissingManagerIfDefault('ms-python.python:pipenv', this.projectManager, this.api);
+                }
             }
         } catch (ex) {
             result = 'error';
             errorType = classifyError(ex);
+            traceError('Pipenv lazy initialization failed', ex);
         } finally {
             sendTelemetryEvent(EventNames.MANAGER_LAZY_INIT, stopWatch.elapsedTime, {
                 managerName: 'pipenv',
@@ -171,6 +179,7 @@ export class PipenvManager implements EnvironmentManager {
                 title: PipenvStrings.pipenvRefreshing,
             },
             async () => {
+                traceInfo('Refreshing Pipenv Environments');
                 const oldCollection = [...this.collection];
                 this.collection = await refreshPipenv(hardRefresh, this.nativeFinder, this.api, this);
                 await this.loadEnvMap();

--- a/src/managers/pipenv/pipenvManager.ts
+++ b/src/managers/pipenv/pipenvManager.ts
@@ -15,6 +15,10 @@ import {
     SetEnvironmentScope,
 } from '../../api';
 import { PipenvStrings } from '../../common/localize';
+import { StopWatch } from '../../common/stopWatch';
+import { EventNames } from '../../common/telemetry/constants';
+import { classifyError } from '../../common/telemetry/errorClassifier';
+import { sendTelemetryEvent } from '../../common/telemetry/sender';
 import { createDeferred, Deferred } from '../../common/utils/deferred';
 import { normalizePath } from '../../common/utils/pathUtils';
 import { withProgress } from '../../common/window.apis';
@@ -22,6 +26,7 @@ import { getProjectFsPathForScope, tryFastPathGet } from '../common/fastPath';
 import { NativePythonFinder } from '../common/nativePythonFinder';
 import {
     clearPipenvCache,
+    getPipenv,
     getPipenvForGlobal,
     getPipenvForWorkspace,
     refreshPipenv,
@@ -74,8 +79,19 @@ export class PipenvManager implements EnvironmentManager {
         }
 
         this._initialized = createDeferred();
+        const stopWatch = new StopWatch();
+        let result: 'success' | 'tool_not_found' | 'error' = 'success';
+        let envCount = 0;
+        let toolSource = 'none';
+        let errorType: string | undefined;
 
         try {
+            // Check if tool is findable before PET refresh (settings/cache/PATH only, no PET)
+            const preRefreshTool = await getPipenv();
+            if (preRefreshTool) {
+                toolSource = 'path';
+            }
+
             await withProgress(
                 {
                     location: ProgressLocation.Window,
@@ -90,7 +106,29 @@ export class PipenvManager implements EnvironmentManager {
                     );
                 },
             );
+
+            envCount = this.collection.length;
+
+            // If tool wasn't found via local lookup, check if refresh discovered it via PET
+            if (!preRefreshTool) {
+                const postRefreshTool = await getPipenv();
+                toolSource = postRefreshTool ? 'pet' : 'none';
+            }
+
+            if (toolSource === 'none') {
+                result = 'tool_not_found';
+            }
+        } catch (ex) {
+            result = 'error';
+            errorType = classifyError(ex);
         } finally {
+            sendTelemetryEvent(EventNames.MANAGER_LAZY_INIT, stopWatch.elapsedTime, {
+                managerName: 'pipenv',
+                result,
+                envCount,
+                toolSource,
+                errorType,
+            });
             this._initialized.resolve();
         }
     }

--- a/src/managers/pipenv/pipenvUtils.ts
+++ b/src/managers/pipenv/pipenvUtils.ts
@@ -51,37 +51,16 @@ export async function clearPipenvCache(): Promise<void> {
     pipenvPath = undefined;
 }
 
-/**
- * Check if any pipenv environments exist without requiring the pipenv CLI.
- * This allows the manager to be registered even if the CLI is not found.
- */
-export async function hasPipenvEnvironments(nativeFinder: NativePythonFinder): Promise<boolean> {
-    let stage = 'nativeFinderRefresh';
-    try {
-        const data = await nativeFinder.refresh(false);
-        stage = 'filterPipenvEnvs';
-        return data
-            .filter((e) => isNativeEnvInfo(e))
-            .some((e) => (e as NativeEnvInfo).kind === NativePythonEnvironmentKind.pipenv);
-    } catch (ex) {
-        const err = ex instanceof Error ? ex : new Error(String(ex));
-        (err as Error & { failureStage?: string }).failureStage = `hasPipenvEnvironments:${stage}`;
-        throw err;
-    }
-}
-
 function getPipenvPathFromSettings(): string | undefined {
     const pipenvPath = getSettingWorkspaceScope<string>('python', 'pipenvPath');
     return pipenvPath ? pipenvPath : undefined;
 }
 
-export async function getPipenv(native?: NativePythonFinder): Promise<string | undefined> {
-    let stage = 'checkSettings';
+export async function getPipenv(): Promise<string | undefined> {
     try {
         // Priority 1: Settings (if explicitly set and valid)
         const settingPath = getPipenvPathFromSettings();
         if (settingPath) {
-            stage = 'validateSettingsPath';
             if (await fs.exists(untildify(settingPath))) {
                 traceInfo(`Using pipenv from settings: ${settingPath}`);
                 return untildify(settingPath);
@@ -90,9 +69,7 @@ export async function getPipenv(native?: NativePythonFinder): Promise<string | u
         }
 
         // Priority 2: In-memory cache
-        stage = 'checkCache';
         if (pipenvPath) {
-            stage = 'validateCachePath';
             if (await fs.exists(untildify(pipenvPath))) {
                 return untildify(pipenvPath);
             }
@@ -100,12 +77,9 @@ export async function getPipenv(native?: NativePythonFinder): Promise<string | u
         }
 
         // Priority 3: Persistent state
-        stage = 'getPersistentState';
         const state = await getWorkspacePersistentState();
-        stage = 'checkPersistentState';
         const storedPath = await state.get<string>(PIPENV_PATH_KEY);
         if (storedPath) {
-            stage = 'validatePersistentStatePath';
             if (await fs.exists(untildify(storedPath))) {
                 pipenvPath = storedPath;
                 traceInfo(`Using pipenv from persistent state: ${pipenvPath}`);
@@ -115,7 +89,6 @@ export async function getPipenv(native?: NativePythonFinder): Promise<string | u
         }
 
         // Priority 4: PATH lookup
-        stage = 'pathLookup';
         const foundPipenv = await findPipenv();
         if (foundPipenv) {
             pipenvPath = foundPipenv;
@@ -123,29 +96,11 @@ export async function getPipenv(native?: NativePythonFinder): Promise<string | u
             return foundPipenv;
         }
 
-        // Priority 5: Native finder as fallback
-        stage = 'nativeFinderRefresh';
-        if (native) {
-            const data = await native.refresh(false);
-            stage = 'filterNativeFinderResults';
-            const managers = data
-                .filter((e) => !isNativeEnvInfo(e))
-                .map((e) => e as NativeEnvManagerInfo)
-                .filter((e) => e.tool.toLowerCase() === 'pipenv');
-            if (managers.length > 0) {
-                pipenvPath = managers[0].executable;
-                traceInfo(`Using pipenv from native finder: ${pipenvPath}`);
-                stage = 'persistNativeFinderResult';
-                await state.set(PIPENV_PATH_KEY, pipenvPath);
-                return pipenvPath;
-            }
-        }
-
-        traceInfo('Pipenv not found');
+        traceInfo('Pipenv not found via settings, cache, or PATH');
         return undefined;
     } catch (ex) {
         const err = ex instanceof Error ? ex : new Error(String(ex));
-        (err as Error & { failureStage?: string }).failureStage = `getPipenv:${stage}`;
+        (err as Error & { failureStage?: string }).failureStage = `getPipenv`;
         throw err;
     }
 }

--- a/src/managers/poetry/main.ts
+++ b/src/managers/poetry/main.ts
@@ -1,64 +1,26 @@
 import { Disposable, LogOutputChannel } from 'vscode';
 import { PythonEnvironmentApi } from '../../api';
 import { traceInfo } from '../../common/logging';
-import { EventNames } from '../../common/telemetry/constants';
-import { classifyError } from '../../common/telemetry/errorClassifier';
-import { sendTelemetryEvent } from '../../common/telemetry/sender';
 import { getPythonApi } from '../../features/pythonApi';
-import { PythonProjectManager } from '../../internal.api';
 import { NativePythonFinder } from '../common/nativePythonFinder';
-import { notifyMissingManagerIfDefault } from '../common/utils';
 import { PoetryManager } from './poetryManager';
 import { PoetryPackageManager } from './poetryPackageManager';
-import { getPoetry, getPoetryVersion } from './poetryUtils';
 
 export async function registerPoetryFeatures(
     nativeFinder: NativePythonFinder,
     disposables: Disposable[],
     outputChannel: LogOutputChannel,
-    projectManager: PythonProjectManager,
 ): Promise<void> {
-    let stage = 'getPythonApi';
     const api: PythonEnvironmentApi = await getPythonApi();
 
-    try {
-        stage = 'getPoetry';
-        const poetryPath = await getPoetry(nativeFinder);
-        if (poetryPath) {
-            traceInfo(
-                'The `shell` command is not available by default in Poetry versions 2.0.0 and above. Therefore all shell activation will be handled by calling `source <path-to-activate>`. If you face any problems with shell activation, please file an issue at https://github.com/microsoft/vscode-python-environments/issues to help us improve this implementation.',
-            );
-            stage = 'getPoetryVersion';
-            const version = await getPoetryVersion(poetryPath);
-            traceInfo(`Poetry found at ${poetryPath}, version: ${version}`);
-            stage = 'createEnvManager';
-            const envManager = new PoetryManager(nativeFinder, api);
-            stage = 'createPkgManager';
-            const pkgManager = new PoetryPackageManager(api, outputChannel, envManager);
+    traceInfo('Registering poetry manager (environments will be discovered lazily)');
+    const envManager = new PoetryManager(nativeFinder, api);
+    const pkgManager = new PoetryPackageManager(api, outputChannel, envManager);
 
-            stage = 'registerManagers';
-            disposables.push(
-                envManager,
-                pkgManager,
-                api.registerEnvironmentManager(envManager),
-                api.registerPackageManager(pkgManager),
-            );
-        } else {
-            traceInfo('Poetry not found, turning off poetry features.');
-            sendTelemetryEvent(EventNames.MANAGER_REGISTRATION_SKIPPED, undefined, {
-                managerName: 'poetry',
-                reason: 'tool_not_found',
-            });
-            await notifyMissingManagerIfDefault('ms-python.python:poetry', projectManager, api);
-        }
-    } catch (ex) {
-        const failureStage = (ex as Error & { failureStage?: string })?.failureStage ?? stage;
-        traceInfo('Poetry not found, turning off poetry features.', ex);
-        sendTelemetryEvent(EventNames.MANAGER_REGISTRATION_FAILED, undefined, {
-            managerName: 'poetry',
-            errorType: classifyError(ex),
-            failureStage,
-        });
-        await notifyMissingManagerIfDefault('ms-python.python:poetry', projectManager, api);
-    }
+    disposables.push(
+        envManager,
+        pkgManager,
+        api.registerEnvironmentManager(envManager),
+        api.registerPackageManager(pkgManager),
+    );
 }

--- a/src/managers/poetry/main.ts
+++ b/src/managers/poetry/main.ts
@@ -2,6 +2,7 @@ import { Disposable, LogOutputChannel } from 'vscode';
 import { PythonEnvironmentApi } from '../../api';
 import { traceInfo } from '../../common/logging';
 import { getPythonApi } from '../../features/pythonApi';
+import { PythonProjectManager } from '../../internal.api';
 import { NativePythonFinder } from '../common/nativePythonFinder';
 import { PoetryManager } from './poetryManager';
 import { PoetryPackageManager } from './poetryPackageManager';
@@ -10,11 +11,12 @@ export async function registerPoetryFeatures(
     nativeFinder: NativePythonFinder,
     disposables: Disposable[],
     outputChannel: LogOutputChannel,
+    projectManager: PythonProjectManager,
 ): Promise<void> {
     const api: PythonEnvironmentApi = await getPythonApi();
 
     traceInfo('Registering poetry manager (environments will be discovered lazily)');
-    const envManager = new PoetryManager(nativeFinder, api);
+    const envManager = new PoetryManager(nativeFinder, api, projectManager);
     const pkgManager = new PoetryPackageManager(api, outputChannel, envManager);
 
     disposables.push(

--- a/src/managers/poetry/poetryManager.ts
+++ b/src/managers/poetry/poetryManager.ts
@@ -24,9 +24,9 @@ import { sendTelemetryEvent } from '../../common/telemetry/sender';
 import { createDeferred, Deferred } from '../../common/utils/deferred';
 import { normalizePath } from '../../common/utils/pathUtils';
 import { withProgress } from '../../common/window.apis';
+import { PythonProjectManager } from '../../internal.api';
 import { NativePythonFinder } from '../common/nativePythonFinder';
 import { getLatest, notifyMissingManagerIfDefault } from '../common/utils';
-import { PythonProjectManager } from '../../internal.api';
 import {
     clearPoetryCache,
     getPoetry,

--- a/src/managers/poetry/poetryManager.ts
+++ b/src/managers/poetry/poetryManager.ts
@@ -20,10 +20,15 @@ import { traceError, traceInfo } from '../../common/logging';
 import { createDeferred, Deferred } from '../../common/utils/deferred';
 import { normalizePath } from '../../common/utils/pathUtils';
 import { withProgress } from '../../common/window.apis';
+import { StopWatch } from '../../common/stopWatch';
+import { EventNames } from '../../common/telemetry/constants';
+import { classifyError } from '../../common/telemetry/errorClassifier';
+import { sendTelemetryEvent } from '../../common/telemetry/sender';
 import { NativePythonFinder } from '../common/nativePythonFinder';
 import { getLatest } from '../common/utils';
 import {
     clearPoetryCache,
+    getPoetry,
     getPoetryForGlobal,
     getPoetryForWorkspace,
     POETRY_GLOBAL,
@@ -74,8 +79,19 @@ export class PoetryManager implements EnvironmentManager, Disposable {
         }
 
         this._initialized = createDeferred();
+        const stopWatch = new StopWatch();
+        let result: 'success' | 'tool_not_found' | 'error' = 'success';
+        let envCount = 0;
+        let toolSource = 'none';
+        let errorType: string | undefined;
 
         try {
+            // Check if tool is findable before PET refresh (settings/cache/PATH only, no PET)
+            const preRefreshTool = await getPoetry();
+            if (preRefreshTool) {
+                toolSource = 'path';
+            }
+
             await withProgress(
                 {
                     location: ProgressLocation.Window,
@@ -90,7 +106,29 @@ export class PoetryManager implements EnvironmentManager, Disposable {
                     );
                 },
             );
+
+            envCount = this.collection.length;
+
+            // If tool wasn't found via local lookup, check if refresh discovered it via PET
+            if (!preRefreshTool) {
+                const postRefreshTool = await getPoetry();
+                toolSource = postRefreshTool ? 'pet' : 'none';
+            }
+
+            if (toolSource === 'none') {
+                result = 'tool_not_found';
+            }
+        } catch (ex) {
+            result = 'error';
+            errorType = classifyError(ex);
         } finally {
+            sendTelemetryEvent(EventNames.MANAGER_LAZY_INIT, stopWatch.elapsedTime, {
+                managerName: 'poetry',
+                result,
+                envCount,
+                toolSource,
+                errorType,
+            });
             this._initialized.resolve();
         }
     }

--- a/src/managers/poetry/poetryManager.ts
+++ b/src/managers/poetry/poetryManager.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { Disposable, EventEmitter, MarkdownString, ProgressLocation, Uri } from 'vscode';
+import { Disposable, EventEmitter, MarkdownString, ProgressLocation, Uri, workspace } from 'vscode';
 import {
     DidChangeEnvironmentEventArgs,
     DidChangeEnvironmentsEventArgs,
@@ -25,7 +25,8 @@ import { createDeferred, Deferred } from '../../common/utils/deferred';
 import { normalizePath } from '../../common/utils/pathUtils';
 import { withProgress } from '../../common/window.apis';
 import { NativePythonFinder } from '../common/nativePythonFinder';
-import { getLatest } from '../common/utils';
+import { getLatest, notifyMissingManagerIfDefault } from '../common/utils';
+import { PythonProjectManager } from '../../internal.api';
 import {
     clearPoetryCache,
     getPoetry,
@@ -53,6 +54,7 @@ export class PoetryManager implements EnvironmentManager, Disposable {
     constructor(
         private readonly nativeFinder: NativePythonFinder,
         private readonly api: PythonEnvironmentApi,
+        private readonly projectManager?: PythonProjectManager,
     ) {
         this.name = 'poetry';
         this.displayName = 'Poetry';
@@ -77,7 +79,6 @@ export class PoetryManager implements EnvironmentManager, Disposable {
         if (this._initialized) {
             return this._initialized.promise;
         }
-
         this._initialized = createDeferred();
         const stopWatch = new StopWatch();
         let result: 'success' | 'tool_not_found' | 'error' = 'success';
@@ -87,9 +88,10 @@ export class PoetryManager implements EnvironmentManager, Disposable {
 
         try {
             // Check if tool is findable before PET refresh (settings/cache/PATH only, no PET)
+            const hasExplicitSetting = !!workspace.getConfiguration('python').get<string>('poetryPath');
             const preRefreshTool = await getPoetry();
             if (preRefreshTool) {
-                toolSource = 'path';
+                toolSource = hasExplicitSetting ? 'settings' : 'local';
             }
 
             await withProgress(
@@ -117,10 +119,14 @@ export class PoetryManager implements EnvironmentManager, Disposable {
 
             if (toolSource === 'none') {
                 result = 'tool_not_found';
+                if (this.projectManager) {
+                    await notifyMissingManagerIfDefault('ms-python.python:poetry', this.projectManager, this.api);
+                }
             }
         } catch (ex) {
             result = 'error';
             errorType = classifyError(ex);
+            traceError('Poetry lazy initialization failed', ex);
         } finally {
             sendTelemetryEvent(EventNames.MANAGER_LAZY_INIT, stopWatch.elapsedTime, {
                 managerName: 'poetry',

--- a/src/managers/poetry/poetryManager.ts
+++ b/src/managers/poetry/poetryManager.ts
@@ -17,13 +17,13 @@ import {
 } from '../../api';
 import { PoetryStrings } from '../../common/localize';
 import { traceError, traceInfo } from '../../common/logging';
-import { createDeferred, Deferred } from '../../common/utils/deferred';
-import { normalizePath } from '../../common/utils/pathUtils';
-import { withProgress } from '../../common/window.apis';
 import { StopWatch } from '../../common/stopWatch';
 import { EventNames } from '../../common/telemetry/constants';
 import { classifyError } from '../../common/telemetry/errorClassifier';
 import { sendTelemetryEvent } from '../../common/telemetry/sender';
+import { createDeferred, Deferred } from '../../common/utils/deferred';
+import { normalizePath } from '../../common/utils/pathUtils';
+import { withProgress } from '../../common/window.apis';
 import { NativePythonFinder } from '../common/nativePythonFinder';
 import { getLatest } from '../common/utils';
 import {

--- a/src/managers/poetry/poetryPackageManager.ts
+++ b/src/managers/poetry/poetryPackageManager.ts
@@ -5,6 +5,7 @@ import {
     CancellationToken,
     Event,
     EventEmitter,
+    l10n,
     LogOutputChannel,
     MarkdownString,
     ProgressLocation,
@@ -163,6 +164,15 @@ export class PoetryPackageManager implements PackageManager, Disposable {
         options: { install?: string[]; uninstall?: string[] },
         token?: CancellationToken,
     ): Promise<Package[]> {
+        const poetry = await getPoetry();
+        if (!poetry) {
+            throw new Error(
+                l10n.t(
+                    'Poetry executable not found. Install Poetry to manage packages, or set the "python.poetryPath" setting.',
+                ),
+            );
+        }
+
         // Handle uninstalls first
         if (options.uninstall && options.uninstall.length > 0) {
             try {
@@ -194,6 +204,15 @@ export class PoetryPackageManager implements PackageManager, Disposable {
     }
 
     private async refreshPackages(environment: PythonEnvironment): Promise<Package[]> {
+        const poetry = await getPoetry();
+        if (!poetry) {
+            throw new Error(
+                l10n.t(
+                    'Poetry executable not found. Install Poetry to manage packages, or set the "python.poetryPath" setting.',
+                ),
+            );
+        }
+
         let cwd = process.cwd();
         const projects = this.api.getPythonProjects();
         if (projects.length === 1) {

--- a/src/managers/poetry/poetryUtils.ts
+++ b/src/managers/poetry/poetryUtils.ts
@@ -118,13 +118,11 @@ export async function setPoetryForWorkspaces(fsPath: string[], envPath: string |
     await state.set(POETRY_WORKSPACE_KEY, data);
 }
 
-export async function getPoetry(native?: NativePythonFinder): Promise<string | undefined> {
-    let stage = 'checkSettings';
+export async function getPoetry(): Promise<string | undefined> {
     try {
         // Priority 1: Settings (if explicitly set and valid)
         const settingPath = getPoetryPathFromSettings();
         if (settingPath) {
-            stage = 'validateSettingsPath';
             if (await fs.exists(untildify(settingPath))) {
                 traceInfo(`Using poetry from settings: ${settingPath}`);
                 return untildify(settingPath);
@@ -133,9 +131,7 @@ export async function getPoetry(native?: NativePythonFinder): Promise<string | u
         }
 
         // Priority 2: In-memory cache
-        stage = 'checkCache';
         if (poetryPath) {
-            stage = 'validateCachePath';
             if (await fs.exists(untildify(poetryPath))) {
                 return untildify(poetryPath);
             }
@@ -143,16 +139,12 @@ export async function getPoetry(native?: NativePythonFinder): Promise<string | u
         }
 
         // Priority 3: Persistent state
-        stage = 'getPersistentState';
         const state = await getWorkspacePersistentState();
-        stage = 'checkPersistentState';
         const storedPath = await state.get<string>(POETRY_PATH_KEY);
         if (storedPath) {
-            stage = 'validatePersistentStatePath';
             if (await fs.exists(untildify(storedPath))) {
                 poetryPath = storedPath;
                 traceInfo(`Using poetry from persistent state: ${poetryPath}`);
-                // Also retrieve the virtualenvs path if we haven't already
                 if (!poetryVirtualenvsPath) {
                     getPoetryVirtualenvsPath(untildify(poetryPath)).catch((e) =>
                         traceError(`Error getting Poetry virtualenvs path: ${e}`),
@@ -164,44 +156,21 @@ export async function getPoetry(native?: NativePythonFinder): Promise<string | u
         }
 
         // Priority 4: PATH lookup
-        stage = 'pathLookup';
         poetryPath = await findPoetry();
         if (poetryPath) {
-            stage = 'setPoetryAfterPathLookup';
             await setPoetry(poetryPath);
             return poetryPath;
         }
 
         // Priority 5: Known user-install locations
-        stage = 'checkUserInstallLocations';
         const home = getUserHomeDir();
         if (home) {
             const poetryUserInstall = path.join(
                 home,
                 isWindows() ? 'AppData\\Roaming\\Python\\Scripts\\poetry.exe' : '.local/bin/poetry',
             );
-            stage = 'validateUserInstallPath';
             if (await fs.exists(poetryUserInstall)) {
                 poetryPath = poetryUserInstall;
-                stage = 'setPoetryAfterUserInstall';
-                await setPoetry(poetryPath);
-                return poetryPath;
-            }
-        }
-
-        // Priority 6: Native finder as fallback
-        stage = 'nativeFinderRefresh';
-        if (native) {
-            const data = await native.refresh(false);
-            stage = 'filterNativeFinderResults';
-            const managers = data
-                .filter((e) => !isNativeEnvInfo(e))
-                .map((e) => e as NativeEnvManagerInfo)
-                .filter((e) => e.tool.toLowerCase() === 'poetry');
-            if (managers.length > 0) {
-                poetryPath = managers[0].executable;
-                traceInfo(`Using poetry from native finder: ${poetryPath}`);
-                stage = 'setPoetryAfterNativeFinder';
                 await setPoetry(poetryPath);
                 return poetryPath;
             }
@@ -210,7 +179,7 @@ export async function getPoetry(native?: NativePythonFinder): Promise<string | u
         return undefined;
     } catch (ex) {
         const err = ex instanceof Error ? ex : new Error(String(ex));
-        (err as Error & { failureStage?: string }).failureStage = `getPoetry:${stage}`;
+        (err as Error & { failureStage?: string }).failureStage = `getPoetry`;
         throw err;
     }
 }
@@ -486,7 +455,7 @@ export async function resolvePoetryPath(
         if (e.kind !== NativePythonEnvironmentKind.poetry) {
             return undefined;
         }
-        const poetry = await getPoetry(nativeFinder);
+        const poetry = await getPoetry();
         if (!poetry) {
             traceError('Poetry not found while resolving environment');
             return undefined;

--- a/src/managers/pyenv/main.ts
+++ b/src/managers/pyenv/main.ts
@@ -1,49 +1,17 @@
 import { Disposable } from 'vscode';
 import { PythonEnvironmentApi } from '../../api';
 import { traceInfo } from '../../common/logging';
-import { EventNames } from '../../common/telemetry/constants';
-import { classifyError } from '../../common/telemetry/errorClassifier';
-import { sendTelemetryEvent } from '../../common/telemetry/sender';
 import { getPythonApi } from '../../features/pythonApi';
-import { PythonProjectManager } from '../../internal.api';
 import { NativePythonFinder } from '../common/nativePythonFinder';
-import { notifyMissingManagerIfDefault } from '../common/utils';
 import { PyEnvManager } from './pyenvManager';
-import { getPyenv } from './pyenvUtils';
 
 export async function registerPyenvFeatures(
     nativeFinder: NativePythonFinder,
     disposables: Disposable[],
-    projectManager: PythonProjectManager,
 ): Promise<void> {
-    let stage = 'getPythonApi';
     const api: PythonEnvironmentApi = await getPythonApi();
 
-    try {
-        stage = 'getPyenv';
-        const pyenv = await getPyenv(nativeFinder);
-
-        if (pyenv) {
-            stage = 'createManager';
-            const mgr = new PyEnvManager(nativeFinder, api);
-            stage = 'registerManager';
-            disposables.push(mgr, api.registerEnvironmentManager(mgr));
-        } else {
-            traceInfo('Pyenv not found, turning off pyenv features.');
-            sendTelemetryEvent(EventNames.MANAGER_REGISTRATION_SKIPPED, undefined, {
-                managerName: 'pyenv',
-                reason: 'tool_not_found',
-            });
-            await notifyMissingManagerIfDefault('ms-python.python:pyenv', projectManager, api);
-        }
-    } catch (ex) {
-        const failureStage = (ex as Error & { failureStage?: string })?.failureStage ?? stage;
-        traceInfo('Pyenv not found, turning off pyenv features.', ex);
-        sendTelemetryEvent(EventNames.MANAGER_REGISTRATION_FAILED, undefined, {
-            managerName: 'pyenv',
-            errorType: classifyError(ex),
-            failureStage,
-        });
-        await notifyMissingManagerIfDefault('ms-python.python:pyenv', projectManager, api);
-    }
+    traceInfo('Registering pyenv manager (environments will be discovered lazily)');
+    const mgr = new PyEnvManager(nativeFinder, api);
+    disposables.push(mgr, api.registerEnvironmentManager(mgr));
 }

--- a/src/managers/pyenv/main.ts
+++ b/src/managers/pyenv/main.ts
@@ -2,16 +2,18 @@ import { Disposable } from 'vscode';
 import { PythonEnvironmentApi } from '../../api';
 import { traceInfo } from '../../common/logging';
 import { getPythonApi } from '../../features/pythonApi';
+import { PythonProjectManager } from '../../internal.api';
 import { NativePythonFinder } from '../common/nativePythonFinder';
 import { PyEnvManager } from './pyenvManager';
 
 export async function registerPyenvFeatures(
     nativeFinder: NativePythonFinder,
     disposables: Disposable[],
+    projectManager: PythonProjectManager,
 ): Promise<void> {
     const api: PythonEnvironmentApi = await getPythonApi();
 
     traceInfo('Registering pyenv manager (environments will be discovered lazily)');
-    const mgr = new PyEnvManager(nativeFinder, api);
+    const mgr = new PyEnvManager(nativeFinder, api, projectManager);
     disposables.push(mgr, api.registerEnvironmentManager(mgr));
 }

--- a/src/managers/pyenv/pyenvManager.ts
+++ b/src/managers/pyenv/pyenvManager.ts
@@ -17,6 +17,10 @@ import {
 } from '../../api';
 import { PyenvStrings } from '../../common/localize';
 import { traceError, traceInfo } from '../../common/logging';
+import { StopWatch } from '../../common/stopWatch';
+import { EventNames } from '../../common/telemetry/constants';
+import { classifyError } from '../../common/telemetry/errorClassifier';
+import { sendTelemetryEvent } from '../../common/telemetry/sender';
 import { createDeferred, Deferred } from '../../common/utils/deferred';
 import { normalizePath } from '../../common/utils/pathUtils';
 import { withProgress } from '../../common/window.apis';
@@ -25,6 +29,7 @@ import { NativePythonFinder } from '../common/nativePythonFinder';
 import { getLatest } from '../common/utils';
 import {
     clearPyenvCache,
+    getPyenv,
     getPyenvForGlobal,
     getPyenvForWorkspace,
     PYENV_VERSIONS,
@@ -75,8 +80,19 @@ export class PyEnvManager implements EnvironmentManager, Disposable {
         }
 
         this._initialized = createDeferred();
+        const stopWatch = new StopWatch();
+        let result: 'success' | 'tool_not_found' | 'error' = 'success';
+        let envCount = 0;
+        let toolSource = 'none';
+        let errorType: string | undefined;
 
         try {
+            // Check if tool is findable before PET refresh (settings/cache/PATH only, no PET)
+            const preRefreshTool = await getPyenv();
+            if (preRefreshTool) {
+                toolSource = 'path';
+            }
+
             await withProgress(
                 {
                     location: ProgressLocation.Window,
@@ -91,7 +107,29 @@ export class PyEnvManager implements EnvironmentManager, Disposable {
                     );
                 },
             );
+
+            envCount = this.collection.length;
+
+            // If tool wasn't found via local lookup, check if refresh discovered it via PET
+            if (!preRefreshTool) {
+                const postRefreshTool = await getPyenv();
+                toolSource = postRefreshTool ? 'pet' : 'none';
+            }
+
+            if (toolSource === 'none') {
+                result = 'tool_not_found';
+            }
+        } catch (ex) {
+            result = 'error';
+            errorType = classifyError(ex);
         } finally {
+            sendTelemetryEvent(EventNames.MANAGER_LAZY_INIT, stopWatch.elapsedTime, {
+                managerName: 'pyenv',
+                result,
+                envCount,
+                toolSource,
+                errorType,
+            });
             this._initialized.resolve();
         }
     }

--- a/src/managers/pyenv/pyenvManager.ts
+++ b/src/managers/pyenv/pyenvManager.ts
@@ -24,9 +24,10 @@ import { sendTelemetryEvent } from '../../common/telemetry/sender';
 import { createDeferred, Deferred } from '../../common/utils/deferred';
 import { normalizePath } from '../../common/utils/pathUtils';
 import { withProgress } from '../../common/window.apis';
+import { PythonProjectManager } from '../../internal.api';
 import { getProjectFsPathForScope, tryFastPathGet } from '../common/fastPath';
 import { NativePythonFinder } from '../common/nativePythonFinder';
-import { getLatest } from '../common/utils';
+import { getLatest, notifyMissingManagerIfDefault } from '../common/utils';
 import {
     clearPyenvCache,
     getPyenv,
@@ -54,6 +55,7 @@ export class PyEnvManager implements EnvironmentManager, Disposable {
     constructor(
         private readonly nativeFinder: NativePythonFinder,
         private readonly api: PythonEnvironmentApi,
+        private readonly projectManager?: PythonProjectManager,
     ) {
         this.name = 'pyenv';
         this.displayName = 'PyEnv';
@@ -78,7 +80,6 @@ export class PyEnvManager implements EnvironmentManager, Disposable {
         if (this._initialized) {
             return this._initialized.promise;
         }
-
         this._initialized = createDeferred();
         const stopWatch = new StopWatch();
         let result: 'success' | 'tool_not_found' | 'error' = 'success';
@@ -87,10 +88,10 @@ export class PyEnvManager implements EnvironmentManager, Disposable {
         let errorType: string | undefined;
 
         try {
-            // Check if tool is findable before PET refresh (settings/cache/PATH only, no PET)
+            // Check if tool is findable before PET refresh (no settings for pyenv path)
             const preRefreshTool = await getPyenv();
             if (preRefreshTool) {
-                toolSource = 'path';
+                toolSource = 'local';
             }
 
             await withProgress(
@@ -118,10 +119,14 @@ export class PyEnvManager implements EnvironmentManager, Disposable {
 
             if (toolSource === 'none') {
                 result = 'tool_not_found';
+                if (this.projectManager) {
+                    await notifyMissingManagerIfDefault('ms-python.python:pyenv', this.projectManager, this.api);
+                }
             }
         } catch (ex) {
             result = 'error';
             errorType = classifyError(ex);
+            traceError('Pyenv lazy initialization failed', ex);
         } finally {
             sendTelemetryEvent(EventNames.MANAGER_LAZY_INIT, stopWatch.elapsedTime, {
                 managerName: 'pyenv',

--- a/src/managers/pyenv/pyenvUtils.ts
+++ b/src/managers/pyenv/pyenvUtils.ts
@@ -111,23 +111,18 @@ export async function setPyenvForWorkspaces(fsPath: string[], envPath: string | 
     await state.set(PYENV_WORKSPACE_KEY, data);
 }
 
-export async function getPyenv(native?: NativePythonFinder): Promise<string | undefined> {
-    let stage = 'checkCache';
+export async function getPyenv(): Promise<string | undefined> {
     try {
         if (pyenvPath) {
-            stage = 'validateCachePath';
             if (await fs.exists(untildify(pyenvPath))) {
                 return untildify(pyenvPath);
             }
             pyenvPath = undefined;
         }
 
-        stage = 'getPersistentState';
         const state = await getWorkspacePersistentState();
-        stage = 'checkPersistentState';
         const storedPath = await state.get<string>(PYENV_PATH_KEY);
         if (storedPath) {
-            stage = 'validatePersistentStatePath';
             if (await fs.exists(untildify(storedPath))) {
                 pyenvPath = storedPath;
                 traceInfo(`Using pyenv from persistent state: ${pyenvPath}`);
@@ -139,27 +134,22 @@ export async function getPyenv(native?: NativePythonFinder): Promise<string | un
         // pyenv-win provides pyenv.bat, not pyenv.exe
         // See: https://github.com/pyenv-win/pyenv-win
         const pyenvBin = isWindows() ? 'pyenv.bat' : 'pyenv';
-        stage = 'checkPyenvRoot';
         const pyenvRoot = process.env.PYENV_ROOT;
         if (pyenvRoot) {
             const pyenvPath = path.join(pyenvRoot, 'bin', pyenvBin);
-            stage = 'validatePyenvRootPath';
             if (await fs.exists(pyenvPath)) {
                 return pyenvPath;
             }
         }
 
-        stage = 'checkHomeDir';
         const home = getUserHomeDir();
         if (home) {
             const pyenvPath = path.join(home, '.pyenv', 'bin', pyenvBin);
-            stage = 'validateHomeDirPath';
             if (await fs.exists(pyenvPath)) {
                 return pyenvPath;
             }
 
             if (isWindows()) {
-                stage = 'validateHomeDirPathWin';
                 const pyenvPathWin = path.join(home, '.pyenv', 'pyenv-win', 'bin', pyenvBin);
                 if (await fs.exists(pyenvPathWin)) {
                     return pyenvPathWin;
@@ -167,33 +157,15 @@ export async function getPyenv(native?: NativePythonFinder): Promise<string | un
             }
         }
 
-        stage = 'pathLookup';
         pyenvPath = await findPyenv();
         if (pyenvPath) {
             return pyenvPath;
         }
 
-        stage = 'nativeFinderRefresh';
-        if (native) {
-            const data = await native.refresh(false);
-            stage = 'filterNativeFinderResults';
-            const managers = data
-                .filter((e) => !isNativeEnvInfo(e))
-                .map((e) => e as NativeEnvManagerInfo)
-                .filter((e) => e.tool.toLowerCase() === 'pyenv');
-            if (managers.length > 0) {
-                pyenvPath = managers[0].executable;
-                traceInfo(`Using pyenv from native finder: ${pyenvPath}`);
-                stage = 'persistNativeFinderResult';
-                await state.set(PYENV_PATH_KEY, pyenvPath);
-                return pyenvPath;
-            }
-        }
-
         return undefined;
     } catch (ex) {
         const err = ex instanceof Error ? ex : new Error(String(ex));
-        (err as Error & { failureStage?: string }).failureStage = `getPyenv:${stage}`;
+        (err as Error & { failureStage?: string }).failureStage = `getPyenv`;
         throw err;
     }
 }
@@ -310,7 +282,7 @@ export async function resolvePyenvPath(
         if (e.kind !== NativePythonEnvironmentKind.pyenv && e.kind !== NativePythonEnvironmentKind.pyenvVirtualEnv) {
             return undefined;
         }
-        const pyenv = await getPyenv(nativeFinder);
+        const pyenv = await getPyenv();
         if (!pyenv) {
             traceError('Pyenv not found while resolving environment');
             return undefined;


### PR DESCRIPTION
most failures for pipenv/poetry/pyenv are at `nativeFinderRefresh` stage in startup. Most of these machines failing on these env manager are NOT using that manager. They're overwhelmingly venv users who just happen to have pipenv/poetry/pyenv installed on their system. Therefore this PR loads these three managers in an optimistic + lazy manner. Instead of trying to find if they exist on the machine at startup (which potentially causes PET to be called during manager registration) let them get registered. If they are registered, the search for environments will then be done later when the user hard-refreshes managers or clicks on the manager in the sidebar where at that point it will check for any envs of these manager types. It may find them (weirdly placed environments for any of these managers but PETs extensive finding succeeds) or not. If not the behavior is fine and just shows no data in the dropdown if no environments end up being found.