### PR TITLE
fix: skip shell-integration wait for shells without SI support (fixes #1391)

### DIFF
--- a/src/features/terminal/utils.ts
+++ b/src/features/terminal/utils.ts
@@ -1,10 +1,13 @@
 import * as path from 'path';
 import { Disposable, env, tasks, Terminal, TerminalOptions, Uri } from 'vscode';
 import { PythonEnvironment, PythonProject, PythonProjectEnvironmentApi, PythonProjectGetterApi } from '../../api';
+import { traceVerbose } from '../../common/logging';
 import { timeout } from '../../common/utils/asyncUtils';
 import { createSimpleDebounce } from '../../common/utils/debounce';
 import { onDidChangeTerminalShellIntegration, onDidWriteTerminalData } from '../../common/window.apis';
 import { getConfiguration, getWorkspaceFolders } from '../../common/workspace.apis';
+import { identifyTerminalShell } from '../common/shellDetector';
+import { shellIntegrationSupportedShells } from './shells/common/shellUtils';
 
 export const SHELL_INTEGRATION_TIMEOUT = 500; // 0.5 seconds
 
@@ -24,10 +27,26 @@ export function getShellIntegrationTimeout(): number {
 }
 
 /**
- * Three conditions in a Promise.race:
- * 1. Timeout based on VS Code's terminal.integrated.shellIntegration.timeout setting
- * 2. Shell integration becoming available (window.onDidChangeTerminalShellIntegration event)
- * 3. Detection of common prompt patterns in terminal output
+ * Waits for shell integration to be ready on the given terminal, up to a timeout.
+ *
+ * Returns:
+ * - `true`  if shell integration is (or becomes) available.
+ * - `false` if the timeout is hit, a common prompt pattern is detected, the terminal
+ *           is undefined, or the shell is known not to support shell integration.
+ *
+ * Behavior:
+ * 1. Returns `true` immediately if `terminal.shellIntegration` is already set.
+ * 2. Returns `false` immediately when the shell type is identified and is NOT in
+ *    {@link shellIntegrationSupportedShells} (e.g. `nu`, `cmd`, `csh`, `tcsh`,
+ *    `ksh`, `xonsh`). VS Code does not provide shell integration for these
+ *    shells, so waiting up to 5s for an event that will never fire only delays
+ *    the fallback `terminal.sendText` activation.
+ *    If shell detection throws or returns `'unknown'`, we fall through to the
+ *    race below to preserve previous behavior.
+ * 3. Otherwise races three conditions:
+ *    a. Timeout based on VS Code's `terminal.integrated.shellIntegration.timeout` setting.
+ *    b. Shell integration becoming available (`window.onDidChangeTerminalShellIntegration`).
+ *    c. Detection of common prompt patterns in terminal output.
  */
 export async function waitForShellIntegration(terminal?: Terminal): Promise<boolean> {
     if (!terminal) {
@@ -35,6 +54,17 @@ export async function waitForShellIntegration(terminal?: Terminal): Promise<bool
     }
     if (terminal.shellIntegration) {
         return true;
+    }
+
+    // Skip the wait for shells that VS Code does not provide shell integration for.
+    try {
+        const shellType = identifyTerminalShell(terminal);
+        if (shellType !== 'unknown' && !shellIntegrationSupportedShells.includes(shellType)) {
+            traceVerbose(`Shell '${shellType}' does not support shell integration; skipping wait.`);
+            return false;
+        }
+    } catch {
+        // Detection failed — preserve original behavior by falling through to the race.
     }
 
     const timeoutMs = getShellIntegrationTimeout();

--- a/src/test/features/terminal/utils.unit.test.ts
+++ b/src/test/features/terminal/utils.unit.test.ts
@@ -1,6 +1,9 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import { Terminal } from 'vscode';
+import * as windowApis from '../../../common/window.apis';
 import * as workspaceApis from '../../../common/workspace.apis';
+import * as shellDetector from '../../../features/common/shellDetector';
 import {
     ACT_TYPE_COMMAND,
     ACT_TYPE_OFF,
@@ -8,6 +11,7 @@ import {
     AutoActivationType,
     getAutoActivationType,
     shouldActivateInCurrentTerminal,
+    waitForShellIntegration,
 } from '../../../features/terminal/utils';
 
 interface MockWorkspaceConfig {
@@ -543,5 +547,156 @@ suite('Terminal Utils - shouldActivateInCurrentTerminal', () => {
             false,
             'Any explicit false at any scope should return false, regardless of higher-precedence true values',
         );
+    });
+});
+
+suite('Terminal Utils - waitForShellIntegration', () => {
+    let mockGetConfiguration: sinon.SinonStub;
+    let identifyTerminalShellStub: sinon.SinonStub;
+    let onDidChangeTerminalShellIntegrationStub: sinon.SinonStub;
+    let onDidWriteTerminalDataStub: sinon.SinonStub;
+
+    function setupLongTimeoutConfig() {
+        // Make the timeout effectively infinite so tests resolve via the listener,
+        // not the timer. Avoids flakiness while keeping the race code paths exercised.
+        const config = {
+            get: sinon.stub(),
+            inspect: sinon.stub(),
+            update: sinon.stub(),
+        };
+        config.get.withArgs('shellIntegration.timeout').returns(60_000);
+        config.get.withArgs('shellIntegration.enabled', true).returns(true);
+        mockGetConfiguration.withArgs('terminal.integrated').returns(config);
+    }
+
+    setup(() => {
+        mockGetConfiguration = sinon.stub(workspaceApis, 'getConfiguration');
+        identifyTerminalShellStub = sinon.stub(shellDetector, 'identifyTerminalShell');
+        onDidChangeTerminalShellIntegrationStub = sinon.stub(windowApis, 'onDidChangeTerminalShellIntegration');
+        onDidWriteTerminalDataStub = sinon.stub(windowApis, 'onDidWriteTerminalData');
+
+        // Default: dispose-only fake event registrations. Tests that need to fire
+        // events override these via .callsFake.
+        const fakeDisposable = { dispose: () => undefined };
+        onDidChangeTerminalShellIntegrationStub.returns(fakeDisposable);
+        onDidWriteTerminalDataStub.returns(fakeDisposable);
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('returns false immediately when terminal is undefined', async () => {
+        const result = await waitForShellIntegration(undefined);
+
+        assert.strictEqual(result, false);
+        sinon.assert.notCalled(identifyTerminalShellStub);
+        sinon.assert.notCalled(onDidChangeTerminalShellIntegrationStub);
+    });
+
+    test('returns true immediately when terminal.shellIntegration is already set', async () => {
+        const terminal = { shellIntegration: {} } as unknown as Terminal;
+
+        const result = await waitForShellIntegration(terminal);
+
+        assert.strictEqual(result, true);
+        sinon.assert.notCalled(identifyTerminalShellStub);
+        sinon.assert.notCalled(onDidChangeTerminalShellIntegrationStub);
+    });
+
+    test('returns false immediately for nu without registering event listeners', async () => {
+        const terminal = {} as Terminal;
+        identifyTerminalShellStub.returns('nu');
+
+        const result = await waitForShellIntegration(terminal);
+
+        assert.strictEqual(result, false);
+        sinon.assert.calledOnce(identifyTerminalShellStub);
+        sinon.assert.notCalled(onDidChangeTerminalShellIntegrationStub);
+        sinon.assert.notCalled(onDidWriteTerminalDataStub);
+    });
+
+    test('returns false immediately for cmd', async () => {
+        const terminal = {} as Terminal;
+        identifyTerminalShellStub.returns('cmd');
+
+        const result = await waitForShellIntegration(terminal);
+
+        assert.strictEqual(result, false);
+        sinon.assert.notCalled(onDidChangeTerminalShellIntegrationStub);
+    });
+
+    test('returns false immediately for csh / tcsh / ksh / xonsh', async () => {
+        const unsupported = ['csh', 'tcsh', 'ksh', 'xonsh'];
+        for (const shell of unsupported) {
+            identifyTerminalShellStub.resetHistory();
+            identifyTerminalShellStub.returns(shell);
+            onDidChangeTerminalShellIntegrationStub.resetHistory();
+
+            const result = await waitForShellIntegration({} as Terminal);
+
+            assert.strictEqual(result, false, `expected false for shell '${shell}'`);
+            sinon.assert.notCalled(onDidChangeTerminalShellIntegrationStub);
+        }
+    });
+
+    test('falls through to event race for bash (supported shell)', async () => {
+        setupLongTimeoutConfig();
+        const terminal = {} as Terminal;
+        identifyTerminalShellStub.returns('bash');
+
+        let listenerRef: ((e: { terminal: Terminal }) => void) | undefined;
+        onDidChangeTerminalShellIntegrationStub.callsFake((listener: (e: { terminal: Terminal }) => void) => {
+            listenerRef = listener;
+            return { dispose: () => undefined };
+        });
+
+        const racePromise = waitForShellIntegration(terminal);
+        // Yield once so the Promise.race body has a chance to register listeners.
+        await new Promise<void>((r) => setImmediate(r));
+        assert.ok(listenerRef, 'shell integration listener should be registered');
+        listenerRef!({ terminal });
+
+        const result = await racePromise;
+        assert.strictEqual(result, true);
+        sinon.assert.calledOnce(onDidChangeTerminalShellIntegrationStub);
+    });
+
+    test('falls through to event race when shell type is unknown', async () => {
+        setupLongTimeoutConfig();
+        const terminal = {} as Terminal;
+        identifyTerminalShellStub.returns('unknown');
+
+        let listenerRef: ((e: { terminal: Terminal }) => void) | undefined;
+        onDidChangeTerminalShellIntegrationStub.callsFake((listener: (e: { terminal: Terminal }) => void) => {
+            listenerRef = listener;
+            return { dispose: () => undefined };
+        });
+
+        const racePromise = waitForShellIntegration(terminal);
+        await new Promise<void>((r) => setImmediate(r));
+        listenerRef!({ terminal });
+
+        const result = await racePromise;
+        assert.strictEqual(result, true);
+    });
+
+    test('falls through to event race when identifyTerminalShell throws', async () => {
+        setupLongTimeoutConfig();
+        const terminal = {} as Terminal;
+        identifyTerminalShellStub.throws(new Error('detection failed'));
+
+        let listenerRef: ((e: { terminal: Terminal }) => void) | undefined;
+        onDidChangeTerminalShellIntegrationStub.callsFake((listener: (e: { terminal: Terminal }) => void) => {
+            listenerRef = listener;
+            return { dispose: () => undefined };
+        });
+
+        const racePromise = waitForShellIntegration(terminal);
+        await new Promise<void>((r) => setImmediate(r));
+        listenerRef!({ terminal });
+
+        const result = await racePromise;
+        assert.strictEqual(result, true, 'should not regress when detection throws');
     });
 });


### PR DESCRIPTION
## Summary

Fixes #1391 — terminal activation is slow on nushell (and any other shell VS Code doesn't provide shell integration for).

When a Python terminal opens in `command` activation mode, `waitForShellIntegration()` is awaited before sending the activation command. For shells VS Code does **not** provide shell integration for — `nu`, `cmd`, `csh`, `tcsh`, `ksh`, `xonsh` — the `onDidChangeTerminalShellIntegration` event never fires, the prompt-pattern heuristic is unreliable, and the wait runs out the full 5 s default timeout (per `getShellIntegrationTimeout()` when `terminal.integrated.shellIntegration.enabled` is true). Once the wait completes, activation falls back to `terminal.sendText` anyway — so the delay is pure overhead and visibly disrupts the user's typing in the new terminal.

## Root cause

`waitForShellIntegration()` in [`src/features/terminal/utils.ts`](src/features/terminal/utils.ts) doesn't consult the codebase's existing source of truth for SI-capable shells (`shellIntegrationSupportedShells` in [`src/features/terminal/shells/common/shellUtils.ts`](src/features/terminal/shells/common/shellUtils.ts)). For `nu`, that means it always times out.

## Fix

After the existing `terminal.shellIntegration` early-return in `waitForShellIntegration`, identify the shell via `identifyTerminalShell()` and return `false` immediately when the shell type is known and **not** in `shellIntegrationSupportedShells`. Wrapped in `try/catch` so any detection failure (or `'unknown'` result) falls through to the existing `Promise.race` body — strictly additive: best case faster, worst case identical to today.

This:

- Reuses the codebase's single source of truth (`shellIntegrationSupportedShells`), so adding a new SI-capable shell automatically benefits both this code and `shouldUseProfileActivation`.
- Returns the same value (`false`) the function would have eventually returned — semantics unchanged for all callers, only latency differs.
- Preserves all existing behavior for supported shells (`pwsh`, `bash`, `gitbash`, `fish`, `zsh`).
- Defensive `try/catch` and explicit `'unknown'` check make the change non-regressing even if shell detection fails.

For nu users, this turns the ~5 s freeze before `overlay use ...activate.nu` runs into an imperceptible delay.

## Testing

### Manual

On `main` with `nu` configured as default profile and `python-envs.terminal.autoActivationType: "command"`:
- Open new terminal → ~5 s gap between prompt appearing and activation command running.

On this branch, same setup:
- Open new terminal → activation command runs immediately after the prompt.
- `Python Environments` output channel logs: `Shell 'nu' does not support shell integration; skipping wait.`

Verified the fix does **not** alter behavior for `pwsh` / `bash` (they still wait for SI to come up, which they do quickly).

### Automated

8 new unit tests in `Terminal Utils - waitForShellIntegration` cover:

- `undefined` terminal → `false` immediately
- `terminal.shellIntegration` already set → `true` immediately, no shell detection
- `nu` → `false` immediately, no event listeners registered
- `cmd` → `false` immediately
- `csh` / `tcsh` / `ksh` / `xonsh` → all `false` immediately
- `bash` → falls through to event race, resolves `true` when SI event fires
- `unknown` shell → falls through to race
- `identifyTerminalShell` throws → falls through to race (defensive)

```
npm run lint           # clean
npm run compile-tests  # clean
npm run unittest       # 992 passing (including the 8 new tests), 2 pending
```

## Related

- #997 — original "Virtual environment activation is slow" tracking issue, where the maintainer explicitly noted: *"In case shell does not support dynamic evals like `nu`, it will fall back to command activation."* This PR makes that command-activation fallback fast.

## Risk

Low. Fully covered by tests. The change is gated by `try/catch` and an explicit allow-list, so the worst case (detection fails or returns `'unknown'`) is identical to current behavior.
