### PR TITLE
Fix refresh failure caused by JSON-RPC sending [null] params to pet binary

### DIFF
--- a/src/managers/common/nativePythonFinder.ts
+++ b/src/managers/common/nativePythonFinder.ts
@@ -435,7 +435,7 @@ class NativePythonFinderImpl implements NativePythonFinder {
         this.connection.dispose();
     }
 
-    private getRefreshOptions(options?: NativePythonEnvironmentKind | Uri[]): RefreshOptions | undefined {
+    private getRefreshOptions(options?: NativePythonEnvironmentKind | Uri[]): RefreshOptions {
         // Note: venvFolders is also fetched in getAllExtraSearchPaths() for configure().
         // This duplication is intentional: when searchPaths is provided to the native finder,
         // it may override (not supplement) the configured environmentDirectories.
@@ -452,8 +452,8 @@ class NativePythonFinderImpl implements NativePythonFinder {
                 return { searchPaths: uriSearchPaths };
             }
         }
-        // return undefined to use configured defaults (for nativeFinder refresh)
-        return undefined;
+        // return empty object to use configured defaults (for nativeFinder refresh)
+        return {};
     }
 
     private start(): rpc.MessageConnection {


### PR DESCRIPTION
CI checks are failing
- `"before all" hook for "All extension commands are registered"`
- `getEnvironments finds Python installations when available`
- `refreshEnvironments completes without error`

## Root cause

`getRefreshOptions()` in `nativePythonFinder.ts` returns `undefined` when no specific search options are needed (the common case for a full refresh). When `undefined` is passed to `connection.sendRequest('refresh', undefined, token)`, the `vscode-jsonrpc` library serializes it as positional params: `[null]`.

The pet binary's Rust deserializer handles `null` and `[]` (empty array) correctly, but **not** `[null]` (array containing null). Serde tries to interpret the 1-element array as a `RefreshOptions` struct with 2 fields and fails.

## Fix

Changed `getRefreshOptions()` to return `{}` instead of `undefined` when no options are specified. This sends a proper empty JSON object over the wire, which the pet binary correctly deserializes into `RefreshOptions { search_kind: None, search_paths: None }` — a full global search using configured workspace directories.

## Why `{}` is safe

- Both `search_kind` and `search_paths` are `Option<T>` in Rust — `None` is the expected default
- Pet's own `normalize_refresh_params` already converts `null` → `{}`, so `{}` is the canonical "no options" format
- The Rust code only accesses these fields via `if let Some(...)` guards — no `.unwrap()` calls
- Pet has [explicit tests](https://github.com/microsoft/python-environment-tools) confirming empty params produce `RefreshOptions::default()`
- `{}` with both fields as `None` triggers a full global search — identical behavior to before

## Changes

- **`src/managers/common/nativePythonFinder.ts`**: `getRefreshOptions()` now returns `{}` instead of `undefined`, and its return type is simplified from `RefreshOptions | undefined` to `RefreshOptions`