### PR TITLE
Fix `set()` for global scope not updating `globalEnv` in memory

### DIFF
--- a/src/managers/conda/condaEnvManager.ts
+++ b/src/managers/conda/condaEnvManager.ts
@@ -95,7 +95,8 @@ export class CondaEnvManager implements EnvironmentManager, Disposable {
                     title: CondaStrings.condaDiscovering,
                 },
                 async () => {
-                    this.collection = (await refreshCondaEnvs(false, this.nativeFinder, this.api, this.log, this)) ?? [];
+                    this.collection =
+                        (await refreshCondaEnvs(false, this.nativeFinder, this.api, this.log, this)) ?? [];
                     await this.loadEnvMap();
 
                     this._onDidChangeEnvironments.fire(
@@ -273,7 +274,8 @@ export class CondaEnvManager implements EnvironmentManager, Disposable {
             resolve: (p) => resolveCondaPath(p, this.nativeFinder, this.api, this.log, this),
             startBackgroundInit: () =>
                 withProgress({ location: ProgressLocation.Window, title: CondaStrings.condaDiscovering }, async () => {
-                    this.collection = (await refreshCondaEnvs(false, this.nativeFinder, this.api, this.log, this)) ?? [];
+                    this.collection =
+                        (await refreshCondaEnvs(false, this.nativeFinder, this.api, this.log, this)) ?? [];
                     await this.loadEnvMap();
                     this._onDidChangeEnvironments.fire(
                         this.collection.map((e) => ({

--- a/src/test/managers/conda/condaEnvManager.findEnvironmentByPath.unit.test.ts
+++ b/src/test/managers/conda/condaEnvManager.findEnvironmentByPath.unit.test.ts
@@ -5,7 +5,7 @@ import { PythonEnvironment, PythonEnvironmentApi } from '../../../api';
 import { isWindows } from '../../../common/utils/platformUtils';
 import { CondaEnvManager } from '../../../managers/conda/condaEnvManager';
 import { NativePythonFinder } from '../.././../managers/common/nativePythonFinder';
-import { makeMockPythonEnvironment as makeEnv } from '../../mocks/pythonEnvironment';
+import { makeMockCondaEnvironment as makeEnv } from '../../mocks/pythonEnvironment';
 
 /**
  * Creates a CondaEnvManager with a given collection, bypassing initialization.

--- a/src/test/managers/conda/condaEnvManager.findEnvironmentByPath.unit.test.ts
+++ b/src/test/managers/conda/condaEnvManager.findEnvironmentByPath.unit.test.ts
@@ -1,33 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import assert from 'assert';
 import * as sinon from 'sinon';
-import { Uri } from 'vscode';
 import { PythonEnvironment, PythonEnvironmentApi } from '../../../api';
 import { isWindows } from '../../../common/utils/platformUtils';
-import { PythonEnvironmentImpl } from '../../../internal.api';
 import { CondaEnvManager } from '../../../managers/conda/condaEnvManager';
 import { NativePythonFinder } from '../.././../managers/common/nativePythonFinder';
-
-/**
- * Helper to create a minimal PythonEnvironment stub with required fields.
- * Only `name`, `environmentPath`, and `version` matter for findEnvironmentByPath.
- */
-function makeEnv(name: string, envPath: string, version: string = '3.12.0'): PythonEnvironment {
-    return new PythonEnvironmentImpl(
-        { id: `${name}-test`, managerId: 'ms-python.python:conda' },
-        {
-            name,
-            displayName: `${name} (${version})`,
-            displayPath: envPath,
-            version,
-            environmentPath: Uri.file(envPath),
-            sysPrefix: envPath,
-            execInfo: {
-                run: { executable: 'python' },
-            },
-        },
-    );
-}
+import { makeMockPythonEnvironment as makeEnv } from '../../mocks/pythonEnvironment';
 
 /**
  * Creates a CondaEnvManager with a given collection, bypassing initialization.

--- a/src/test/managers/conda/condaEnvManager.setEvents.unit.test.ts
+++ b/src/test/managers/conda/condaEnvManager.setEvents.unit.test.ts
@@ -7,7 +7,7 @@ import { normalizePath } from '../../../common/utils/pathUtils';
 import { CondaEnvManager } from '../../../managers/conda/condaEnvManager';
 import * as condaUtils from '../../../managers/conda/condaUtils';
 import { NativePythonFinder } from '../../../managers/common/nativePythonFinder';
-import { makeMockPythonEnvironment as makeEnv } from '../../mocks/pythonEnvironment';
+import { makeMockCondaEnvironment as makeEnv } from '../../mocks/pythonEnvironment';
 
 function createManager(apiOverrides?: Partial<PythonEnvironmentApi>): CondaEnvManager {
     const api = {

--- a/src/test/managers/conda/condaEnvManager.setEvents.unit.test.ts
+++ b/src/test/managers/conda/condaEnvManager.setEvents.unit.test.ts
@@ -2,29 +2,12 @@
 import assert from 'assert';
 import * as sinon from 'sinon';
 import { Uri } from 'vscode';
-import { DidChangeEnvironmentEventArgs, PythonEnvironment, PythonEnvironmentApi, PythonProject } from '../../../api';
+import { DidChangeEnvironmentEventArgs, PythonEnvironmentApi, PythonProject } from '../../../api';
 import { normalizePath } from '../../../common/utils/pathUtils';
-import { PythonEnvironmentImpl } from '../../../internal.api';
 import { CondaEnvManager } from '../../../managers/conda/condaEnvManager';
 import * as condaUtils from '../../../managers/conda/condaUtils';
 import { NativePythonFinder } from '../../../managers/common/nativePythonFinder';
-
-function makeEnv(name: string, envPath: string, version: string = '3.12.0'): PythonEnvironment {
-    return new PythonEnvironmentImpl(
-        { id: `${name}-test`, managerId: 'ms-python.python:conda' },
-        {
-            name,
-            displayName: `${name} (${version})`,
-            displayPath: envPath,
-            version,
-            environmentPath: Uri.file(envPath),
-            sysPrefix: envPath,
-            execInfo: {
-                run: { executable: 'python' },
-            },
-        },
-    );
-}
+import { makeMockPythonEnvironment as makeEnv } from '../../mocks/pythonEnvironment';
 
 function createManager(apiOverrides?: Partial<PythonEnvironmentApi>): CondaEnvManager {
     const api = {

--- a/src/test/managers/conda/condaEnvManager.setGlobal.unit.test.ts
+++ b/src/test/managers/conda/condaEnvManager.setGlobal.unit.test.ts
@@ -5,7 +5,7 @@ import { PythonEnvironmentApi } from '../../../api';
 import { CondaEnvManager } from '../../../managers/conda/condaEnvManager';
 import * as condaUtils from '../../../managers/conda/condaUtils';
 import { NativePythonFinder } from '../../../managers/common/nativePythonFinder';
-import { makeMockPythonEnvironment as makeEnv } from '../../mocks/pythonEnvironment';
+import { makeMockCondaEnvironment as makeEnv } from '../../mocks/pythonEnvironment';
 
 function createManager(): CondaEnvManager {
     const manager = new CondaEnvManager(

--- a/src/test/managers/conda/condaEnvManager.setGlobal.unit.test.ts
+++ b/src/test/managers/conda/condaEnvManager.setGlobal.unit.test.ts
@@ -1,29 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import assert from 'assert';
 import * as sinon from 'sinon';
-import { Uri } from 'vscode';
-import { PythonEnvironment, PythonEnvironmentApi } from '../../../api';
-import { PythonEnvironmentImpl } from '../../../internal.api';
+import { PythonEnvironmentApi } from '../../../api';
 import { CondaEnvManager } from '../../../managers/conda/condaEnvManager';
 import * as condaUtils from '../../../managers/conda/condaUtils';
 import { NativePythonFinder } from '../../../managers/common/nativePythonFinder';
-
-function makeEnv(name: string, envPath: string, version: string = '3.12.0'): PythonEnvironment {
-    return new PythonEnvironmentImpl(
-        { id: `${name}-test`, managerId: 'ms-python.python:conda' },
-        {
-            name,
-            displayName: `${name} (${version})`,
-            displayPath: envPath,
-            version,
-            environmentPath: Uri.file(envPath),
-            sysPrefix: envPath,
-            execInfo: {
-                run: { executable: 'python' },
-            },
-        },
-    );
-}
+import { makeMockPythonEnvironment as makeEnv } from '../../mocks/pythonEnvironment';
 
 function createManager(): CondaEnvManager {
     const manager = new CondaEnvManager(

--- a/src/test/managers/conda/condaEnvManager.setGlobal.unit.test.ts
+++ b/src/test/managers/conda/condaEnvManager.setGlobal.unit.test.ts
@@ -1,0 +1,110 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import assert from 'assert';
+import * as sinon from 'sinon';
+import { Uri } from 'vscode';
+import { PythonEnvironment, PythonEnvironmentApi } from '../../../api';
+import { PythonEnvironmentImpl } from '../../../internal.api';
+import { CondaEnvManager } from '../../../managers/conda/condaEnvManager';
+import * as condaUtils from '../../../managers/conda/condaUtils';
+import { NativePythonFinder } from '../../../managers/common/nativePythonFinder';
+
+function makeEnv(name: string, envPath: string, version: string = '3.12.0'): PythonEnvironment {
+    return new PythonEnvironmentImpl(
+        { id: `${name}-test`, managerId: 'ms-python.python:conda' },
+        {
+            name,
+            displayName: `${name} (${version})`,
+            displayPath: envPath,
+            version,
+            environmentPath: Uri.file(envPath),
+            sysPrefix: envPath,
+            execInfo: {
+                run: { executable: 'python' },
+            },
+        },
+    );
+}
+
+function createManager(): CondaEnvManager {
+    const manager = new CondaEnvManager(
+        {} as NativePythonFinder,
+        {} as PythonEnvironmentApi,
+        { info: sinon.stub(), error: sinon.stub(), warn: sinon.stub() } as any,
+    );
+    // Bypass initialization
+    (manager as any)._initialized = { completed: true, promise: Promise.resolve() };
+    (manager as any).collection = [];
+    return manager;
+}
+
+suite('CondaEnvManager.set - globalEnv update', () => {
+    let setCondaForGlobalStub: sinon.SinonStub;
+    let checkNoPythonStub: sinon.SinonStub;
+
+    setup(() => {
+        setCondaForGlobalStub = sinon.stub(condaUtils, 'setCondaForGlobal').resolves();
+        checkNoPythonStub = sinon.stub(condaUtils, 'checkForNoPythonCondaEnvironment');
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('set(undefined, env) updates globalEnv in memory', async () => {
+        const manager = createManager();
+        const oldEnv = makeEnv('base', '/miniconda3', '3.11.0');
+        const newEnv = makeEnv('myenv', '/miniconda3/envs/myenv', '3.12.0');
+        (manager as any).globalEnv = oldEnv;
+
+        // checkForNoPythonCondaEnvironment returns the env as-is (has Python)
+        checkNoPythonStub.resolves(newEnv);
+
+        await manager.set(undefined, newEnv);
+
+        // globalEnv should now be updated in memory
+        const result = await manager.get(undefined);
+        assert.strictEqual(result, newEnv, 'get(undefined) should return the newly set environment');
+        assert.notStrictEqual(result, oldEnv, 'get(undefined) should NOT return the old environment');
+    });
+
+    test('set(undefined, env) persists to disk', async () => {
+        const manager = createManager();
+        const newEnv = makeEnv('myenv', '/miniconda3/envs/myenv', '3.12.0');
+        checkNoPythonStub.resolves(newEnv);
+
+        await manager.set(undefined, newEnv);
+
+        assert.ok(setCondaForGlobalStub.calledOnce, 'setCondaForGlobal should be called');
+        assert.strictEqual(
+            setCondaForGlobalStub.firstCall.args[0],
+            newEnv.environmentPath.fsPath,
+            'should persist the correct path',
+        );
+    });
+
+    test('set(undefined, undefined) clears globalEnv', async () => {
+        const manager = createManager();
+        const oldEnv = makeEnv('base', '/miniconda3', '3.11.0');
+        (manager as any).globalEnv = oldEnv;
+
+        await manager.set(undefined, undefined);
+
+        const result = await manager.get(undefined);
+        assert.strictEqual(result, undefined, 'get(undefined) should return undefined after clearing');
+    });
+
+    test('set(undefined, noPythonEnv) where user declines install clears globalEnv', async () => {
+        const manager = createManager();
+        const oldEnv = makeEnv('base', '/miniconda3', '3.11.0');
+        const noPythonEnv = makeEnv('nopy', '/miniconda3/envs/nopy', 'no-python');
+        (manager as any).globalEnv = oldEnv;
+
+        // User declined to install Python
+        checkNoPythonStub.resolves(undefined);
+
+        await manager.set(undefined, noPythonEnv);
+
+        const result = await manager.get(undefined);
+        assert.strictEqual(result, undefined, 'globalEnv should be cleared when checkedEnv is undefined');
+    });
+});

--- a/src/test/mocks/pythonEnvironment.ts
+++ b/src/test/mocks/pythonEnvironment.ts
@@ -67,14 +67,12 @@ export function createMockPythonEnvironment(options: MockPythonEnvironmentOption
 }
 
 /**
- * Positional shorthand for {@link createMockPythonEnvironment} used by conda
- * manager unit tests. Prefer {@link createMockPythonEnvironment} for new tests
- * that need to customize additional fields.
+ * Positional shorthand for {@link createMockPythonEnvironment} that always
+ * creates a conda environment (`managerId` = `ms-python.python:conda`).
+ * Used by conda manager unit tests. Prefer {@link createMockPythonEnvironment}
+ * for new tests that need to customize additional fields or target a different
+ * manager.
  */
-export function makeMockPythonEnvironment(
-    name: string,
-    envPath: string,
-    version: string = '3.12.0',
-): PythonEnvironment {
+export function makeMockCondaEnvironment(name: string, envPath: string, version: string = '3.12.0'): PythonEnvironment {
     return createMockPythonEnvironment({ name, envPath, version });
 }

--- a/src/test/mocks/pythonEnvironment.ts
+++ b/src/test/mocks/pythonEnvironment.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Uri } from 'vscode';
+import { PythonEnvironment } from '../../api';
+import { PythonEnvironmentImpl } from '../../internal.api';
+
+/**
+ * Options for {@link createMockPythonEnvironment}.
+ */
+export interface MockPythonEnvironmentOptions {
+    /** Environment name, e.g. `myenv`. Defaults to `test-env`. */
+    name?: string;
+    /** Filesystem path for `environmentPath`, `displayPath`, and `sysPrefix`. */
+    envPath: string;
+    /** Version string. Defaults to `3.12.0`. */
+    version?: string;
+    /** Manager id. Defaults to `ms-python.python:conda`. */
+    managerId?: string;
+    /** Environment id. Defaults to `<name>-test`. */
+    id?: string;
+    /** Optional description. */
+    description?: string;
+    /** Optional display name. Defaults to `<name> (<version>)`. */
+    displayName?: string;
+    /** If true, includes an `activation` entry in `execInfo`. */
+    hasActivation?: boolean;
+}
+
+/**
+ * Create a minimal {@link PythonEnvironment} for use in unit tests.
+ *
+ * Shared across manager and view tests so they agree on the shape of a mock
+ * environment. Only fields that tests commonly need are populated; extend this
+ * helper if additional fields become required.
+ */
+export function createMockPythonEnvironment(options: MockPythonEnvironmentOptions): PythonEnvironment {
+    const {
+        name = 'test-env',
+        envPath,
+        version = '3.12.0',
+        managerId = 'ms-python.python:conda',
+        id = `${name}-test`,
+        description,
+        displayName = `${name} (${version})`,
+        hasActivation = false,
+    } = options;
+
+    return new PythonEnvironmentImpl(
+        { id, managerId },
+        {
+            name,
+            displayName,
+            displayPath: envPath,
+            version,
+            description,
+            environmentPath: Uri.file(envPath),
+            sysPrefix: envPath,
+            execInfo: {
+                run: { executable: 'python' },
+                ...(hasActivation && {
+                    activation: [{ executable: envPath.replace('python', 'activate') }],
+                }),
+            },
+        },
+    );
+}
+
+/**
+ * Positional shorthand for {@link createMockPythonEnvironment} used by conda
+ * manager unit tests. Prefer {@link createMockPythonEnvironment} for new tests
+ * that need to customize additional fields.
+ */
+export function makeMockPythonEnvironment(
+    name: string,
+    envPath: string,
+    version: string = '3.12.0',
+): PythonEnvironment {
+    return createMockPythonEnvironment({ name, envPath, version });
+}


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode-python-environments/issues/1454

## Bug

When a user selects a conda environment as the global Python interpreter, `CondaEnvManager.set(undefined, environment)` persists the selection to disk via `setCondaForGlobal()`, but never updates `this.globalEnv` in memory. Subsequent calls to `get(undefined)` return the stale old environment because `get()` returns `this.globalEnv` directly (line 305).

## Why it's a bug

The orchestrator's `getEnvironment()` method calls `manager.get(scope)`, which returns the in-memory `this.globalEnv`. Since the field is never updated after `set()`, the persisted selection is effectively invisible until VS Code is restarted (when `loadEnvMap` re-reads from persistent state). This causes the selection to appear to "revert" or "flicker" back to the previous environment.

## Repro steps

1. Open VS Code with no workspace folders (so the scope is global).
2. Select a conda environment as the Python interpreter.
3. The status bar briefly shows the new environment (from the orchestrator's event), but any subsequent query for the active environment returns the **old** environment.
4. The selection appears to revert on its own.

## Fix

Update `this.globalEnv` in memory before persisting to disk, matching the pattern already used by `venvManager.ts` (lines 407–414):

```ts
if (scope === undefined) {
    this.globalEnv = checkedEnv;
    await setCondaForGlobal(checkedEnv?.environmentPath?.fsPath);
}
```
Before:
![20260414-2047-47 0606257](https://github.com/user-attachments/assets/9273203a-3d1c-4f1f-b81d-508d75889467)

After:
![20260414-2046-10 3832185](https://github.com/user-attachments/assets/a2db4c2f-b3ff-4a02-87d4-a081acb569b0)


## Why this fix is correct

- The venv manager already uses this pattern and works correctly.
- The `checkedEnv` variable already accounts for no-python environments (it's `undefined` if the user declines Python installation), so setting `this.globalEnv = checkedEnv` correctly handles both the set and unset cases.
- No downstream code assumes `globalEnv` is only updated during initialization.

## Tests added

- `condaEnvManager.setGlobal.unit.test.ts`: 4 test cases covering set, persist, clear, and no-python decline scenarios.
