### PR TITLE
Fix invalid PEP 723 header in new-script template

### DIFF
--- a/files/templates/new723ScriptTemplate/script.py
+++ b/files/templates/new723ScriptTemplate/script.py
@@ -1,4 +1,4 @@
-# /// script_name
+# /// script
 # requires-python = ">=X.XX" TODO: Update this to the minimum Python version you want to support
 # dependencies = [
 #   TODO: Add any dependencies your script requires

--- a/src/test/features/creators/newScriptProject.unit.test.ts
+++ b/src/test/features/creators/newScriptProject.unit.test.ts
@@ -1,0 +1,44 @@
+import assert from 'assert';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+
+// Path to the real script template, resolved from the compiled test location
+// (out/test/features/creators/ → workspaceRoot/files/templates/...). We do NOT
+// rely on `NEW_PROJECT_TEMPLATES_FOLDER` because it is anchored at
+// `path.dirname(__dirname)` of the compiled `constants.js`, which resolves to
+// `out/` in test mode and does not contain the bundled template tree.
+const TEMPLATE_PATH = path.join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    '..',
+    'files',
+    'templates',
+    'new723ScriptTemplate',
+    'script.py',
+);
+
+suite('new723ScriptTemplate / NewScriptProject', () => {
+    let tmpDir: string;
+
+    setup(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'new-script-test-'));
+    });
+
+    teardown(async () => {
+        await fs.remove(tmpDir);
+    });
+
+    test('Template file starts with a valid PEP 723 header (# /// script)', async () => {
+        const contents = await fs.readFile(TEMPLATE_PATH, 'utf8');
+        const firstNonBlankLine = contents.split(/\r?\n/).find((l) => l.trim().length > 0);
+
+        assert.strictEqual(
+            firstNonBlankLine,
+            '# /// script',
+            'Template must start with a valid PEP 723 `script` header line',
+        );
+    });
+});


### PR DESCRIPTION
I was reading PEP723 specs trying to understand the scope for supporting it in envs extension and noticed that the header is invalid in the template, so sending the PR to fix it.

## Summary
The script template shipped under `files/templates/new723ScriptTemplate/script.py` opens with `# /// script_name`, which is **not** a valid PEP 723 inline-script metadata header — the [spec](https://packaging.python.org/en/latest/specifications/inline-script-metadata/) mandates the literal type `script`. Compounding this, [newScriptProject.ts](src/features/creators/newScriptProject.ts) substitutes the user's filename into that token at create-time, producing further invalid headers like `# /// my_script`. This PR replaces the template's first line with the literal `# /// script` so the generated script is recognized by every PEP 723–compliant tool, and adds a unit test that locks the behaviour in.
