### PR TITLE
fix: change stop hook from blocking to warning to prevent auto-commits

### DIFF
--- a/.github/hooks/scripts/stop_hook.py
+++ b/.github/hooks/scripts/stop_hook.py
@@ -110,13 +110,12 @@ def main() -> int:
         response = {
             "hookSpecificOutput": {
                 "hookEventName": "Stop",
-                "decision": "block",
+                "decision": "warn",
                 "reason": (
                     "You have uncommitted TypeScript changes. "
-                    "Before finishing, use the run-pre-commit-checks skill "
+                    "Before finishing, consider using the run-pre-commit-checks skill "
                     "or manually run: npm run lint && npm run compile-tests && npm run unittest. "
-                    "If checks pass and changes are ready, commit them. "
-                    "If this session is just research/exploration, you can proceed without committing."
+                    "Ask the user whether to commit or leave changes uncommitted."
                 ),
             }
         }
@@ -128,10 +127,10 @@ def main() -> int:
         response = {
             "hookSpecificOutput": {
                 "hookEventName": "Stop",
-                "decision": "block",
+                "decision": "warn",
                 "reason": (
                     "You have staged changes that haven't been committed. "
-                    "Either commit them with a proper message or unstage them before finishing."
+                    "Ask the user whether to commit them or leave them staged."
                 ),
             }
         }


### PR DESCRIPTION


## Summary

Changes the stop hook from `"decision": "block"` to `"decision": "warn"` so the agent asks the user before committing instead of auto-committing.

## Background

The `stop_hook.py` is a pre-session stop hook that runs when an agent (maintainer) session ends. It checks the git state for:

1. **Uncommitted TypeScript changes** (staged, modified, or untracked `.ts`/`.tsx` files) — reminds the agent to run pre-commit checks (lint, type-check, tests)
2. **Staged but uncommitted changes** — reminds the agent that work hasn't been committed

## Problem

Previously, both checks used `"decision": "block"`, which **prevented the agent from ending the session** until the condition was resolved. The reason text explicitly told the agent to commit changes (e.g., *"If checks pass and changes are ready, commit them"*). This combination caused the agent to **auto-commit every time** without asking the user, which is undesirable when the user wants to review changes before committing.

## Changes

- **`"decision": "block"` → `"decision": "warn"`** for both the TS changes check and the staged changes check. The agent sees the warning but is no longer forced to act on it.
- **Removed commit instructions** from the reason text (e.g., *"commit them"*, *"Either commit them with a proper message"*) so the agent doesn't interpret them as required actions.
- **Added explicit user-consent escape**: reason text now says *"Ask the user whether to commit or leave changes uncommitted"*, ensuring the agent defers to the user.

## Files Changed

- `.github/hooks/scripts/stop_hook.py`