### PR TITLE
 Don't block on global scope during ext startup

### DIFF
--- a/src/common/telemetry/constants.ts
+++ b/src/common/telemetry/constants.ts
@@ -102,6 +102,16 @@ export enum EventNames {
      */
     ENV_SELECTION_RESULT = 'ENV_SELECTION.RESULT',
     /**
+     * Telemetry event fired when applyInitialEnvironmentSelection returns.
+     * Duration measures the blocking time (excludes deferred global scope).
+     * Properties:
+     * - globalScopeDeferred: boolean (true = global scope fired in background, false = awaited)
+     * - workspaceFolderCount: number (total workspace folders)
+     * - resolvedFolderCount: number (folders that resolved with a non-undefined env)
+     * - settingErrorCount: number (user-configured settings that could not be applied)
+     */
+    ENV_SELECTION_COMPLETED = 'ENV_SELECTION.COMPLETED',
+    /**
      * Telemetry event fired when a lazily-registered manager completes its first initialization.
      * Replaces MANAGER_REGISTRATION_SKIPPED and MANAGER_REGISTRATION_FAILED for managers
      * that now register unconditionally (pipenv, poetry, pyenv).
@@ -384,6 +394,21 @@ export interface IEventNamePropertyMapping {
         managerId: string;
         resolutionPath: string;
         hasPersistedSelection: boolean;
+    };
+
+    /* __GDPR__
+        "env_selection.completed": {
+            "globalScopeDeferred": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "workspaceFolderCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
+            "resolvedFolderCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
+            "settingErrorCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" }
+        }
+    */
+    [EventNames.ENV_SELECTION_COMPLETED]: {
+        globalScopeDeferred: boolean;
+        workspaceFolderCount: number;
+        resolvedFolderCount: number;
+        settingErrorCount: number;
     };
 
     /* __GDPR__

--- a/src/features/interpreterSelection.ts
+++ b/src/features/interpreterSelection.ts
@@ -407,12 +407,26 @@ export async function applyInitialEnvironmentSelection(
 /**
  * Notify the user when their configured settings could not be applied.
  * Shows a warning message with an option to open settings.
+ * Tracks already-warned settings to avoid duplicate dialogs (e.g., when
+ * the same user-level misconfiguration is hit by both workspace and
+ * deferred global scope resolution).
  */
+const warnedSettings = new Set<string>();
+
+export function resetSettingWarnings(): void {
+    warnedSettings.clear();
+}
+
 async function notifyUserOfSettingErrors(errors: SettingResolutionError[]): Promise<void> {
     // Group errors by setting type to avoid spamming the user
     const uniqueSettings = [...new Set(errors.map((e) => e.setting))];
 
     for (const setting of uniqueSettings) {
+        if (warnedSettings.has(setting)) {
+            continue;
+        }
+        warnedSettings.add(setting);
+
         const settingErrors = errors.filter((e) => e.setting === setting);
         const firstError = settingErrors[0];
 

--- a/src/features/interpreterSelection.ts
+++ b/src/features/interpreterSelection.ts
@@ -298,6 +298,7 @@ export async function applyInitialEnvironmentSelection(
     });
 
     const allErrors: SettingResolutionError[] = [];
+    let workspaceFolderResolved = false;
 
     for (const folder of folders) {
         try {
@@ -328,6 +329,10 @@ export async function applyInitialEnvironmentSelection(
             // Cache only — NO settings.json write (shouldPersistSettings = false)
             await envManagers.setEnvironment(folder.uri, env, false);
 
+            if (env) {
+                workspaceFolderResolved = true;
+            }
+
             traceInfo(
                 `[interpreterSelection] ${folder.name}: ${env?.displayName ?? 'none'} (source: ${result.source})`,
             );
@@ -336,35 +341,72 @@ export async function applyInitialEnvironmentSelection(
         }
     }
 
-    // Also apply initial selection for global scope (no workspace folder)
-    // This ensures defaultInterpreterPath is respected even without a workspace
-    try {
-        const globalStopWatch = new StopWatch();
-        const { result, errors } = await resolvePriorityChainCore(undefined, envManagers, undefined, nativeFinder, api);
-        allErrors.push(...errors);
+    // Global scope: resolve a fallback Python environment for files opened OUTSIDE all
+    // workspace folders (e.g., /tmp/script.py). This is NOT a workspace folder — every
+    // workspace folder was already fully resolved and cached in the for-loop above,
+    // so switching between workspace folders is unaffected by whether this runs now or later.
+    //
+    // When at least one workspace folder resolved, we defer global scope to the background
+    // so it doesn't block post-selection startup (clearHangWatchdog, terminal init, telemetry).
+    // Errors inside resolveGlobalScope are handled internally:
+    //   - Setting resolution errors (bad paths, unknown managers) → notifyUserOfSettingErrors
+    //   - Unexpected crashes → logged via traceError, never silently swallowed
+    const resolveGlobalScope = async () => {
+        try {
+            const globalStopWatch = new StopWatch();
+            const { result, errors: globalErrors } = await resolvePriorityChainCore(
+                undefined,
+                envManagers,
+                undefined,
+                nativeFinder,
+                api,
+            );
 
-        const isPathA = result.environment !== undefined;
+            const isPathA = result.environment !== undefined;
+            const env = result.environment ?? (await result.manager.get(undefined));
 
-        // Get the specific environment if not already resolved
-        const env = result.environment ?? (await result.manager.get(undefined));
+            sendTelemetryEvent(EventNames.ENV_SELECTION_RESULT, globalStopWatch.elapsedTime, {
+                scope: 'global',
+                prioritySource: result.source,
+                managerId: result.manager.id,
+                resolutionPath: isPathA ? 'envPreResolved' : 'managerDiscovery',
+                hasPersistedSelection: env !== undefined,
+            });
 
-        sendTelemetryEvent(EventNames.ENV_SELECTION_RESULT, globalStopWatch.elapsedTime, {
-            scope: 'global',
-            prioritySource: result.source,
-            managerId: result.manager.id,
-            resolutionPath: isPathA ? 'envPreResolved' : 'managerDiscovery',
-            hasPersistedSelection: env !== undefined,
-        });
+            await envManagers.setEnvironments('global', env, false);
 
-        // Cache only — NO settings.json write (shouldPersistSettings = false)
-        await envManagers.setEnvironments('global', env, false);
+            traceInfo(`[interpreterSelection] global: ${env?.displayName ?? 'none'} (source: ${result.source})`);
 
-        traceInfo(`[interpreterSelection] global: ${env?.displayName ?? 'none'} (source: ${result.source})`);
-    } catch (err) {
-        traceError(`[interpreterSelection] Failed to set global environment: ${err}`);
+            if (globalErrors.length > 0) {
+                await notifyUserOfSettingErrors(globalErrors);
+            }
+        } catch (err) {
+            traceError(`[interpreterSelection] Failed to set global environment: ${err}`);
+        }
+    };
+
+    if (workspaceFolderResolved) {
+        // At least one workspace folder got a non-undefined environment (in multi-root,
+        // ANY folder succeeding is sufficient). ALL workspace folder envs are already
+        // active via setEnvironment calls in the loop — switching between folders in a
+        // multi-root workspace is not affected by deferring the global scope.
+        // Defer global scope to a background task so we don't block post-selection
+        // startup work in extension.ts (clearHangWatchdog, terminal init, telemetry).
+        // The outer .catch is a safety net — resolveGlobalScope has its own try/catch,
+        // so this only fires if the inner handler itself throws unexpectedly.
+        traceInfo('[interpreterSelection] Workspace env resolved, deferring global scope to background');
+        resolveGlobalScope().catch((err) =>
+            traceError(`[interpreterSelection] Background global scope resolution failed: ${err}`),
+        );
+    } else {
+        // Either: (a) no workspace folders are open, (b) every folder resolved with
+        // env=undefined (no Python found), or (c) every folder threw an error.
+        // In all cases the global environment is the user's primary fallback,
+        // so we must await it before returning.
+        await resolveGlobalScope();
     }
 
-    // Notify user if any settings could not be applied
+    // Notify user if any workspace-scoped settings could not be applied
     if (allErrors.length > 0) {
         await notifyUserOfSettingErrors(allErrors);
     }

--- a/src/features/interpreterSelection.ts
+++ b/src/features/interpreterSelection.ts
@@ -354,7 +354,7 @@ export async function applyInitialEnvironmentSelection(
     // Errors inside resolveGlobalScope are handled internally:
     //   - Setting resolution errors (bad paths, unknown managers) → notifyUserOfSettingErrors
     //   - Unexpected crashes → logged via traceError, never silently swallowed
-    const resolveGlobalScope = async () => {
+    const resolveGlobalScope = async (): Promise<SettingResolutionError[]> => {
         try {
             const globalStopWatch = new StopWatch();
             const { result, errors: globalErrors } = await resolvePriorityChainCore(
@@ -380,11 +380,10 @@ export async function applyInitialEnvironmentSelection(
 
             traceInfo(`[interpreterSelection] global: ${env?.displayName ?? 'none'} (source: ${result.source})`);
 
-            if (globalErrors.length > 0) {
-                await notifyUserOfSettingErrors(globalErrors);
-            }
+            return globalErrors;
         } catch (err) {
             traceError(`[interpreterSelection] Failed to set global environment: ${err}`);
+            return [];
         }
     };
 
@@ -395,21 +394,26 @@ export async function applyInitialEnvironmentSelection(
         // multi-root workspace is not affected by deferring the global scope.
         // Defer global scope to a background task so we don't block post-selection
         // startup work in extension.ts (clearHangWatchdog, terminal init, telemetry).
-        // The outer .catch is a safety net — resolveGlobalScope has its own try/catch,
-        // so this only fires if the inner handler itself throws unexpectedly.
+        // Global errors are notified separately since we can't aggregate with workspace errors.
         traceInfo('[interpreterSelection] Workspace env resolved, deferring global scope to background');
-        resolveGlobalScope().catch((err) =>
-            traceError(`[interpreterSelection] Background global scope resolution failed: ${err}`),
-        );
+        resolveGlobalScope()
+            .then(async (globalErrors) => {
+                if (globalErrors.length > 0) {
+                    await notifyUserOfSettingErrors(globalErrors);
+                }
+            })
+            .catch((err) => traceError(`[interpreterSelection] Background global scope resolution failed: ${err}`));
     } else {
         // Either: (a) no workspace folders are open, (b) every folder resolved with
         // env=undefined (no Python found), or (c) every folder threw an error.
         // In all cases the global environment is the user's primary fallback,
-        // so we must await it before returning.
-        await resolveGlobalScope();
+        // so we must await it before returning. Errors are aggregated with workspace
+        // errors so notifyUserOfSettingErrors can dedupe across both scopes.
+        const globalErrors = await resolveGlobalScope();
+        allErrors.push(...globalErrors);
     }
 
-    // Notify user if any workspace-scoped settings could not be applied
+    // Notify user if any settings could not be applied (workspace + global when awaited)
     if (allErrors.length > 0) {
         await notifyUserOfSettingErrors(allErrors);
     }

--- a/src/features/interpreterSelection.ts
+++ b/src/features/interpreterSelection.ts
@@ -290,7 +290,6 @@ export async function applyInitialEnvironmentSelection(
         `[interpreterSelection] Applying initial environment selection for ${folders.length} workspace folder(s)`,
     );
 
-    // Checkpoint 1: env selection starting — managers are registered
     sendTelemetryEvent(EventNames.ENV_SELECTION_STARTED, activationToReadyDurationMs, {
         registeredManagerCount: envManagers.managers.length,
         registeredManagerIds: envManagers.managers.map((m) => m.id).join(','),
@@ -314,17 +313,13 @@ export async function applyInitialEnvironmentSelection(
             );
             allErrors.push(...errors);
 
-            // Checkpoint 2: priority chain resolved — which path?
-            const isPathA = result.environment !== undefined;
-
-            // Get the specific environment if not already resolved
             const env = result.environment ?? (await result.manager.get(folder.uri));
 
             sendTelemetryEvent(EventNames.ENV_SELECTION_RESULT, scopeStopWatch.elapsedTime, {
                 scope: 'workspace',
                 prioritySource: result.source,
                 managerId: result.manager.id,
-                resolutionPath: isPathA ? 'envPreResolved' : 'managerDiscovery',
+                resolutionPath: result.environment ? 'envPreResolved' : 'managerDiscovery',
                 hasPersistedSelection: env !== undefined,
             });
 
@@ -344,16 +339,8 @@ export async function applyInitialEnvironmentSelection(
         }
     }
 
-    // Global scope: resolve a fallback Python environment for files opened OUTSIDE all
-    // workspace folders (e.g., /tmp/script.py). This is NOT a workspace folder — every
-    // workspace folder was already fully resolved and cached in the for-loop above,
-    // so switching between workspace folders is unaffected by whether this runs now or later.
-    //
-    // When at least one workspace folder resolved, we defer global scope to the background
-    // so it doesn't block post-selection startup (clearHangWatchdog, terminal init, telemetry).
-    // Errors inside resolveGlobalScope are handled internally:
-    //   - Setting resolution errors (bad paths, unknown managers) → notifyUserOfSettingErrors
-    //   - Unexpected crashes → logged via traceError, never silently swallowed
+    // Resolve global scope (fallback for files outside workspace folders).
+    // Deferred to background when a workspace folder already resolved.
     const resolveGlobalScope = async (): Promise<SettingResolutionError[]> => {
         try {
             const globalStopWatch = new StopWatch();
@@ -365,17 +352,17 @@ export async function applyInitialEnvironmentSelection(
                 api,
             );
 
-            const isPathA = result.environment !== undefined;
             const env = result.environment ?? (await result.manager.get(undefined));
 
             sendTelemetryEvent(EventNames.ENV_SELECTION_RESULT, globalStopWatch.elapsedTime, {
                 scope: 'global',
                 prioritySource: result.source,
                 managerId: result.manager.id,
-                resolutionPath: isPathA ? 'envPreResolved' : 'managerDiscovery',
+                resolutionPath: result.environment ? 'envPreResolved' : 'managerDiscovery',
                 hasPersistedSelection: env !== undefined,
             });
 
+            // Cache only — NO settings.json write
             await envManagers.setEnvironments('global', env, false);
 
             traceInfo(`[interpreterSelection] global: ${env?.displayName ?? 'none'} (source: ${result.source})`);
@@ -388,13 +375,7 @@ export async function applyInitialEnvironmentSelection(
     };
 
     if (workspaceFolderResolved) {
-        // At least one workspace folder got a non-undefined environment (in multi-root,
-        // ANY folder succeeding is sufficient). ALL workspace folder envs are already
-        // active via setEnvironment calls in the loop — switching between folders in a
-        // multi-root workspace is not affected by deferring the global scope.
-        // Defer global scope to a background task so we don't block post-selection
-        // startup work in extension.ts (clearHangWatchdog, terminal init, telemetry).
-        // Global errors are notified separately since we can't aggregate with workspace errors.
+        // Defer global scope so it doesn't block post-selection startup.
         traceInfo('[interpreterSelection] Workspace env resolved, deferring global scope to background');
         resolveGlobalScope()
             .then(async (globalErrors) => {
@@ -404,11 +385,7 @@ export async function applyInitialEnvironmentSelection(
             })
             .catch((err) => traceError(`[interpreterSelection] Background global scope resolution failed: ${err}`));
     } else {
-        // Either: (a) no workspace folders are open, (b) every folder resolved with
-        // env=undefined (no Python found), or (c) every folder threw an error.
-        // In all cases the global environment is the user's primary fallback,
-        // so we must await it before returning. Errors are aggregated with workspace
-        // errors so notifyUserOfSettingErrors can dedupe across both scopes.
+        // No workspace folder resolved — global scope is the primary fallback, must await.
         const globalErrors = await resolveGlobalScope();
         allErrors.push(...globalErrors);
     }
@@ -418,9 +395,7 @@ export async function applyInitialEnvironmentSelection(
         await notifyUserOfSettingErrors(allErrors);
     }
 
-    // Checkpoint 3: env selection function returning — duration measures blocking time only.
-    // If globalScopeDeferred=true, the global scope is still running in the background
-    // and its duration is NOT included in this measurement.
+    // Duration measures blocking time only (excludes deferred global scope).
     sendTelemetryEvent(EventNames.ENV_SELECTION_COMPLETED, selectionStopWatch.elapsedTime, {
         globalScopeDeferred: workspaceFolderResolved,
         workspaceFolderCount: folders.length,

--- a/src/features/interpreterSelection.ts
+++ b/src/features/interpreterSelection.ts
@@ -299,6 +299,8 @@ export async function applyInitialEnvironmentSelection(
 
     const allErrors: SettingResolutionError[] = [];
     let workspaceFolderResolved = false;
+    let resolvedFolderCount = 0;
+    const selectionStopWatch = new StopWatch();
 
     for (const folder of folders) {
         try {
@@ -331,6 +333,7 @@ export async function applyInitialEnvironmentSelection(
 
             if (env) {
                 workspaceFolderResolved = true;
+                resolvedFolderCount++;
             }
 
             traceInfo(
@@ -410,6 +413,16 @@ export async function applyInitialEnvironmentSelection(
     if (allErrors.length > 0) {
         await notifyUserOfSettingErrors(allErrors);
     }
+
+    // Checkpoint 3: env selection function returning — duration measures blocking time only.
+    // If globalScopeDeferred=true, the global scope is still running in the background
+    // and its duration is NOT included in this measurement.
+    sendTelemetryEvent(EventNames.ENV_SELECTION_COMPLETED, selectionStopWatch.elapsedTime, {
+        globalScopeDeferred: workspaceFolderResolved,
+        workspaceFolderCount: folders.length,
+        resolvedFolderCount,
+        settingErrorCount: allErrors.length,
+    });
 }
 
 /**

--- a/src/test/features/interpreterSelection.unit.test.ts
+++ b/src/test/features/interpreterSelection.unit.test.ts
@@ -868,36 +868,18 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
 
         const showWarnStub = sandbox.stub(windowApis, 'showWarningMessage').resolves(undefined);
 
-        // Block setEnvironments so we can control when global scope completes
-        let resolveSetEnvironments: () => void;
-        const setEnvironmentsPromise = new Promise<void>((resolve) => {
-            resolveSetEnvironments = resolve;
-        });
-        mockEnvManagers.setEnvironments.callsFake(async () => {
-            await setEnvironmentsPromise;
-        });
-
-        let functionReturned = false;
-        const resultPromise = applyInitialEnvironmentSelection(
+        await applyInitialEnvironmentSelection(
             mockEnvManagers as unknown as EnvironmentManagers,
             mockProjectManager as unknown as PythonProjectManager,
             mockNativeFinder as unknown as NativePythonFinder,
             mockApi as unknown as PythonEnvironmentApi,
-        ).then(() => {
-            functionReturned = true;
-        });
-
-        // Yield to microtasks — in deferred path, function should return
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        assert.ok(functionReturned, 'Function should return before global scope completes (deferred path)');
+        );
 
         // Workspace folder should resolve (venv found)
         assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called for workspace folder');
 
-        // Unblock global scope and let it finish
-        resolveSetEnvironments!();
-        await resultPromise;
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        // Wait a tick for the background global scope to complete
+        await new Promise((resolve) => setTimeout(resolve, 50));
 
         // Global scope should still resolve (falls to auto-discovery) and show warning
         assert.ok(mockEnvManagers.setEnvironments.called, 'setEnvironments should be called for global scope');
@@ -914,124 +896,28 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
         sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
         sandbox.stub(helpers, 'getUserConfiguredSetting').returns(undefined);
 
-        // Block setEnvironments until we reject it, simulating a crash
-        let rejectSetEnvironments: (err: Error) => void;
-        const setEnvironmentsPromise = new Promise<void>((_resolve, reject) => {
-            rejectSetEnvironments = reject;
-        });
-        mockEnvManagers.setEnvironments.callsFake(async () => {
-            await setEnvironmentsPromise;
-        });
+        // Make setEnvironments throw — simulating a crash in global scope
+        mockEnvManagers.setEnvironments.rejects(new Error('Simulated global scope crash'));
 
-        let functionReturned = false;
-        const resultPromise = applyInitialEnvironmentSelection(
+        // Should NOT throw — errors are caught inside resolveGlobalScope
+        await applyInitialEnvironmentSelection(
             mockEnvManagers as unknown as EnvironmentManagers,
             mockProjectManager as unknown as PythonProjectManager,
             mockNativeFinder as unknown as NativePythonFinder,
             mockApi as unknown as PythonEnvironmentApi,
-        ).then(() => {
-            functionReturned = true;
-        });
+        );
 
-        // Yield to microtasks — in deferred path, function should return
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        assert.ok(functionReturned, 'Function should return before global scope completes (deferred path)');
+        // Wait a tick for the background global scope to complete
+        await new Promise((resolve) => setTimeout(resolve, 50));
 
-        // Workspace folder should have resolved
+        // Workspace folder should still have resolved
         assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called for workspace folder');
-
-        // Trigger the crash and let it propagate through the catch chain
-        rejectSetEnvironments!(new Error('Simulated global scope crash'));
-        await resultPromise;
-        await new Promise((resolve) => setTimeout(resolve, 0));
 
         // setEnvironments was called (and threw), proving the global scope was attempted
         assert.ok(
             mockEnvManagers.setEnvironments.called,
             'setEnvironments should have been attempted for global scope',
         );
-    });
-
-    test('should defer global scope when workspace folder resolves with env', async () => {
-        // Core deferral test: when a workspace folder resolves with an environment,
-        // applyInitialEnvironmentSelection should return BEFORE setEnvironments completes
-        // for the global scope. This verifies the fire-and-forget optimization.
-        sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([{ uri: testUri, name: 'test', index: 0 }]);
-        sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
-        sandbox.stub(helpers, 'getUserConfiguredSetting').returns(undefined);
-
-        // Block setEnvironments so we can observe that the function returns before it completes
-        let resolveSetEnvironments: () => void;
-        const setEnvironmentsPromise = new Promise<void>((resolve) => {
-            resolveSetEnvironments = resolve;
-        });
-        mockEnvManagers.setEnvironments.callsFake(async () => {
-            await setEnvironmentsPromise;
-        });
-
-        let functionReturned = false;
-        const resultPromise = applyInitialEnvironmentSelection(
-            mockEnvManagers as unknown as EnvironmentManagers,
-            mockProjectManager as unknown as PythonProjectManager,
-            mockNativeFinder as unknown as NativePythonFinder,
-            mockApi as unknown as PythonEnvironmentApi,
-        ).then(() => {
-            functionReturned = true;
-        });
-
-        // Yield to microtasks — in DEFERRED path, function returns before global completes
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        assert.ok(functionReturned, 'Function should return before global scope completes (deferred path)');
-        assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called for workspace folder');
-
-        // Clean up: unblock the global scope
-        resolveSetEnvironments!();
-        await resultPromise;
-        await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
-    test('should await global scope when all workspace folders resolve with env=undefined', async () => {
-        // When workspace folders exist but all resolve to env=undefined (no Python found),
-        // workspaceFolderResolved stays false and global scope must be awaited (not deferred).
-        sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([{ uri: testUri, name: 'test', index: 0 }]);
-        sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
-        sandbox.stub(helpers, 'getUserConfiguredSetting').returns(undefined);
-
-        // All managers return undefined for workspace scope — no Python found
-        mockVenvManager.get.resolves(undefined);
-        mockSystemManager.get.resolves(undefined);
-
-        // Block setEnvironments so we can verify the function does NOT return before it completes
-        let resolveSetEnvironments: () => void;
-        const setEnvironmentsPromise = new Promise<void>((resolve) => {
-            resolveSetEnvironments = resolve;
-        });
-        mockEnvManagers.setEnvironments.callsFake(async () => {
-            await setEnvironmentsPromise;
-        });
-
-        let functionReturned = false;
-        const resultPromise = applyInitialEnvironmentSelection(
-            mockEnvManagers as unknown as EnvironmentManagers,
-            mockProjectManager as unknown as PythonProjectManager,
-            mockNativeFinder as unknown as NativePythonFinder,
-            mockApi as unknown as PythonEnvironmentApi,
-        ).then(() => {
-            functionReturned = true;
-        });
-
-        // Yield to microtasks — in AWAITED path, function should NOT have returned yet
-        await new Promise((resolve) => setTimeout(resolve, 0));
-        assert.ok(!functionReturned, 'Function should NOT return before global scope completes (awaited path)');
-
-        // Unblock global scope
-        resolveSetEnvironments!();
-        await resultPromise;
-
-        // Now the function has returned after global scope completed
-        assert.ok(functionReturned, 'Function should have returned after global scope completes');
-        assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called for workspace folder');
-        assert.ok(mockEnvManagers.setEnvironments.called, 'setEnvironments should be called for global scope');
     });
 
     test('notifyUserOfSettingErrors shows warning with Open Settings for defaultInterpreterPath', async () => {

--- a/src/test/features/interpreterSelection.unit.test.ts
+++ b/src/test/features/interpreterSelection.unit.test.ts
@@ -868,6 +868,16 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
 
         const showWarnStub = sandbox.stub(windowApis, 'showWarningMessage').resolves(undefined);
 
+        // Use a deferred promise to deterministically wait for the background global scope
+        let resolveGlobalDone!: () => void;
+        const globalDone = new Promise<void>((resolve) => {
+            resolveGlobalDone = resolve;
+        });
+        const origSetEnvironments = mockEnvManagers.setEnvironments;
+        origSetEnvironments.callsFake(async (...args: unknown[]) => {
+            resolveGlobalDone();
+        });
+
         await applyInitialEnvironmentSelection(
             mockEnvManagers as unknown as EnvironmentManagers,
             mockProjectManager as unknown as PythonProjectManager,
@@ -878,8 +888,10 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
         // Workspace folder should resolve (venv found)
         assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called for workspace folder');
 
-        // Wait a tick for the background global scope to complete
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        // Wait for the background global scope to call setEnvironments
+        await globalDone;
+        // Flush microtasks so the .then() handler for notifyUserOfSettingErrors runs
+        await new Promise<void>((resolve) => process.nextTick(resolve));
 
         // Global scope should still resolve (falls to auto-discovery) and show warning
         assert.ok(mockEnvManagers.setEnvironments.called, 'setEnvironments should be called for global scope');
@@ -896,8 +908,17 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
         sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
         sandbox.stub(helpers, 'getUserConfiguredSetting').returns(undefined);
 
+        // Use a deferred promise to deterministically wait for the background global scope
+        let resolveGlobalDone!: () => void;
+        const globalDone = new Promise<void>((resolve) => {
+            resolveGlobalDone = resolve;
+        });
+
         // Make setEnvironments throw — simulating a crash in global scope
-        mockEnvManagers.setEnvironments.rejects(new Error('Simulated global scope crash'));
+        mockEnvManagers.setEnvironments.callsFake(async () => {
+            resolveGlobalDone();
+            throw new Error('Simulated global scope crash');
+        });
 
         // Should NOT throw — errors are caught inside resolveGlobalScope
         await applyInitialEnvironmentSelection(
@@ -907,8 +928,10 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
             mockApi as unknown as PythonEnvironmentApi,
         );
 
-        // Wait a tick for the background global scope to complete
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        // Wait for the background global scope to call setEnvironments
+        await globalDone;
+        // Flush microtasks so the catch handler runs
+        await new Promise<void>((resolve) => process.nextTick(resolve));
 
         // Workspace folder should still have resolved
         assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called for workspace folder');

--- a/src/test/features/interpreterSelection.unit.test.ts
+++ b/src/test/features/interpreterSelection.unit.test.ts
@@ -5,7 +5,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { ConfigurationChangeEvent, Uri, WorkspaceConfiguration, WorkspaceFolder } from 'vscode';
-import { PythonEnvironment, PythonEnvironmentApi, PythonProject } from '../../api';
+import { PythonEnvironment, PythonEnvironmentApi, PythonProject, SetEnvironmentScope } from '../../api';
 import * as windowApis from '../../common/window.apis';
 import * as workspaceApis from '../../common/workspace.apis';
 import {
@@ -716,6 +716,349 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
             showWarnStub.notCalled,
             'showWarningMessage should not be called when ${workspaceFolder} is only unresolvable in global scope',
         );
+    });
+
+    test('should catch and continue when workspace folder resolution throws', async () => {
+        // When manager.get() throws for a folder, the error should be caught
+        // and the function should still complete (falling through to awaited global scope).
+        sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([{ uri: testUri, name: 'test', index: 0 }]);
+        sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
+        sandbox.stub(helpers, 'getUserConfiguredSetting').returns(undefined);
+
+        // Make venvManager.get() throw for the workspace folder
+        mockVenvManager.get.rejects(new Error('Simulated venv discovery failure'));
+        // systemManager.get() throws for workspace scope but succeeds for global scope
+        mockSystemManager.get.callsFake((scope: Uri | undefined) => {
+            if (scope) {
+                return Promise.reject(new Error('Simulated system discovery failure'));
+            }
+            return Promise.resolve(undefined);
+        });
+
+        // Should NOT throw — the per-folder catch block handles it
+        await applyInitialEnvironmentSelection(
+            mockEnvManagers as unknown as EnvironmentManagers,
+            mockProjectManager as unknown as PythonProjectManager,
+            mockNativeFinder as unknown as NativePythonFinder,
+            mockApi as unknown as PythonEnvironmentApi,
+        );
+
+        // setEnvironment should NOT have been called for the failed folder
+        assert.ok(
+            mockEnvManagers.setEnvironment.notCalled,
+            'setEnvironment should not be called when folder resolution throws',
+        );
+
+        // Global scope should still be resolved (awaited, since no workspace folder succeeded)
+        assert.ok(
+            mockEnvManagers.setEnvironments.called,
+            'setEnvironments should still be called for global scope after folder failure',
+        );
+    });
+
+    test('should continue processing remaining folders when one folder throws', async () => {
+        // In multi-root: if folder 1's resolution throws (e.g., setEnvironment fails),
+        // the error is caught and folder 2 should still be processed.
+        const uri1 = Uri.file('/workspace1');
+        const uri2 = Uri.file('/workspace2');
+        sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([
+            { uri: uri1, name: 'workspace1', index: 0 },
+            { uri: uri2, name: 'workspace2', index: 1 },
+        ]);
+        sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
+        sandbox.stub(helpers, 'getUserConfiguredSetting').returns(undefined);
+
+        // setEnvironment throws for folder 1 only, succeeds for folder 2
+        mockEnvManagers.setEnvironment.callsFake((scope: SetEnvironmentScope) => {
+            if (scope && !Array.isArray(scope) && scope.fsPath === uri1.fsPath) {
+                return Promise.reject(new Error('Folder 1 setEnvironment failure'));
+            }
+            return Promise.resolve();
+        });
+
+        await applyInitialEnvironmentSelection(
+            mockEnvManagers as unknown as EnvironmentManagers,
+            mockProjectManager as unknown as PythonProjectManager,
+            mockNativeFinder as unknown as NativePythonFinder,
+            mockApi as unknown as PythonEnvironmentApi,
+        );
+
+        // setEnvironment should be called for both folders (folder 1 threw, folder 2 succeeded)
+        assert.strictEqual(
+            mockEnvManagers.setEnvironment.callCount,
+            2,
+            'setEnvironment should be attempted for both folders',
+        );
+        // Folder 2 succeeded — verify it was called with the correct URI
+        const secondCallUri = mockEnvManagers.setEnvironment.secondCall.args[0] as Uri;
+        assert.strictEqual(secondCallUri.fsPath, uri2.fsPath, 'Second call should be for folder 2');
+    });
+
+    test('should show warning when pythonProjects references unregistered manager', async () => {
+        // Priority 1 error path: pythonProjects[] names a manager that isn't registered.
+        // Should fall through to auto-discovery and show a warning.
+        const workspaceFolder = { uri: testUri, name: 'test', index: 0 } as WorkspaceFolder;
+        sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([workspaceFolder]);
+        sandbox.stub(workspaceApis, 'getWorkspaceFolder').returns(workspaceFolder);
+        sandbox
+            .stub(workspaceApis, 'getConfiguration')
+            .returns(
+                createMockConfig([{ path: '.', envManager: 'ms-python.python:nonexistent' }]) as WorkspaceConfiguration,
+            );
+        sandbox.stub(helpers, 'getUserConfiguredSetting').returns(undefined);
+
+        mockProjectManager.get.returns({ uri: testUri, name: 'test' } as PythonProject);
+
+        const showWarnStub = sandbox.stub(windowApis, 'showWarningMessage').resolves(undefined);
+
+        await applyInitialEnvironmentSelection(
+            mockEnvManagers as unknown as EnvironmentManagers,
+            mockProjectManager as unknown as PythonProjectManager,
+            mockNativeFinder as unknown as NativePythonFinder,
+            mockApi as unknown as PythonEnvironmentApi,
+        );
+
+        // Should still set the environment (falls through to auto-discovery)
+        assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called via fallback');
+
+        // Should show a warning about the unregistered manager
+        assert.ok(showWarnStub.called, 'showWarningMessage should be called for unregistered pythonProjects manager');
+    });
+
+    test('should show warning when defaultEnvManager references unregistered manager', async () => {
+        // Priority 2 error path: defaultEnvManager names a manager that isn't registered.
+        sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([{ uri: testUri, name: 'test', index: 0 }]);
+        sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
+        sandbox.stub(helpers, 'getUserConfiguredSetting').callsFake((section: string, key: string) => {
+            if (section === 'python-envs' && key === 'defaultEnvManager') {
+                return 'ms-python.python:nonexistent';
+            }
+            return undefined;
+        });
+
+        const showWarnStub = sandbox.stub(windowApis, 'showWarningMessage').resolves(undefined);
+
+        await applyInitialEnvironmentSelection(
+            mockEnvManagers as unknown as EnvironmentManagers,
+            mockProjectManager as unknown as PythonProjectManager,
+            mockNativeFinder as unknown as NativePythonFinder,
+            mockApi as unknown as PythonEnvironmentApi,
+        );
+
+        // Should still set the environment (falls through to auto-discovery)
+        assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called via fallback');
+
+        // Should show a warning about the unregistered manager
+        assert.ok(showWarnStub.called, 'showWarningMessage should be called for unregistered defaultEnvManager');
+    });
+
+    test('should handle global scope errors when deferred to background', async () => {
+        // When workspace folder resolves but global scope has setting errors,
+        // notifyUserOfSettingErrors should still be called from the background task.
+        sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([{ uri: testUri, name: 'test', index: 0 }]);
+        sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
+
+        // Global scope gets a defaultEnvManager that doesn't exist → produces a SettingResolutionError
+        sandbox.stub(helpers, 'getUserConfiguredSetting').callsFake((section: string, key: string, scope?: Uri) => {
+            if (!scope && section === 'python-envs' && key === 'defaultEnvManager') {
+                return 'ms-python.python:nonexistent-global';
+            }
+            return undefined;
+        });
+
+        const showWarnStub = sandbox.stub(windowApis, 'showWarningMessage').resolves(undefined);
+
+        // Block setEnvironments so we can control when global scope completes
+        let resolveSetEnvironments: () => void;
+        const setEnvironmentsPromise = new Promise<void>((resolve) => {
+            resolveSetEnvironments = resolve;
+        });
+        mockEnvManagers.setEnvironments.callsFake(async () => {
+            await setEnvironmentsPromise;
+        });
+
+        let functionReturned = false;
+        const resultPromise = applyInitialEnvironmentSelection(
+            mockEnvManagers as unknown as EnvironmentManagers,
+            mockProjectManager as unknown as PythonProjectManager,
+            mockNativeFinder as unknown as NativePythonFinder,
+            mockApi as unknown as PythonEnvironmentApi,
+        ).then(() => {
+            functionReturned = true;
+        });
+
+        // Yield to microtasks — in deferred path, function should return
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        assert.ok(functionReturned, 'Function should return before global scope completes (deferred path)');
+
+        // Workspace folder should resolve (venv found)
+        assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called for workspace folder');
+
+        // Unblock global scope and let it finish
+        resolveSetEnvironments!();
+        await resultPromise;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        // Global scope should still resolve (falls to auto-discovery) and show warning
+        assert.ok(mockEnvManagers.setEnvironments.called, 'setEnvironments should be called for global scope');
+        assert.ok(
+            showWarnStub.called,
+            'showWarningMessage should be called for global scope setting error even when deferred',
+        );
+    });
+
+    test('should handle global scope crash when deferred to background', async () => {
+        // When workspace folder resolves but global scope crashes (resolveGlobalScope catch block),
+        // the error should be logged and not propagate.
+        sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([{ uri: testUri, name: 'test', index: 0 }]);
+        sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
+        sandbox.stub(helpers, 'getUserConfiguredSetting').returns(undefined);
+
+        // Block setEnvironments until we reject it, simulating a crash
+        let rejectSetEnvironments: (err: Error) => void;
+        const setEnvironmentsPromise = new Promise<void>((_resolve, reject) => {
+            rejectSetEnvironments = reject;
+        });
+        mockEnvManagers.setEnvironments.callsFake(async () => {
+            await setEnvironmentsPromise;
+        });
+
+        let functionReturned = false;
+        const resultPromise = applyInitialEnvironmentSelection(
+            mockEnvManagers as unknown as EnvironmentManagers,
+            mockProjectManager as unknown as PythonProjectManager,
+            mockNativeFinder as unknown as NativePythonFinder,
+            mockApi as unknown as PythonEnvironmentApi,
+        ).then(() => {
+            functionReturned = true;
+        });
+
+        // Yield to microtasks — in deferred path, function should return
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        assert.ok(functionReturned, 'Function should return before global scope completes (deferred path)');
+
+        // Workspace folder should have resolved
+        assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called for workspace folder');
+
+        // Trigger the crash and let it propagate through the catch chain
+        rejectSetEnvironments!(new Error('Simulated global scope crash'));
+        await resultPromise;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        // setEnvironments was called (and threw), proving the global scope was attempted
+        assert.ok(
+            mockEnvManagers.setEnvironments.called,
+            'setEnvironments should have been attempted for global scope',
+        );
+    });
+
+    test('should defer global scope when workspace folder resolves with env', async () => {
+        // Core deferral test: when a workspace folder resolves with an environment,
+        // applyInitialEnvironmentSelection should return BEFORE setEnvironments completes
+        // for the global scope. This verifies the fire-and-forget optimization.
+        sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([{ uri: testUri, name: 'test', index: 0 }]);
+        sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
+        sandbox.stub(helpers, 'getUserConfiguredSetting').returns(undefined);
+
+        // Block setEnvironments so we can observe that the function returns before it completes
+        let resolveSetEnvironments: () => void;
+        const setEnvironmentsPromise = new Promise<void>((resolve) => {
+            resolveSetEnvironments = resolve;
+        });
+        mockEnvManagers.setEnvironments.callsFake(async () => {
+            await setEnvironmentsPromise;
+        });
+
+        let functionReturned = false;
+        const resultPromise = applyInitialEnvironmentSelection(
+            mockEnvManagers as unknown as EnvironmentManagers,
+            mockProjectManager as unknown as PythonProjectManager,
+            mockNativeFinder as unknown as NativePythonFinder,
+            mockApi as unknown as PythonEnvironmentApi,
+        ).then(() => {
+            functionReturned = true;
+        });
+
+        // Yield to microtasks — in DEFERRED path, function returns before global completes
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        assert.ok(functionReturned, 'Function should return before global scope completes (deferred path)');
+        assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called for workspace folder');
+
+        // Clean up: unblock the global scope
+        resolveSetEnvironments!();
+        await resultPromise;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    test('should await global scope when all workspace folders resolve with env=undefined', async () => {
+        // When workspace folders exist but all resolve to env=undefined (no Python found),
+        // workspaceFolderResolved stays false and global scope must be awaited (not deferred).
+        sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([{ uri: testUri, name: 'test', index: 0 }]);
+        sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
+        sandbox.stub(helpers, 'getUserConfiguredSetting').returns(undefined);
+
+        // All managers return undefined for workspace scope — no Python found
+        mockVenvManager.get.resolves(undefined);
+        mockSystemManager.get.resolves(undefined);
+
+        // Block setEnvironments so we can verify the function does NOT return before it completes
+        let resolveSetEnvironments: () => void;
+        const setEnvironmentsPromise = new Promise<void>((resolve) => {
+            resolveSetEnvironments = resolve;
+        });
+        mockEnvManagers.setEnvironments.callsFake(async () => {
+            await setEnvironmentsPromise;
+        });
+
+        let functionReturned = false;
+        const resultPromise = applyInitialEnvironmentSelection(
+            mockEnvManagers as unknown as EnvironmentManagers,
+            mockProjectManager as unknown as PythonProjectManager,
+            mockNativeFinder as unknown as NativePythonFinder,
+            mockApi as unknown as PythonEnvironmentApi,
+        ).then(() => {
+            functionReturned = true;
+        });
+
+        // Yield to microtasks — in AWAITED path, function should NOT have returned yet
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        assert.ok(!functionReturned, 'Function should NOT return before global scope completes (awaited path)');
+
+        // Unblock global scope
+        resolveSetEnvironments!();
+        await resultPromise;
+
+        // Now the function has returned after global scope completed
+        assert.ok(functionReturned, 'Function should have returned after global scope completes');
+        assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called for workspace folder');
+        assert.ok(mockEnvManagers.setEnvironments.called, 'setEnvironments should be called for global scope');
+    });
+
+    test('notifyUserOfSettingErrors shows warning with Open Settings for defaultInterpreterPath', async () => {
+        // Trigger the defaultInterpreterPath error branch of notifyUserOfSettingErrors.
+        sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([{ uri: testUri, name: 'test', index: 0 }]);
+        sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
+        sandbox.stub(helpers, 'getUserConfiguredSetting').callsFake((section: string, key: string) => {
+            if (section === 'python' && key === 'defaultInterpreterPath') {
+                return '/nonexistent/python';
+            }
+            return undefined;
+        });
+        // nativeFinder.resolve fails — path can't be resolved
+        mockNativeFinder.resolve.rejects(new Error('Not found'));
+
+        const showWarnStub = sandbox.stub(windowApis, 'showWarningMessage').resolves(undefined);
+
+        await applyInitialEnvironmentSelection(
+            mockEnvManagers as unknown as EnvironmentManagers,
+            mockProjectManager as unknown as PythonProjectManager,
+            mockNativeFinder as unknown as NativePythonFinder,
+            mockApi as unknown as PythonEnvironmentApi,
+        );
+
+        assert.ok(showWarnStub.called, 'showWarningMessage should be called for unresolvable defaultInterpreterPath');
+        const warningMessage = showWarnStub.firstCall.args[0] as string;
+        assert.ok(warningMessage.includes('/nonexistent/python'), 'Warning message should include the configured path');
     });
 });
 

--- a/src/test/features/interpreterSelection.unit.test.ts
+++ b/src/test/features/interpreterSelection.unit.test.ts
@@ -873,8 +873,7 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
         const globalDone = new Promise<void>((resolve) => {
             resolveGlobalDone = resolve;
         });
-        const origSetEnvironments = mockEnvManagers.setEnvironments;
-        origSetEnvironments.callsFake(async (...args: unknown[]) => {
+        mockEnvManagers.setEnvironments.callsFake(async () => {
             resolveGlobalDone();
         });
 
@@ -913,8 +912,6 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
         const globalDone = new Promise<void>((resolve) => {
             resolveGlobalDone = resolve;
         });
-
-        // Make setEnvironments throw — simulating a crash in global scope
         mockEnvManagers.setEnvironments.callsFake(async () => {
             resolveGlobalDone();
             throw new Error('Simulated global scope crash');

--- a/src/test/features/interpreterSelection.unit.test.ts
+++ b/src/test/features/interpreterSelection.unit.test.ts
@@ -11,6 +11,7 @@ import * as workspaceApis from '../../common/workspace.apis';
 import {
     applyInitialEnvironmentSelection,
     registerInterpreterSettingsChangeListener,
+    resetSettingWarnings,
     resolveEnvironmentByPriority,
     resolveGlobalEnvironmentByPriority,
 } from '../../features/interpreterSelection';
@@ -552,6 +553,7 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
 
     setup(() => {
         sandbox = sinon.createSandbox();
+        resetSettingWarnings();
 
         mockVenvManager = {
             id: 'ms-python.python:venv',


### PR DESCRIPTION
When at least one workspace folder resolved successfully, don't await the global scope resolution. Run it as a background task instead of blocking startup on it.

For more than 3/4ths of slow sessions where the workspace env resolves fast (via `envPreResolved`), this should make the status bar update near-instantly.

Files opened outside the workspace folder wouldn't have a Python env immediately available. They would resolve moments later when the background task completes.