### PR TITLE
feat: add triggerReason to pet.process_restart and globalScopeDeferred to setup.hang_detected

### DIFF
--- a/src/common/telemetry/constants.ts
+++ b/src/common/telemetry/constants.ts
@@ -391,12 +391,15 @@ export interface IEventNamePropertyMapping {
     /* __GDPR__
         "setup.hang_detected": {
             "failureStage": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "StellaHuang95" },
+            "globalScopeDeferred": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
             "<duration>": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
             "<stageDuration>": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" }
         }
     */
     [EventNames.SETUP_HANG_DETECTED]: {
         failureStage: string;
+        /** Whether the global Python scope search was deferred to background at time of hang. undefined = hang fired before env-selection stage. */
+        globalScopeDeferred: boolean | undefined;
     };
 
     /* __GDPR__
@@ -549,6 +552,7 @@ export interface IEventNamePropertyMapping {
             "attempt": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
             "result": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
             "errorType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "triggerReason": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
             "<duration>": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" }
         }
     */
@@ -556,6 +560,8 @@ export interface IEventNamePropertyMapping {
         attempt: number;
         result: 'success' | 'error';
         errorType?: string;
+        /** Why the PET process needed restarting: process_exit:<code>:<signal>, process_error, rpc_connection_error, rpc_refresh_timeout, rpc_resolve_timeout, rpc_configure_timeout, start_failed, or unknown */
+        triggerReason: string;
     };
 
     /* __GDPR__

--- a/src/common/telemetry/constants.ts
+++ b/src/common/telemetry/constants.ts
@@ -518,6 +518,11 @@ export interface IEventNamePropertyMapping {
             "searchPathCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
             "attempt": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
             "errorType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "breakdownLocators": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "owner": "eleanorjboyd" },
+            "breakdownPath": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "owner": "eleanorjboyd" },
+            "breakdownGlobalVirtualEnvs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "owner": "eleanorjboyd" },
+            "breakdownWorkspaces": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "owner": "eleanorjboyd" },
+            "locatorsJson": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "owner": "eleanorjboyd" },
             "<duration>": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" }
         }
     */
@@ -529,6 +534,16 @@ export interface IEventNamePropertyMapping {
         searchPathCount?: number;
         attempt: number;
         errorType?: string;
+        /** ms spent in the Locators phase (runs locator plugins). From PET RefreshPerformance.breakdown. */
+        breakdownLocators?: number;
+        /** ms spent walking PATH entries. From PET RefreshPerformance.breakdown. */
+        breakdownPath?: number;
+        /** ms spent scanning global virtual-env dirs. From PET RefreshPerformance.breakdown. */
+        breakdownGlobalVirtualEnvs?: number;
+        /** ms spent scanning workspace dirs. From PET RefreshPerformance.breakdown. */
+        breakdownWorkspaces?: number;
+        /** JSON-serialized Record<locatorName, ms>. Query with parse_json() in Kusto. From PET RefreshPerformance.locators. */
+        locatorsJson?: string;
     };
 
     /* __GDPR__

--- a/src/common/telemetry/constants.ts
+++ b/src/common/telemetry/constants.ts
@@ -60,11 +60,12 @@ export enum EventNames {
      */
     MANAGER_REGISTRATION_FAILED = 'MANAGER_REGISTRATION.FAILED',
     /**
-     * Telemetry event fired when the setup block appears to be hung.
-     * A watchdog timer fires after a deadline; if the setup completes normally,
-     * the timer is cancelled and this event never fires.
+     * Watchdog event fired when setup appears hung. Cancelled if setup completes normally.
      * Properties:
-     * - failureStage: string (which phase was in progress when the watchdog fired)
+     * - failureStage: which phase was in progress when the watchdog fired
+     * - globalScopeDeferred: distinguishes a real foreground hang from the benign 120s
+     *   background global-scope scan. String union (not boolean) because the sender drops
+     *   undefined. Values: 'deferred' | 'not_deferred' | 'unknown'.
      * Measures:
      * - duration: total elapsed since activation
      * - stageDuration: elapsed in the current stage
@@ -87,12 +88,11 @@ export enum EventNames {
      */
     PET_INIT_DURATION = 'PET.INIT_DURATION',
     /**
-     * Telemetry event fired once per activation reporting the version of the bundled
-     * PET (Python Environment Tools) binary in use. Used to slice other PET telemetry
-     * by binary version when investigating regressions/improvements.
+     * Fired once per activation. Lets us slice every other PET event by which binary
+     * version was running — important since PET evolves independently of the extension.
      * Properties:
-     * - version: string (e.g. '0.1.0' from `pet --version`; 'unknown' if the lookup failed)
-     * - source: 'envs_extension' | 'python_extension' (which extension shipped the binary)
+     * - version: output of `pet --version` (e.g. '0.1.0'), or 'unknown' on failure/timeout
+     * - source: 'envs_extension' | 'python_extension' — which extension shipped the binary
      */
     PET_VERSION = 'PET.VERSION',
     /**
@@ -155,12 +155,16 @@ export enum EventNames {
      * Telemetry event for a PET refresh attempt (the core discovery RPC call).
      * Properties:
      * - result: 'success' | 'timeout' | 'error'
-     * - envCount: number (environments returned via notifications)
-     * - unresolvedCount: number (envs that needed follow-up resolve calls)
-     * - workspaceDirCount: number (workspace directories sent in configure)
-     * - searchPathCount: number (extra search paths sent in configure)
-     * - attempt: number (0 = first try, 1 = retry)
-     * - errorType: string (classified error category, on failure only)
+     * - envCount, unresolvedCount, workspaceDirCount, searchPathCount: number
+     * - attempt: 0 = first try, 1 = retry
+     * - errorType: classified error category, on failure only
+     * - locatorsJson: JSON-serialized Record<locatorName, ms>. Locator set is platform-dependent
+     *   so a flat blob is more practical than a fixed schema. Parse with parse_json() in Kusto.
+     * Measures (numeric; phases run in parallel so sum may exceed total wall-clock):
+     * - breakdownLocators: ms in locator plugins
+     * - breakdownPathEnv: ms scanning PATH env var entries (not a file path)
+     * - breakdownGlobalVirtualEnvs: ms scanning global virtualenv dirs
+     * - breakdownWorkspaces: ms scanning workspace dirs
      */
     PET_REFRESH = 'PET.REFRESH',
     /**
@@ -175,9 +179,15 @@ export enum EventNames {
     /**
      * Telemetry event for PET process restart attempts.
      * Properties:
-     * - attempt: number (1-based restart attempt number)
+     * - attempt: 1-based restart attempt number
      * - result: 'success' | 'error'
-     * - errorType: string (classified error category, on failure only)
+     * - errorType: classified error category, on failure only
+     * - triggerReason: why the restart was needed (lets us separate crashes from
+     *   timeout-induced kills; the most specific reason wins — rpc_* recorded before a
+     *   kill is not overwritten by the subsequent exit event). Values:
+     *     rpc_connection_error | rpc_resolve_timeout | rpc_refresh_timeout |
+     *     rpc_configure_timeout | process_exit:<code>:<signal> | process_error |
+     *     start_failed | unknown
      */
     PET_PROCESS_RESTART = 'PET.PROCESS_RESTART',
     /**
@@ -408,11 +418,10 @@ export interface IEventNamePropertyMapping {
     [EventNames.SETUP_HANG_DETECTED]: {
         failureStage: string;
         /**
-         * State of the global Python scope search at the time of hang:
-         * - 'deferred': workspace env resolved and global scope was pushed to background.
-         * - 'not_deferred': no workspace env resolved, global scope was awaited as primary fallback.
-         * - 'unknown': hang fired before the env-selection stage reached the global-scope decision
-         *   (i.e. before/during env selection, prior to the workspace-resolution branch).
+         * Distinguishes a real foreground hang from the benign 120s background global-scope scan.
+         * - 'deferred':     workspace env resolved; global scope ran in background.
+         * - 'not_deferred': no workspace env; global scope was awaited as primary fallback.
+         * - 'unknown':      hang fired before env-selection reached the global-scope decision.
          */
         globalScopeDeferred: 'deferred' | 'not_deferred' | 'unknown';
     };
@@ -547,7 +556,7 @@ export interface IEventNamePropertyMapping {
             "attempt": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
             "errorType": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
             "breakdownLocators": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "owner": "eleanorjboyd" },
-            "breakdownPath": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "owner": "eleanorjboyd" },
+            "breakdownPathEnv": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "owner": "eleanorjboyd" },
             "breakdownGlobalVirtualEnvs": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "owner": "eleanorjboyd" },
             "breakdownWorkspaces": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "owner": "eleanorjboyd" },
             "locatorsJson": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "owner": "eleanorjboyd" },
@@ -562,15 +571,16 @@ export interface IEventNamePropertyMapping {
         searchPathCount?: number;
         attempt: number;
         errorType?: string;
-        /** ms spent in the Locators phase (runs locator plugins). From PET RefreshPerformance.breakdown. */
+        // breakdown* fields go through the measures payload (numeric); listed here for GDPR only.
+        /** ms in the Locators phase. */
         breakdownLocators?: number;
-        /** ms spent walking PATH entries. From PET RefreshPerformance.breakdown. */
-        breakdownPath?: number;
-        /** ms spent scanning global virtual-env dirs. From PET RefreshPerformance.breakdown. */
+        /** ms walking PATH env var entries (not a file path). */
+        breakdownPathEnv?: number;
+        /** ms scanning global virtual-env dirs. */
         breakdownGlobalVirtualEnvs?: number;
-        /** ms spent scanning workspace dirs. From PET RefreshPerformance.breakdown. */
+        /** ms scanning workspace dirs. */
         breakdownWorkspaces?: number;
-        /** JSON-serialized Record<locatorName, ms>. Query with parse_json() in Kusto. From PET RefreshPerformance.locators. */
+        /** JSON-serialized Record<locatorName, ms>. Parse with parse_json() in Kusto. */
         locatorsJson?: string;
     };
 
@@ -603,7 +613,13 @@ export interface IEventNamePropertyMapping {
         attempt: number;
         result: 'success' | 'error';
         errorType?: string;
-        /** Why the PET process needed restarting: process_exit:<code>:<signal>, process_error, rpc_connection_error, rpc_refresh_timeout, rpc_resolve_timeout, rpc_configure_timeout, start_failed, or unknown */
+        /**
+         * Why the restart was needed. The most specific reason wins (an rpc_* value recorded
+         * before the kill is not overwritten by the subsequent exit/error event).
+         * Values: rpc_connection_error | rpc_resolve_timeout | rpc_refresh_timeout |
+         * rpc_configure_timeout | process_exit:<code>:<signal> | process_error |
+         * start_failed | unknown.
+         */
         triggerReason: string;
     };
 

--- a/src/common/telemetry/constants.ts
+++ b/src/common/telemetry/constants.ts
@@ -87,6 +87,15 @@ export enum EventNames {
      */
     PET_INIT_DURATION = 'PET.INIT_DURATION',
     /**
+     * Telemetry event fired once per activation reporting the version of the bundled
+     * PET (Python Environment Tools) binary in use. Used to slice other PET telemetry
+     * by binary version when investigating regressions/improvements.
+     * Properties:
+     * - version: string (e.g. '0.1.0' from `pet --version`; 'unknown' if the lookup failed)
+     * - source: 'envs_extension' | 'python_extension' (which extension shipped the binary)
+     */
+    PET_VERSION = 'PET.VERSION',
+    /**
      * Telemetry event fired when applyInitialEnvironmentSelection begins.
      * Signals that all managers are registered and env selection is starting.
      * Properties:
@@ -398,8 +407,14 @@ export interface IEventNamePropertyMapping {
     */
     [EventNames.SETUP_HANG_DETECTED]: {
         failureStage: string;
-        /** Whether the global Python scope search was deferred to background at time of hang. undefined = hang fired before env-selection stage. */
-        globalScopeDeferred: boolean | undefined;
+        /**
+         * State of the global Python scope search at the time of hang:
+         * - 'deferred': workspace env resolved and global scope was pushed to background.
+         * - 'not_deferred': no workspace env resolved, global scope was awaited as primary fallback.
+         * - 'unknown': hang fired before the env-selection stage reached the global-scope decision
+         *   (i.e. before/during env selection, prior to the workspace-resolution branch).
+         */
+        globalScopeDeferred: 'deferred' | 'not_deferred' | 'unknown';
     };
 
     /* __GDPR__
@@ -423,6 +438,19 @@ export interface IEventNamePropertyMapping {
     [EventNames.PET_INIT_DURATION]: {
         result: 'success' | 'error' | 'timeout';
         errorType?: string;
+    };
+
+    /* __GDPR__
+        "pet.version": {
+            "version": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
+            "source": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" }
+        }
+    */
+    [EventNames.PET_VERSION]: {
+        /** Version string reported by `pet --version` (e.g. '0.1.0'), or 'unknown' if the lookup failed. */
+        version: string;
+        /** Which extension shipped the PET binary that's being used. */
+        source: 'envs_extension' | 'python_extension';
     };
 
     /* __GDPR__

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -553,6 +553,9 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
     setImmediate(async () => {
         let failureStage = 'nativeFinder';
         const stageWatch = new StopWatch();
+        // Mutable ref so the hang watchdog can report whether global scope was deferred
+        // even if it fires mid-envSelection before applyInitialEnvironmentSelection returns.
+        const globalScopeDeferredRef: { value: boolean | undefined } = { value: undefined };
         // Watchdog: fires if setup hasn't completed within 120s, indicating a likely hang
         const SETUP_HANG_TIMEOUT_MS = 120_000;
         let hangWatchdogActive = true;
@@ -572,7 +575,7 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
             sendTelemetryEvent(
                 EventNames.SETUP_HANG_DETECTED,
                 { duration: start.elapsedTime, stageDuration: stageWatch.elapsedTime },
-                { failureStage },
+                { failureStage, globalScopeDeferred: globalScopeDeferredRef.value },
             );
         }, SETUP_HANG_TIMEOUT_MS);
         context.subscriptions.push({ dispose: clearHangWatchdog });
@@ -618,7 +621,14 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
 
             failureStage = 'envSelection';
             stageWatch.reset();
-            await applyInitialEnvironmentSelection(envManagers, projectManager, nativeFinder, api, start.elapsedTime);
+            await applyInitialEnvironmentSelection(
+                envManagers,
+                projectManager,
+                nativeFinder,
+                api,
+                start.elapsedTime,
+                globalScopeDeferredRef,
+            );
 
             // Register manager-agnostic terminal watcher for package-modifying commands
             failureStage = 'terminalWatcher';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,7 +96,12 @@ import { collectEnvironmentInfo, getEnvManagerAndPackageManagerConfigLevels, run
 import { EnvironmentManagers, ProjectCreators, PythonProjectManager } from './internal.api';
 import { registerSystemPythonFeatures } from './managers/builtin/main';
 import { SysPythonManager } from './managers/builtin/sysPythonManager';
-import { createNativePythonFinder, NativePythonFinder } from './managers/common/nativePythonFinder';
+import {
+    createNativePythonFinder,
+    getNativePythonToolsPathAndSource,
+    getNativePythonToolsVersion,
+    NativePythonFinder,
+} from './managers/common/nativePythonFinder';
 import { IDisposable } from './managers/common/types';
 import { registerCondaFeatures } from './managers/conda/main';
 import { registerPipenvFeatures } from './managers/pipenv/main';
@@ -555,7 +560,7 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
         const stageWatch = new StopWatch();
         // Mutable ref so the hang watchdog can report whether global scope was deferred
         // even if it fires mid-envSelection before applyInitialEnvironmentSelection returns.
-        const globalScopeDeferredRef: { value: boolean | undefined } = { value: undefined };
+        const globalScopeDeferredRef: { value: 'deferred' | 'not_deferred' | 'unknown' } = { value: 'unknown' };
         // Watchdog: fires if setup hasn't completed within 120s, indicating a likely hang
         const SETUP_HANG_TIMEOUT_MS = 120_000;
         let hangWatchdogActive = true;
@@ -586,6 +591,19 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
             try {
                 nativeFinder = await createNativePythonFinder(outputChannel, api, context);
                 sendTelemetryEvent(EventNames.PET_INIT_DURATION, petStart.elapsedTime, { result: 'success' });
+                // Fire-and-forget: report the bundled PET binary version so other PET telemetry
+                // can be sliced by version. Don't block activation on this.
+                void getNativePythonToolsPathAndSource()
+                    .then(async ({ toolPath, source }) => {
+                        const version = await getNativePythonToolsVersion(toolPath);
+                        sendTelemetryEvent(EventNames.PET_VERSION, undefined, { version, source });
+                    })
+                    .catch(() => {
+                        sendTelemetryEvent(EventNames.PET_VERSION, undefined, {
+                            version: 'unknown',
+                            source: 'python_extension',
+                        });
+                    });
             } catch (petError) {
                 sendTelemetryEvent(
                     EventNames.PET_INIT_DURATION,

--- a/src/features/interpreterSelection.ts
+++ b/src/features/interpreterSelection.ts
@@ -284,6 +284,7 @@ export async function applyInitialEnvironmentSelection(
     nativeFinder: NativePythonFinder,
     api: PythonEnvironmentApi,
     activationToReadyDurationMs?: number,
+    globalScopeDeferredRef?: { value: boolean | undefined },
 ): Promise<void> {
     const folders = getWorkspaceFolders() ?? [];
     traceInfo(
@@ -377,6 +378,9 @@ export async function applyInitialEnvironmentSelection(
     if (workspaceFolderResolved) {
         // Defer global scope so it doesn't block post-selection startup.
         traceInfo('[interpreterSelection] Workspace env resolved, deferring global scope to background');
+        if (globalScopeDeferredRef) {
+            globalScopeDeferredRef.value = true;
+        }
         resolveGlobalScope()
             .then(async (globalErrors) => {
                 if (globalErrors.length > 0) {
@@ -386,6 +390,9 @@ export async function applyInitialEnvironmentSelection(
             .catch((err) => traceError(`[interpreterSelection] Background global scope resolution failed: ${err}`));
     } else {
         // No workspace folder resolved — global scope is the primary fallback, must await.
+        if (globalScopeDeferredRef) {
+            globalScopeDeferredRef.value = false;
+        }
         const globalErrors = await resolveGlobalScope();
         allErrors.push(...globalErrors);
     }

--- a/src/features/interpreterSelection.ts
+++ b/src/features/interpreterSelection.ts
@@ -284,7 +284,7 @@ export async function applyInitialEnvironmentSelection(
     nativeFinder: NativePythonFinder,
     api: PythonEnvironmentApi,
     activationToReadyDurationMs?: number,
-    globalScopeDeferredRef?: { value: boolean | undefined },
+    globalScopeDeferredRef?: { value: 'deferred' | 'not_deferred' | 'unknown' },
 ): Promise<void> {
     const folders = getWorkspaceFolders() ?? [];
     traceInfo(
@@ -379,7 +379,7 @@ export async function applyInitialEnvironmentSelection(
         // Defer global scope so it doesn't block post-selection startup.
         traceInfo('[interpreterSelection] Workspace env resolved, deferring global scope to background');
         if (globalScopeDeferredRef) {
-            globalScopeDeferredRef.value = true;
+            globalScopeDeferredRef.value = 'deferred';
         }
         resolveGlobalScope()
             .then(async (globalErrors) => {
@@ -391,7 +391,7 @@ export async function applyInitialEnvironmentSelection(
     } else {
         // No workspace folder resolved — global scope is the primary fallback, must await.
         if (globalScopeDeferredRef) {
-            globalScopeDeferredRef.value = false;
+            globalScopeDeferredRef.value = 'not_deferred';
         }
         const globalErrors = await resolveGlobalScope();
         allErrors.push(...globalErrors);

--- a/src/managers/common/nativePythonFinder.ts
+++ b/src/managers/common/nativePythonFinder.ts
@@ -237,6 +237,7 @@ class NativePythonFinderImpl implements NativePythonFinder {
     private startFailed: boolean = false;
     private restartAttempts: number = 0;
     private isRestarting: boolean = false;
+    private processExitReason: string | undefined = undefined;
     private readonly configureRetry = new ConfigureRetryState();
 
     constructor(
@@ -279,6 +280,8 @@ class NativePythonFinderImpl implements NativePythonFinder {
                     this.outputChannel.warn(`[pet] Resolve request ${reason}, killing process for restart`);
                     this.killProcess();
                     this.processExited = true;
+                    this.processExitReason =
+                        ex instanceof rpc.ConnectionError ? 'rpc_connection_error' : 'rpc_resolve_timeout';
                 }
                 throw ex;
             }
@@ -339,6 +342,7 @@ class NativePythonFinderImpl implements NativePythonFinder {
         this.isRestarting = true;
         this.restartAttempts++;
         const attempt = this.restartAttempts;
+        const triggerReason = this.processExitReason ?? (this.startFailed ? 'start_failed' : 'unknown');
 
         const backoffMs = RESTART_BACKOFF_BASE_MS * Math.pow(2, this.restartAttempts - 1);
         this.outputChannel.warn(
@@ -361,6 +365,7 @@ class NativePythonFinderImpl implements NativePythonFinder {
             // Reset state flags
             this.processExited = false;
             this.startFailed = false;
+            this.processExitReason = undefined;
             this.lastConfiguration = undefined; // Force reconfiguration
             this.configureRetry.reset();
 
@@ -368,7 +373,11 @@ class NativePythonFinderImpl implements NativePythonFinder {
             this.connection = this.start();
 
             this.outputChannel.info('[pet] Python Environment Tools restarted successfully');
-            sendTelemetryEvent(EventNames.PET_PROCESS_RESTART, sw.elapsedTime, { attempt, result: 'success' });
+            sendTelemetryEvent(EventNames.PET_PROCESS_RESTART, sw.elapsedTime, {
+                attempt,
+                result: 'success',
+                triggerReason,
+            });
 
             // Reset restart attempts on successful start (process didn't immediately fail)
             // We'll reset this only after a successful request completes
@@ -376,7 +385,7 @@ class NativePythonFinderImpl implements NativePythonFinder {
             sendTelemetryEvent(
                 EventNames.PET_PROCESS_RESTART,
                 sw.elapsedTime,
-                { attempt, result: 'error', errorType: classifyError(ex) },
+                { attempt, result: 'error', errorType: classifyError(ex), triggerReason },
                 ex instanceof Error ? ex : undefined,
             );
             this.outputChannel.error('[pet] Failed to restart Python Environment Tools:', ex);
@@ -520,15 +529,19 @@ class NativePythonFinderImpl implements NativePythonFinder {
             this.proc.on('exit', (code, signal) => {
                 this.processExited = true;
                 if (code !== 0) {
+                    this.processExitReason = `process_exit:${code ?? 'null'}:${signal ?? 'none'}`;
                     this.outputChannel.error(
                         `[pet] Python Environment Tools exited unexpectedly with code ${code}, signal ${signal}`,
                     );
+                } else {
+                    this.processExitReason = 'process_exit:0';
                 }
             });
 
             // Handle process errors (e.g., ENOENT if executable not found)
             this.proc.on('error', (err) => {
                 this.processExited = true;
+                this.processExitReason = 'process_error';
                 this.outputChannel.error('[pet] Process error:', err);
             });
 
@@ -626,6 +639,8 @@ class NativePythonFinderImpl implements NativePythonFinder {
                         // Kill and restart for retry
                         this.killProcess();
                         this.processExited = true;
+                        this.processExitReason =
+                            ex instanceof rpc.ConnectionError ? 'rpc_connection_error' : 'rpc_refresh_timeout';
                         continue;
                     }
                     // Final attempt failed
@@ -737,6 +752,8 @@ class NativePythonFinderImpl implements NativePythonFinder {
                 this.outputChannel.warn(`[pet] PET process ${reason}, killing for restart`);
                 this.killProcess();
                 this.processExited = true;
+                this.processExitReason =
+                    ex instanceof rpc.ConnectionError ? 'rpc_connection_error' : 'rpc_refresh_timeout';
             }
             this.outputChannel.error('[pet] Error refreshing', ex);
             throw ex;
@@ -806,6 +823,7 @@ class NativePythonFinderImpl implements NativePythonFinder {
                     );
                     this.killProcess();
                     this.processExited = true;
+                    this.processExitReason = 'rpc_configure_timeout';
                 } else {
                     this.outputChannel.warn(
                         `[pet] Configure request timed out (attempt ${this.configureRetry.timeoutCount}/${MAX_CONFIGURE_TIMEOUTS_BEFORE_KILL}), ` +

--- a/src/managers/common/nativePythonFinder.ts
+++ b/src/managers/common/nativePythonFinder.ts
@@ -85,12 +85,21 @@ export class ConfigureRetryState {
     }
 }
 
+export type NativePythonToolsSource = 'envs_extension' | 'python_extension';
+
 export async function getNativePythonToolsPath(): Promise<string> {
+    return (await getNativePythonToolsPathAndSource()).toolPath;
+}
+
+export async function getNativePythonToolsPathAndSource(): Promise<{
+    toolPath: string;
+    source: NativePythonToolsSource;
+}> {
     const envsExt = getExtension(ENVS_EXTENSION_ID);
     if (envsExt) {
         const petPath = path.join(envsExt.extensionPath, 'python-env-tools', 'bin', isWindows() ? 'pet.exe' : 'pet');
         if (await fs.pathExists(petPath)) {
-            return petPath;
+            return { toolPath: petPath, source: 'envs_extension' };
         }
     }
 
@@ -99,7 +108,54 @@ export async function getNativePythonToolsPath(): Promise<string> {
         throw new Error('Python extension not found');
     }
 
-    return path.join(python.extensionPath, 'python-env-tools', 'bin', isWindows() ? 'pet.exe' : 'pet');
+    return {
+        toolPath: path.join(python.extensionPath, 'python-env-tools', 'bin', isWindows() ? 'pet.exe' : 'pet'),
+        source: 'python_extension',
+    };
+}
+
+/**
+ * Runs `pet --version` and returns the parsed version string (e.g. '0.1.0').
+ * Returns 'unknown' if the command fails, times out, or the output can't be parsed.
+ */
+export async function getNativePythonToolsVersion(toolPath: string, timeoutMs: number = 5_000): Promise<string> {
+    return new Promise<string>((resolve) => {
+        let settled = false;
+        const settle = (value: string) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            resolve(value);
+        };
+        try {
+            const proc = spawnProcess(toolPath, ['--version'], { stdio: 'pipe' });
+            let stdout = '';
+            const timer = setTimeout(() => {
+                try {
+                    proc.kill('SIGTERM');
+                } catch {
+                    // ignore
+                }
+                settle('unknown');
+            }, timeoutMs);
+            proc.stdout?.on('data', (data: Buffer) => {
+                stdout += data.toString();
+            });
+            proc.on('error', () => {
+                clearTimeout(timer);
+                settle('unknown');
+            });
+            proc.on('close', () => {
+                clearTimeout(timer);
+                // Output looks like "pet 0.1.0\n" — extract the version token.
+                const match = stdout.match(/\b\d+\.\d+\.\d+\S*/);
+                settle(match ? match[0] : 'unknown');
+            });
+        } catch {
+            settle('unknown');
+        }
+    });
 }
 
 export interface NativeEnvInfo {
@@ -545,20 +601,23 @@ class NativePythonFinderImpl implements NativePythonFinder {
             // Handle process exit - mark as exited so pending requests fail fast
             this.proc.on('exit', (code, signal) => {
                 this.processExited = true;
-                if (code !== 0) {
+                // Preserve a more-specific reason (e.g. rpc_*) if one was already recorded before the kill.
+                if (this.processExitReason === undefined) {
                     this.processExitReason = `process_exit:${code ?? 'null'}:${signal ?? 'none'}`;
+                }
+                if (code !== 0) {
                     this.outputChannel.error(
                         `[pet] Python Environment Tools exited unexpectedly with code ${code}, signal ${signal}`,
                     );
-                } else {
-                    this.processExitReason = 'process_exit:0';
                 }
             });
 
             // Handle process errors (e.g., ENOENT if executable not found)
             this.proc.on('error', (err) => {
                 this.processExited = true;
-                this.processExitReason = 'process_error';
+                if (this.processExitReason === undefined) {
+                    this.processExitReason = 'process_error';
+                }
                 this.outputChannel.error('[pet] Process error:', err);
             });
 

--- a/src/managers/common/nativePythonFinder.ts
+++ b/src/managers/common/nativePythonFinder.ts
@@ -182,6 +182,23 @@ interface RefreshOptions {
     searchPaths?: string[];
 }
 
+/** Performance breakdown sent by PET via the `telemetry` notification after a refresh. */
+interface RefreshPerformance {
+    total: number;
+    /** Phase name (Locators | Path | GlobalVirtualEnvs | Workspaces) → wall-clock ms */
+    breakdown: Record<string, number>;
+    /** Locator name (Conda | WindowsRegistry | …) → wall-clock ms; only ran locators are present */
+    locators: Record<string, number>;
+}
+
+/** Params shape of the PET `telemetry` JSON-RPC notification. */
+interface PetTelemetryNotification {
+    event: string;
+    data: {
+        refreshPerformance?: RefreshPerformance;
+    };
+}
+
 /**
  * Error thrown when a JSON-RPC request times out.
  */
@@ -673,6 +690,7 @@ class NativePythonFinderImpl implements NativePythonFinder {
         const nativeInfo: NativeInfo[] = [];
         const sw = new StopWatch();
         let unresolvedCount = 0;
+        let refreshPerf: RefreshPerformance | undefined;
         try {
             await this.configure();
             const refreshOptions = this.getRefreshOptions(options);
@@ -708,6 +726,11 @@ class NativePythonFinderImpl implements NativePythonFinder {
                     this.outputChannel.info(`Discovered manager: (${data.tool}) ${data.executable}`);
                     nativeInfo.push(data);
                 }),
+                this.connection.onNotification('telemetry', (notification: PetTelemetryNotification) => {
+                    if (notification?.event === 'RefreshPerformance' && notification.data?.refreshPerformance) {
+                        refreshPerf = notification.data.refreshPerformance;
+                    }
+                }),
             );
             await sendRequestWithTimeout<{ duration: number }>(
                 this.connection,
@@ -730,6 +753,15 @@ class NativePythonFinderImpl implements NativePythonFinder {
                 workspaceDirCount,
                 searchPathCount,
                 attempt,
+                // Per-phase breakdown from PET's RefreshPerformance notification.
+                // Breakdown phases run in parallel so their sum may exceed total (wall-clock).
+                breakdownLocators: refreshPerf?.breakdown['Locators'],
+                breakdownPath: refreshPerf?.breakdown['Path'],
+                breakdownGlobalVirtualEnvs: refreshPerf?.breakdown['GlobalVirtualEnvs'],
+                breakdownWorkspaces: refreshPerf?.breakdown['Workspaces'],
+                // Per-locator timing serialized as JSON; platform-dependent keys (e.g. WindowsRegistry, Conda).
+                // Query in Kusto with: parse_json(Properties.locatorsJson)
+                locatorsJson: refreshPerf ? JSON.stringify(refreshPerf.locators) : undefined,
             });
         } catch (ex) {
             const errorType = classifyError(ex);

--- a/src/managers/common/nativePythonFinder.ts
+++ b/src/managers/common/nativePythonFinder.ts
@@ -134,6 +134,16 @@ export async function getNativePythonToolsVersion(toolPath: string, timeoutMs: n
             const timer = setTimeout(() => {
                 try {
                     proc.kill('SIGTERM');
+                    // Force kill after a short grace period if still running.
+                    setTimeout(() => {
+                        if (proc.exitCode === null) {
+                            try {
+                                proc.kill('SIGKILL');
+                            } catch {
+                                // ignore
+                            }
+                        }
+                    }, 500);
                 } catch {
                     // ignore
                 }
@@ -805,23 +815,33 @@ class NativePythonFinderImpl implements NativePythonFinder {
                 this.outputChannel.info(`[pet] Refresh succeeded on retry attempt ${attempt + 1}`);
             }
 
-            sendTelemetryEvent(EventNames.PET_REFRESH, sw.elapsedTime, {
-                result: 'success',
-                envCount: nativeInfo.filter((e) => isNativeEnvInfo(e)).length,
-                unresolvedCount,
-                workspaceDirCount,
-                searchPathCount,
-                attempt,
-                // Per-phase breakdown from PET's RefreshPerformance notification.
-                // Breakdown phases run in parallel so their sum may exceed total (wall-clock).
-                breakdownLocators: refreshPerf?.breakdown['Locators'],
-                breakdownPath: refreshPerf?.breakdown['Path'],
-                breakdownGlobalVirtualEnvs: refreshPerf?.breakdown['GlobalVirtualEnvs'],
-                breakdownWorkspaces: refreshPerf?.breakdown['Workspaces'],
-                // Per-locator timing serialized as JSON; platform-dependent keys (e.g. WindowsRegistry, Conda).
-                // Query in Kusto with: parse_json(Properties.locatorsJson)
-                locatorsJson: refreshPerf ? JSON.stringify(refreshPerf.locators) : undefined,
-            });
+            sendTelemetryEvent(
+                EventNames.PET_REFRESH,
+                {
+                    duration: sw.elapsedTime,
+                    ...(refreshPerf?.breakdown['Locators'] !== undefined && {
+                        breakdownLocators: refreshPerf.breakdown['Locators'],
+                    }),
+                    ...(refreshPerf?.breakdown['Path'] !== undefined && {
+                        breakdownPathEnv: refreshPerf.breakdown['Path'],
+                    }),
+                    ...(refreshPerf?.breakdown['GlobalVirtualEnvs'] !== undefined && {
+                        breakdownGlobalVirtualEnvs: refreshPerf.breakdown['GlobalVirtualEnvs'],
+                    }),
+                    ...(refreshPerf?.breakdown['Workspaces'] !== undefined && {
+                        breakdownWorkspaces: refreshPerf.breakdown['Workspaces'],
+                    }),
+                },
+                {
+                    result: 'success',
+                    envCount: nativeInfo.filter((e) => isNativeEnvInfo(e)).length,
+                    unresolvedCount,
+                    workspaceDirCount,
+                    searchPathCount,
+                    attempt,
+                    locatorsJson: refreshPerf ? JSON.stringify(refreshPerf.locators) : undefined,
+                },
+            );
         } catch (ex) {
             const errorType = classifyError(ex);
             sendTelemetryEvent(


### PR DESCRIPTION
- pet.process_restart now emits triggerReason (process_exit:<code>:<signal>, process_error, rpc_connection_error, rpc_refresh_timeout, rpc_resolve_timeout, rpc_configure_timeout, start_failed, unknown) so we can distinguish crash restarts from timeout restarts.
- setup.hang_detected now emits globalScopeDeferred (true/false/undefined) so we can tell whether a watchdog trip was a real foreground hang or a background global-scope scan running past 120s after the user already had an env selected

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>