### PR TITLE
 Add GitHub issue templates (Bug Report, Feature Request, Question)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,85 @@
+---
+name: Bug Report
+about: Create a report to help us improve.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+Please search existing issues first to avoid creating duplicates:
+https://github.com/microsoft/vscode-python-environments/issues
+-->
+
+## Environment data
+
+<!--
+To find extension versions, open the VS Code Extensions panel and locate each
+extension from the list of installed extensions. The version appears next to the name.
+-->
+
+-   Python Environments extension version: XXX
+-   Python extension (`ms-python.python`) version: XXX
+-   VS Code version (Help → About): XXX
+-   OS and version: XXX
+-   Python version (& distribution if applicable, e.g. Anaconda): XXX
+-   Environment manager in use (`venv` / `conda` / `pyenv` / `poetry` / `pipenv` / `system` / `uv` / other): XXX
+-   Shell (bash / zsh / fish / pwsh / cmd / other): XXX
+-   Remote / container scenario (none / WSL / SSH Remote / Dev Container / Codespaces): XXX
+-   Workspace type (single folder / multi-root / mono-repo): XXX
+-   Is this a regression? If yes, last known working extension version: XXX
+
+## Repro Steps
+
+<!--
+Please list the minimal steps needed to reproduce the issue, starting from a fresh
+VS Code window when possible. If the issue only reproduces with specific workspace
+contents (e.g. a `pyproject.toml`, `.venv`, `environment.yml`, `Pipfile`, `poetry.lock`,
+`.python-version`), please share a minimal example or describe the layout.
+
+If the bug only reproduces with certain settings, please include the relevant entries
+from your `settings.json` (user and/or workspace).
+
+Note: If a GIF or screenshot would help, consider tools like
+https://github.com/vkohaupt/vokoscreenNG, https://www.cockos.com/licecap/,
+https://github.com/phw/peek or https://www.screentogif.com/ .
+-->
+
+1. XXX
+
+## Expected behavior
+
+XXX
+
+## Actual behavior
+
+XXX
+
+## Logs
+
+<!--
+Please include logs from the "Python Environments" output channel.
+
+To capture verbose logs:
+1. Open the Output panel (View → Output).
+2. Select "Python Environments" from the channel dropdown in the upper-right.
+3. Click the gear / filter icon at the top of the Output panel and set the level to "Trace".
+   (Alternatively: Command Palette → "Developer: Set Log Level…" → "Python Environments" → "Trace".)
+4. Reproduce the issue.
+5. Paste the relevant output below, or save it to a `.txt` file and attach it to the issue (preferred for long logs).
+
+If the issue is about terminal activation, please also paste the exact terminal
+output where the problem occurs.
+-->
+
+```
+XXX
+```
+
+## Additional context
+
+<!--
+Anything else that may help us reproduce: screenshots, videos, related issues,
+links to your project, workarounds you've tried, etc.
+-->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -40,10 +40,6 @@ contents (e.g. a `pyproject.toml`, `.venv`, `environment.yml`, `Pipfile`, `poetr
 
 If the bug only reproduces with certain settings, please include the relevant entries
 from your `settings.json` (user and/or workspace).
-
-Note: If a GIF or screenshot would help, consider tools like
-https://github.com/vkohaupt/vokoscreenNG, https://www.cockos.com/licecap/,
-https://github.com/phw/peek or https://www.screentogif.com/ .
 -->
 
 1. XXX

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,12 @@
+---
+name: Feature Request
+about: Suggest an idea for this project.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- Please search existing feature requests to avoid creating duplicates. -->
+
+<!-- Describe the feature you'd like. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,19 @@
+---
+name: Question
+about: Ask a question about this project.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+Please search existing issues to avoid creating duplicates.
+For general Python-in-VS-Code usage questions, consider starting a discussion at
+https://github.com/microsoft/vscode-python/discussions/categories/q-a
+or checking the issues in the following related repositories:
+- Python extension: https://github.com/microsoft/vscode-python/issues
+- Pylance: https://github.com/microsoft/pylance-release/issues
+- Jupyter: https://github.com/microsoft/vscode-jupyter/issues
+- Python Debugger: https://github.com/microsoft/vscode-python-debugger/issues
+-->


### PR DESCRIPTION
 ## What
 
 Adds an `.github/ISSUE_TEMPLATE/` folder with three Markdown templates so users filing issues from the repo's "New issue" page get a template chooser instead of a blank textarea:
 
 - **Bug Report** (`bug-report.md`)
 - **Feature Request** (`feature-request.md`)
 - **Question** (`question.md`)
 
 ## Why
 
 The repo currently has no issue templates, so every new issue starts from an empty body. Triage consistently spends extra round-trips asking for the same basics (extension version, OS, shell, active 
environment manager, remote vs. local, repro steps, logs). The new templates front-load that information and steer misfiled issues toward Discussions and sibling repos.
 
 ## Bug Report fields (and why they're there)
 
 Fields were chosen by reviewing recent and historical bug reports in this repo. Each one corresponds to information that has repeatedly blocked or slowed triage:
 
 | Field | Motivating issues |
 |---|---|
 | Python Environments ext version | Every report; needed for regression detection |
 | Python extension (`ms-python.python`) version | Version-skew between the two extensions |
 | VS Code version | Standard |
 | OS and version | Path / exec-policy bugs are OS-specific (#1180, #1181, #1182, #1341) |
 | Python version & distribution | Anaconda / system / Store Python behave differently |
 | Environment manager in use | Conda / poetry / pipenv / pyenv reports (#1454, #1180, #1182–1185, #1206) |
 | Shell | Activation bugs are shell-specific (#1325 bash, #1158 fish, #1341 PowerShell) |
 | Remote / container scenario | WSL / SSH / Dev Container / Codespaces reports (#1357, #1337, #1027) |
 | Workspace type | Multi-root / mono-repo is a distinct code path (#1039, #1099, #1145, #1200) |
 | Regression? last working version | Enables bisect for "this started recently" reports (#1124, #1325) |
 
 The Logs section directs users to the `"Python Environments"` `LogOutputChannel` (created in `src/extension.ts`) and the gear/filter icon in the Output panel to switch it to Trace — with the `Developer: 
Set Log Level…` command as an alternative — and suggests attaching long logs as `.txt` files.
 
 ## Feature Request & Question
 
 Kept intentionally minimal (matches Pylance). The Question template points users to [Discussions](https://github.com/microsoft/vscode-python/discussions/categories/q-a) and the sibling repos (Python, 
Pylance, Jupyter, Python Debugger) to deflect misfiled issues.
 
 ## Notes
 
 - No `config.yml` included — blank issues remain enabled, matching Pylance's setup. Happy to add one (with `blank_issues_enabled: false` and contact links) in a follow-up if preferred.
 - Templates only take effect once merged to the default branch. Preview before merging: `https://github.com/microsoft/vscode-python-environments/issues/new/choose?template=bug-report.md` on this branch.
 - No code changes; docs/repo-infra only.