### PR TITLE
Distinguish between direct and transitive packages

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -694,6 +694,13 @@ export interface PackageManager {
 
     /**
      * Fetches the names of direct (non-transitive) packages for the specified Python environment.
+     *
+     * **Caveat:** Most package managers cannot track user install intent. For pip, this uses
+     * `pip list --not-required` which returns packages with no installed dependents (leaf packages),
+     * not necessarily packages the user explicitly installed. For example, if a user runs
+     * `pip install flask werkzeug`, werkzeug will still be reported as transitive because flask
+     * depends on it. This is a best-effort approximation.
+     *
      * @param environment - The Python environment for which to fetch direct package names.
      * @returns A promise that resolves to a set of package name strings, or undefined if not supported.
      */

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -688,6 +688,13 @@ export interface PackageManager {
     onDidChangePackages?: Event<DidChangePackagesEventArgs>;
 
     /**
+     * Fetches the names of direct (non-transitive) packages for the specified Python environment.
+     * @param environment - The Python environment for which to fetch direct package names.
+     * @returns A promise that resolves to an array of package name strings, or undefined if not supported.
+     */
+    fetchDirectPackageNames?(environment: PythonEnvironment): Promise<Set<string> | undefined>;
+
+    /**
      * Clears the package manager's cache.
      * @returns A promise that resolves when the cache is cleared.
      */

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -675,9 +675,9 @@ export interface PackageManager {
     /**
      * Refreshes the package list for the specified Python environment.
      * @param environment - The Python environment for which to refresh the package list.
-     * @returns A promise that resolves when the refresh is complete.
+     * @returns A promise that resolves with the refreshed list of packages, or undefined.
      */
-    refresh(environment: PythonEnvironment): Promise<void>;
+    refresh(environment: PythonEnvironment): Promise<Package[] | undefined>;
 
     /**
      * Retrieves the list of packages for the specified Python environment.
@@ -1041,9 +1041,9 @@ export interface PythonPackageGetterApi {
      * Refresh the list of packages in a Python Environment.
      *
      * @param environment The Python Environment for which the list of packages is to be refreshed.
-     * @returns A promise that resolves when the list of packages has been refreshed.
+     * @returns A promise that resolves with the refreshed list of packages, or undefined.
      */
-    refreshPackages(environment: PythonEnvironment): Promise<void>;
+    refreshPackages(environment: PythonEnvironment): Promise<Package[] | undefined>;
 
     /**
      * Get the list of packages in a Python Environment.

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -578,6 +578,11 @@ export interface PackageInfo {
      * The URIs associated with the package.
      */
     readonly uris?: readonly Uri[];
+
+    /**
+     * Whether the package is a transitive dependency.
+     */
+    readonly isTransitive?: boolean;
 }
 
 /**
@@ -690,9 +695,9 @@ export interface PackageManager {
     /**
      * Fetches the names of direct (non-transitive) packages for the specified Python environment.
      * @param environment - The Python environment for which to fetch direct package names.
-     * @returns A promise that resolves to an array of package name strings, or undefined if not supported.
+     * @returns A promise that resolves to a set of package name strings, or undefined if not supported.
      */
-    fetchDirectPackageNames?(environment: PythonEnvironment): Promise<Set<string> | undefined>;
+    getDirectPackageNames?(environment: PythonEnvironment): Promise<Set<string> | undefined>;
 
     /**
      * Clears the package manager's cache.

--- a/package-lock.json
+++ b/package-lock.json
@@ -812,6 +812,7 @@
             "integrity": "sha512-D7DbgGFtsqIPIFMPJwCad9Gfi/hC0PWErRRHFnaCWoEDYi5tQUDiJCTmGUbBiLzjqAck4KcXt9Ayj0CNlIrF+w==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.16.0",
                 "@typescript-eslint/types": "8.16.0",
@@ -1520,6 +1521,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1794,6 +1796,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2532,6 +2535,7 @@
             "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -4875,6 +4879,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -5548,6 +5553,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
             "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -5674,6 +5680,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
             "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -5722,6 +5729,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",
@@ -6532,6 +6540,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.16.0.tgz",
             "integrity": "sha512-D7DbgGFtsqIPIFMPJwCad9Gfi/hC0PWErRRHFnaCWoEDYi5tQUDiJCTmGUbBiLzjqAck4KcXt9Ayj0CNlIrF+w==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@typescript-eslint/scope-manager": "8.16.0",
                 "@typescript-eslint/types": "8.16.0",
@@ -7039,7 +7048,8 @@
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "acorn-import-phases": {
             "version": "1.0.4",
@@ -7226,6 +7236,7 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
             "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -7736,6 +7747,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
             "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -9417,6 +9429,7 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
                     "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
                         "fast-uri": "^3.0.1",
@@ -9873,7 +9886,8 @@
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
             "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "uc.micro": {
             "version": "1.0.6",
@@ -9959,6 +9973,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
             "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -9992,6 +10007,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -812,7 +812,6 @@
             "integrity": "sha512-D7DbgGFtsqIPIFMPJwCad9Gfi/hC0PWErRRHFnaCWoEDYi5tQUDiJCTmGUbBiLzjqAck4KcXt9Ayj0CNlIrF+w==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.16.0",
                 "@typescript-eslint/types": "8.16.0",
@@ -1521,7 +1520,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1796,7 +1794,6 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2535,7 +2532,6 @@
             "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -4879,7 +4875,6 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -5553,7 +5548,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
             "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -5680,7 +5674,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
             "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -5729,7 +5722,6 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",
@@ -6540,7 +6532,6 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.16.0.tgz",
             "integrity": "sha512-D7DbgGFtsqIPIFMPJwCad9Gfi/hC0PWErRRHFnaCWoEDYi5tQUDiJCTmGUbBiLzjqAck4KcXt9Ayj0CNlIrF+w==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@typescript-eslint/scope-manager": "8.16.0",
                 "@typescript-eslint/types": "8.16.0",
@@ -7048,8 +7039,7 @@
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "acorn-import-phases": {
             "version": "1.0.4",
@@ -7236,7 +7226,6 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
             "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -7747,7 +7736,6 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
             "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -9429,7 +9417,6 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
                     "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
                     "dev": true,
-                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
                         "fast-uri": "^3.0.1",
@@ -9886,8 +9873,7 @@
             "version": "5.3.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
             "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "uc.micro": {
             "version": "1.0.6",
@@ -9973,7 +9959,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
             "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -10007,7 +9992,6 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",

--- a/src/api.ts
+++ b/src/api.ts
@@ -576,7 +576,7 @@ export interface PackageInfo {
     /**
      * Whether the package is a transitive dependency.
      */
-    isTransitive?: boolean;
+    readonly isTransitive?: boolean;
 }
 
 /**
@@ -689,7 +689,7 @@ export interface PackageManager {
     /**
      * Fetches the names of direct (non-transitive) packages for the specified Python environment.
      * @param environment - The Python environment for which to fetch direct package names.
-     * @returns A promise that resolves to an array of package name strings, or undefined if not supported.
+     * @returns A promise that resolves to a set of package name strings, or undefined if not supported.
      */
     getDirectPackageNames?(environment: PythonEnvironment): Promise<Set<string> | undefined>;
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -691,7 +691,7 @@ export interface PackageManager {
      * @param environment - The Python environment for which to fetch direct package names.
      * @returns A promise that resolves to an array of package name strings, or undefined if not supported.
      */
-    fetchDirectPackageNames?(environment: PythonEnvironment): Promise<Set<string> | undefined>;
+    getDirectPackageNames?(environment: PythonEnvironment): Promise<Set<string> | undefined>;
 
     /**
      * Clears the package manager's cache.

--- a/src/api.ts
+++ b/src/api.ts
@@ -572,6 +572,11 @@ export interface PackageInfo {
      * The URIs associated with the package.
      */
     readonly uris?: readonly Uri[];
+
+    /**
+     * Whether the package is a transitive dependency.
+     */
+    isTransitive?: boolean;
 }
 
 /**
@@ -680,6 +685,13 @@ export interface PackageManager {
      * Event that is fired when packages change.
      */
     onDidChangePackages?: Event<DidChangePackagesEventArgs>;
+
+    /**
+     * Fetches the names of direct (non-transitive) packages for the specified Python environment.
+     * @param environment - The Python environment for which to fetch direct package names.
+     * @returns A promise that resolves to an array of package name strings, or undefined if not supported.
+     */
+    fetchDirectPackageNames?(environment: PythonEnvironment): Promise<Set<string> | undefined>;
 
     /**
      * Clears the package manager's cache.

--- a/src/api.ts
+++ b/src/api.ts
@@ -669,9 +669,9 @@ export interface PackageManager {
     /**
      * Refreshes the package list for the specified Python environment.
      * @param environment - The Python environment for which to refresh the package list.
-     * @returns A promise that resolves when the refresh is complete.
+     * @returns A promise that resolves with the refreshed list of packages, or undefined.
      */
-    refresh(environment: PythonEnvironment): Promise<void>;
+    refresh(environment: PythonEnvironment): Promise<Package[] | undefined>;
 
     /**
      * Retrieves the list of packages for the specified Python environment.
@@ -1035,9 +1035,9 @@ export interface PythonPackageGetterApi {
      * Refresh the list of packages in a Python Environment.
      *
      * @param environment The Python Environment for which the list of packages is to be refreshed.
-     * @returns A promise that resolves when the list of packages has been refreshed.
+     * @returns A promise that resolves with the refreshed list of packages, or undefined.
      */
-    refreshPackages(environment: PythonEnvironment): Promise<void>;
+    refreshPackages(environment: PythonEnvironment): Promise<Package[] | undefined>;
 
     /**
      * Get the list of packages in a Python Environment.

--- a/src/api.ts
+++ b/src/api.ts
@@ -688,6 +688,13 @@ export interface PackageManager {
 
     /**
      * Fetches the names of direct (non-transitive) packages for the specified Python environment.
+     *
+     * **Caveat:** Most package managers cannot track user install intent. For pip, this uses
+     * `pip list --not-required` which returns packages with no installed dependents (leaf packages),
+     * not necessarily packages the user explicitly installed. For example, if a user runs
+     * `pip install flask werkzeug`, werkzeug will still be reported as transitive because flask
+     * depends on it. This is a best-effort approximation.
+     *
      * @param environment - The Python environment for which to fetch direct package names.
      * @returns A promise that resolves to a set of package name strings, or undefined if not supported.
      */

--- a/src/features/envCommands.ts
+++ b/src/features/envCommands.ts
@@ -306,7 +306,18 @@ export async function removeEnvironmentCommand(context: unknown, managers: Envir
 export async function handlePackageUninstall(context: unknown, em: EnvironmentManagers) {
     if (context instanceof PackageTreeItem || context instanceof ProjectPackage) {
         if (context.pkg.isTransitive) {
-            return;
+            const confirm = await showInformationMessage(
+                l10n.t(
+                    'The package "{0}" is a transitive dependency. Uninstalling it may break other packages that depend on it.',
+                    context.pkg.name,
+                ),
+                { modal: true },
+                l10n.t('Uninstall Anyway'),
+                l10n.t('Cancel'),
+            );
+            if (confirm !== l10n.t('Uninstall Anyway')) {
+                return;
+            }
         }
         const moduleName = context.pkg.name;
         const environment = context instanceof ProjectPackage ? context.parent.environment : context.parent.environment;

--- a/src/features/envCommands.ts
+++ b/src/features/envCommands.ts
@@ -307,18 +307,7 @@ export async function handlePackageUninstall(context: unknown, em: EnvironmentMa
     if (context instanceof PackageTreeItem || context instanceof ProjectPackage) {
         // Ask for user confirmation if the package is transitive
         if (context.pkg.isTransitive) {
-            const confirm = await showInformationMessage(
-                l10n.t(
-                    'The package "{0}" is a transitive dependency. Uninstalling it may break other packages that depend on it. Are you sure you want to uninstall it?',
-                    context.pkg.name,
-                ),
-                { modal: true },
-                l10n.t('Uninstall'),
-                l10n.t('Cancel'),
-            );
-            if (confirm !== l10n.t('Uninstall')) {
-                return;
-            }
+            return;
         }
         const moduleName = context.pkg.name;
         const environment = context instanceof ProjectPackage ? context.parent.environment : context.parent.environment;

--- a/src/features/envCommands.ts
+++ b/src/features/envCommands.ts
@@ -305,7 +305,6 @@ export async function removeEnvironmentCommand(context: unknown, managers: Envir
 
 export async function handlePackageUninstall(context: unknown, em: EnvironmentManagers) {
     if (context instanceof PackageTreeItem || context instanceof ProjectPackage) {
-        // Ask for user confirmation if the package is transitive
         if (context.pkg.isTransitive) {
             return;
         }

--- a/src/features/envCommands.ts
+++ b/src/features/envCommands.ts
@@ -307,9 +307,16 @@ export async function handlePackageUninstall(context: unknown, em: EnvironmentMa
     if (context instanceof PackageTreeItem || context instanceof ProjectPackage) {
         // Ask for user confirmation if the package is transitive
         if (context.pkg.isTransitive) {
-            const message = `The package "${context.pkg.name}" is a transitive dependency. Uninstalling it may break other packages that depend on it. Are you sure you want to uninstall it?`;
-            const confirm = await showInformationMessage(message, { modal: true }, 'Uninstall', 'Cancel');
-            if (confirm !== 'Uninstall') {
+            const confirm = await showInformationMessage(
+                l10n.t(
+                    'The package "{0}" is a transitive dependency. Uninstalling it may break other packages that depend on it. Are you sure you want to uninstall it?',
+                    context.pkg.name,
+                ),
+                { modal: true },
+                l10n.t('Uninstall'),
+                l10n.t('Cancel'),
+            );
+            if (confirm !== l10n.t('Uninstall')) {
                 return;
             }
         }

--- a/src/features/envCommands.ts
+++ b/src/features/envCommands.ts
@@ -305,6 +305,14 @@ export async function removeEnvironmentCommand(context: unknown, managers: Envir
 
 export async function handlePackageUninstall(context: unknown, em: EnvironmentManagers) {
     if (context instanceof PackageTreeItem || context instanceof ProjectPackage) {
+        // Ask for user confirmation if the package is transitive
+        if (context.pkg.isTransitive) {
+            const message = `The package "${context.pkg.name}" is a transitive dependency. Uninstalling it may break other packages that depend on it. Are you sure you want to uninstall it?`;
+            const confirm = await showInformationMessage(message, { modal: true }, 'Uninstall', 'Cancel');
+            if (confirm !== 'Uninstall') {
+                return;
+            }
+        }
         const moduleName = context.pkg.name;
         const environment = context instanceof ProjectPackage ? context.parent.environment : context.parent.environment;
         const packageManager = em.getPackageManager(environment);

--- a/src/features/pythonApi.ts
+++ b/src/features/pythonApi.ts
@@ -250,7 +250,7 @@ class PythonEnvironmentApiImpl implements PythonEnvironmentApi {
         }
         return manager.manage(context, options);
     }
-    async refreshPackages(context: PythonEnvironment): Promise<void> {
+    async refreshPackages(context: PythonEnvironment): Promise<Package[] | undefined> {
         await waitForEnvManagerId([context.envId.managerId]);
         const manager = this.envManagers.getPackageManager(context);
         if (!manager) {

--- a/src/features/views/envManagersView.ts
+++ b/src/features/views/envManagersView.ts
@@ -252,11 +252,7 @@ export class EnvManagerView implements TreeDataProvider<EnvTreeItem>, Disposable
             const views: EnvTreeItem[] = [];
 
             if (pkgManager) {
-                let packages = await pkgManager.getPackages(environment);
-                if (!packages || packages.length === 0) {
-                    await pkgManager.refresh(environment);
-                    packages = await pkgManager.getPackages(environment);
-                }
+                let packages = await pkgManager.refresh(environment);
                 if (packages && packages.length > 0) {
                     views.push(
                         ...packages

--- a/src/features/views/envManagersView.ts
+++ b/src/features/views/envManagersView.ts
@@ -252,6 +252,7 @@ export class EnvManagerView implements TreeDataProvider<EnvTreeItem>, Disposable
             const views: EnvTreeItem[] = [];
 
             if (pkgManager) {
+                await pkgManager.refresh(environment);
                 const packages = await pkgManager.getPackages(environment);
                 if (packages && packages.length > 0) {
                     views.push(...packages.map((p) => new PackageTreeItem(p, parent, pkgManager)));

--- a/src/features/views/envManagersView.ts
+++ b/src/features/views/envManagersView.ts
@@ -255,7 +255,11 @@ export class EnvManagerView implements TreeDataProvider<EnvTreeItem>, Disposable
                 await pkgManager.refresh(environment);
                 const packages = await pkgManager.getPackages(environment);
                 if (packages && packages.length > 0) {
-                    views.push(...packages.map((p) => new PackageTreeItem(p, parent, pkgManager)));
+                    views.push(
+                        ...packages
+                            .sort((a, b) => (a.isTransitive === b.isTransitive ? 0 : a.isTransitive ? 1 : -1))
+                            .map((p) => new PackageTreeItem(p, parent, pkgManager)),
+                    );
                 } else {
                     views.push(new EnvInfoTreeItem(parent, ProjectViews.noPackages));
                 }

--- a/src/features/views/envManagersView.ts
+++ b/src/features/views/envManagersView.ts
@@ -252,8 +252,11 @@ export class EnvManagerView implements TreeDataProvider<EnvTreeItem>, Disposable
             const views: EnvTreeItem[] = [];
 
             if (pkgManager) {
-                await pkgManager.refresh(environment);
-                const packages = await pkgManager.getPackages(environment);
+                let packages = await pkgManager.getPackages(environment);
+                if (!packages || packages.length === 0) {
+                    await pkgManager.refresh(environment);
+                    packages = await pkgManager.getPackages(environment);
+                }
                 if (packages && packages.length > 0) {
                     views.push(
                         ...packages

--- a/src/features/views/projectView.ts
+++ b/src/features/views/projectView.ts
@@ -244,6 +244,7 @@ export class ProjectView implements TreeDataProvider<ProjectTreeItem> {
                 return [new ProjectEnvironmentInfo(environmentItem, ProjectViews.noPackageManager)];
             }
 
+            await pkgManager.refresh(environment);
             let packages = await pkgManager.getPackages(environment);
             if (!packages) {
                 return [new ProjectEnvironmentInfo(environmentItem, ProjectViews.noPackages)];

--- a/src/features/views/projectView.ts
+++ b/src/features/views/projectView.ts
@@ -244,8 +244,11 @@ export class ProjectView implements TreeDataProvider<ProjectTreeItem> {
                 return [new ProjectEnvironmentInfo(environmentItem, ProjectViews.noPackageManager)];
             }
 
-            await pkgManager.refresh(environment);
             let packages = await pkgManager.getPackages(environment);
+            if (!packages || packages.length === 0) {
+                await pkgManager.refresh(environment);
+                packages = await pkgManager.getPackages(environment);
+            }
             if (!packages) {
                 return [new ProjectEnvironmentInfo(environmentItem, ProjectViews.noPackages)];
             }

--- a/src/features/views/projectView.ts
+++ b/src/features/views/projectView.ts
@@ -244,11 +244,7 @@ export class ProjectView implements TreeDataProvider<ProjectTreeItem> {
                 return [new ProjectEnvironmentInfo(environmentItem, ProjectViews.noPackageManager)];
             }
 
-            let packages = await pkgManager.getPackages(environment);
-            if (!packages || packages.length === 0) {
-                await pkgManager.refresh(environment);
-                packages = await pkgManager.getPackages(environment);
-            }
+            let packages = await pkgManager.refresh(environment);
             if (!packages) {
                 return [new ProjectEnvironmentInfo(environmentItem, ProjectViews.noPackages)];
             }

--- a/src/features/views/treeViewItems.ts
+++ b/src/features/views/treeViewItems.ts
@@ -211,7 +211,7 @@ export class PackageTreeItem implements EnvTreeItem {
     ) {
         const item = new TreeItem(pkg.displayName);
         item.iconPath = pkg.isTransitive ? new ThemeIcon('list-tree') : new ThemeIcon('package');
-        item.contextValue = 'python-package';
+        item.contextValue = pkg.isTransitive ? 'python-package-transitive' : 'python-package';
         item.description = (pkg.isTransitive ? '(dependency) ' : '') + (pkg.description ?? pkg.version);
         item.tooltip = pkg.tooltip;
         this.treeItem = item;
@@ -431,7 +431,7 @@ export class ProjectPackage implements ProjectTreeItem {
         this.id = ProjectPackage.getId(parent, pkg);
         const item = new TreeItem(this.pkg.displayName, TreeItemCollapsibleState.None);
         item.iconPath = this.pkg.iconPath;
-        item.contextValue = 'python-package';
+        item.contextValue = this.pkg.isTransitive ? 'python-package-transitive' : 'python-package';
         item.description = this.pkg.description ?? this.pkg.version;
         item.tooltip = this.pkg.tooltip;
         this.treeItem = item;

--- a/src/features/views/treeViewItems.ts
+++ b/src/features/views/treeViewItems.ts
@@ -214,7 +214,9 @@ export class PackageTreeItem implements EnvTreeItem {
         item.iconPath = pkg.iconPath ?? defaultIcon;
         item.contextValue = pkg.isTransitive ? 'python-package-transitive' : 'python-package';
         item.description = (pkg.isTransitive ? l10n.t('(transitive) ') : '') + (pkg.description ?? pkg.version);
-        item.tooltip = pkg.tooltip;
+        item.tooltip = pkg.isTransitive
+            ? l10n.t('This package is a dependency of another installed package. It may also have been explicitly installed.')
+            : pkg.tooltip;
         this.treeItem = item;
     }
 }

--- a/src/features/views/treeViewItems.ts
+++ b/src/features/views/treeViewItems.ts
@@ -210,7 +210,7 @@ export class PackageTreeItem implements EnvTreeItem {
         public readonly manager: InternalPackageManager,
     ) {
         const item = new TreeItem(pkg.displayName);
-        item.iconPath = pkg.iconPath;
+        item.iconPath = pkg.isTransitive ? new ThemeIcon('list-tree') : new ThemeIcon('package');
         item.contextValue = 'python-package';
         item.description = pkg.description ?? pkg.version;
         item.tooltip = pkg.tooltip;

--- a/src/features/views/treeViewItems.ts
+++ b/src/features/views/treeViewItems.ts
@@ -212,7 +212,7 @@ export class PackageTreeItem implements EnvTreeItem {
         const item = new TreeItem(pkg.displayName);
         item.iconPath = pkg.isTransitive ? new ThemeIcon('list-tree') : new ThemeIcon('package');
         item.contextValue = pkg.isTransitive ? 'python-package-transitive' : 'python-package';
-        item.description = (pkg.isTransitive ? '(dependency) ' : '') + (pkg.description ?? pkg.version);
+        item.description = (pkg.isTransitive ? '(transitive) ' : '') + (pkg.description ?? pkg.version);
         item.tooltip = pkg.tooltip;
         this.treeItem = item;
     }

--- a/src/features/views/treeViewItems.ts
+++ b/src/features/views/treeViewItems.ts
@@ -212,7 +212,7 @@ export class PackageTreeItem implements EnvTreeItem {
         const item = new TreeItem(pkg.displayName);
         item.iconPath = pkg.isTransitive ? new ThemeIcon('list-tree') : new ThemeIcon('package');
         item.contextValue = 'python-package';
-        item.description = pkg.description ?? pkg.version;
+        item.description = (pkg.isTransitive ? '(dependency) ' : '') + (pkg.description ?? pkg.version);
         item.tooltip = pkg.tooltip;
         this.treeItem = item;
     }

--- a/src/features/views/treeViewItems.ts
+++ b/src/features/views/treeViewItems.ts
@@ -1,4 +1,4 @@
-import { Command, MarkdownString, ThemeIcon, TreeItem, TreeItemCollapsibleState } from 'vscode';
+import { Command, MarkdownString, ThemeIcon, TreeItem, TreeItemCollapsibleState, l10n } from 'vscode';
 import { EnvironmentGroupInfo, IconPath, Package, PythonEnvironment, PythonProject } from '../../api';
 import { EnvViewStrings, UvInstallStrings, VenvManagerStrings } from '../../common/localize';
 import { InternalEnvironmentManager, InternalPackageManager } from '../../internal.api';
@@ -210,9 +210,10 @@ export class PackageTreeItem implements EnvTreeItem {
         public readonly manager: InternalPackageManager,
     ) {
         const item = new TreeItem(pkg.displayName);
-        item.iconPath = pkg.isTransitive ? new ThemeIcon('list-tree') : new ThemeIcon('package');
+        const defaultIcon = pkg.isTransitive ? new ThemeIcon('list-tree') : new ThemeIcon('package');
+        item.iconPath = pkg.iconPath ?? defaultIcon;
         item.contextValue = pkg.isTransitive ? 'python-package-transitive' : 'python-package';
-        item.description = (pkg.isTransitive ? '(transitive) ' : '') + (pkg.description ?? pkg.version);
+        item.description = (pkg.isTransitive ? l10n.t('(transitive) ') : '') + (pkg.description ?? pkg.version);
         item.tooltip = pkg.tooltip;
         this.treeItem = item;
     }

--- a/src/internal.api.ts
+++ b/src/internal.api.ts
@@ -364,7 +364,7 @@ export class InternalPackageManager implements PackageManager {
         }
     }
 
-    refresh(environment: PythonEnvironment): Promise<void> {
+    refresh(environment: PythonEnvironment): Promise<Package[] | undefined> {
         return this.manager.refresh(environment);
     }
 

--- a/src/internal.api.ts
+++ b/src/internal.api.ts
@@ -446,6 +446,8 @@ export class PythonPackageImpl implements Package {
     public readonly iconPath?: IconPath;
     public readonly uris?: readonly Uri[];
 
+    public readonly isTransitive?: boolean;
+
     constructor(
         public readonly pkgId: PackageId,
         info: PackageInfo,
@@ -457,6 +459,7 @@ export class PythonPackageImpl implements Package {
         this.tooltip = info.tooltip;
         this.iconPath = info.iconPath;
         this.uris = info.uris;
+        this.isTransitive = info.isTransitive;
     }
 }
 

--- a/src/managers/builtin/pipListUtils.ts
+++ b/src/managers/builtin/pipListUtils.ts
@@ -4,6 +4,19 @@ export interface PipPackage {
     displayName: string;
     description: string;
 }
+export function isValidVersion(version: string): boolean {
+    return /^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$/.test(
+        version,
+    );
+}
+
+export function parseUvTree(data: string): string[] {
+    return data
+        .split('\n')
+        .map((line) => line.trim())
+        .map((line) => line.split(/\s+/, 1)[0])
+        .filter((name) => !!name);
+}
 
 export function parsePipListJson(data: string): PipPackage[] {
     try {

--- a/src/managers/builtin/pipListUtils.ts
+++ b/src/managers/builtin/pipListUtils.ts
@@ -4,12 +4,6 @@ export interface PipPackage {
     displayName: string;
     description: string;
 }
-export function isValidVersion(version: string): boolean {
-    return /^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$/.test(
-        version,
-    );
-}
-
 export function parseUvTree(data: string): string[] {
     return data
         .split('\n')

--- a/src/managers/builtin/pipListUtils.ts
+++ b/src/managers/builtin/pipListUtils.ts
@@ -1,3 +1,5 @@
+import { LogOutputChannel } from 'vscode';
+
 export interface PipPackage {
     name: string;
     version: string;
@@ -12,7 +14,7 @@ export function parseUvTree(data: string): string[] {
         .filter((name) => !!name);
 }
 
-export function parsePipListJson(data: string): PipPackage[] {
+export function parsePipListJson(data: string, log?: LogOutputChannel): PipPackage[] {
     try {
         const json = JSON.parse(data);
         if (Array.isArray(json)) {
@@ -25,8 +27,8 @@ export function parsePipListJson(data: string): PipPackage[] {
                     description: version,
                 }));
         }
-    } catch (_) {
-        // If JSON parsing fails, return an empty array. The caller can decide how to handle this case.
+    } catch (ex) {
+        log?.error('Failed to parse pip list JSON output', ex);
     }
     return [];
 }

--- a/src/managers/builtin/pipPackageManager.ts
+++ b/src/managers/builtin/pipPackageManager.ts
@@ -135,6 +135,12 @@ export class PipPackageManager implements PackageManager, Disposable {
         this.packages.clear();
     }
 
+    /**
+     * Returns direct (non-transitive) package names using `pip list --not-required` or `uv pip tree --depth=0`.
+     *
+     * Note: These commands return packages with no installed dependents (leaf packages), not packages
+     * the user explicitly installed. pip/uv do not track install intent.
+     */
     async getDirectPackageNames(environment: PythonEnvironment): Promise<Set<string> | undefined> {
         const data = await refreshPipDirectPackageNames(environment, this.log);
         return data ? new Set(data.map(normalizePackageName)) : undefined;

--- a/src/managers/builtin/pipPackageManager.ts
+++ b/src/managers/builtin/pipPackageManager.ts
@@ -21,7 +21,7 @@ import {
 } from '../../api';
 import { updatePackagesAndNotify } from '../common/packageChanges';
 import { getWorkspacePackagesToInstall } from './pipUtils';
-import { managePackages, refreshPipDirectPackageNames, refreshPipPackages } from './utils';
+import { managePackages, normalizePackageName, refreshPipDirectPackageNames, refreshPipPackages } from './utils';
 import { VenvManager } from './venvManager';
 
 export class PipPackageManager implements PackageManager, Disposable {
@@ -137,6 +137,6 @@ export class PipPackageManager implements PackageManager, Disposable {
 
     async getDirectPackageNames(environment: PythonEnvironment): Promise<Set<string> | undefined> {
         const data = await refreshPipDirectPackageNames(environment, this.log);
-        return data ? new Set(data) : undefined;
+        return data ? new Set(data.map(normalizePackageName)) : undefined;
     }
 }

--- a/src/managers/builtin/pipPackageManager.ts
+++ b/src/managers/builtin/pipPackageManager.ts
@@ -21,7 +21,7 @@ import {
 } from '../../api';
 import { updatePackagesAndNotify } from '../common/packageChanges';
 import { getWorkspacePackagesToInstall } from './pipUtils';
-import { managePackages, refreshPipPackages } from './utils';
+import { managePackages, refreshPipDirectPackageNames, refreshPipPackages } from './utils';
 import { VenvManager } from './venvManager';
 
 export class PipPackageManager implements PackageManager, Disposable {
@@ -128,5 +128,10 @@ export class PipPackageManager implements PackageManager, Disposable {
     dispose(): void {
         this._onDidChangePackages.dispose();
         this.packages.clear();
+    }
+
+    async fetchDirectPackageNames(environment: PythonEnvironment): Promise<Set<string> | undefined> {
+        const data = await refreshPipDirectPackageNames(environment, this.log);
+        return data ? new Set(data) : undefined;
     }
 }

--- a/src/managers/builtin/pipPackageManager.ts
+++ b/src/managers/builtin/pipPackageManager.ts
@@ -130,7 +130,7 @@ export class PipPackageManager implements PackageManager, Disposable {
         this.packages.clear();
     }
 
-    async fetchDirectPackageNames(environment: PythonEnvironment): Promise<Set<string> | undefined> {
+    async getDirectPackageNames(environment: PythonEnvironment): Promise<Set<string> | undefined> {
         const data = await refreshPipDirectPackageNames(environment, this.log);
         return data ? new Set(data) : undefined;
     }

--- a/src/managers/builtin/pipPackageManager.ts
+++ b/src/managers/builtin/pipPackageManager.ts
@@ -101,16 +101,21 @@ export class PipPackageManager implements PackageManager, Disposable {
         );
     }
 
-    async refresh(environment: PythonEnvironment): Promise<void> {
-        await window.withProgress(
+    async refresh(environment: PythonEnvironment): Promise<Package[] | undefined> {
+        return window.withProgress(
             {
                 location: ProgressLocation.Window,
                 title: 'Refreshing packages',
             },
             async () => {
-                await updatePackagesAndNotify(this, environment, this.packages.get(environment.envId.id), (changes) => {
-                    this._onDidChangePackages.fire({ environment, manager: this, changes });
-                });
+                return updatePackagesAndNotify(
+                    this,
+                    environment,
+                    this.packages.get(environment.envId.id),
+                    (changes) => {
+                        this._onDidChangePackages.fire({ environment, manager: this, changes });
+                    },
+                );
             },
         );
     }

--- a/src/managers/builtin/utils.ts
+++ b/src/managers/builtin/utils.ts
@@ -380,3 +380,7 @@ export async function resolveSystemPythonEnvironmentPath(
     }
     return undefined;
 }
+
+export function normalizePackageName(name: string): string {
+    return name.replace(/[-_.]+/g, '-').toLowerCase();
+}

--- a/src/managers/builtin/utils.ts
+++ b/src/managers/builtin/utils.ts
@@ -243,6 +243,14 @@ export async function refreshPipPackages(
     }
 }
 
+/**
+ * Returns names of packages with no installed dependents (leaf packages).
+ *
+ * Uses `pip list --not-required` (pip) or `uv pip tree --depth=0` (uv). These report
+ * packages that nothing else depends on, which is a proxy for "directly installed" but
+ * not equivalent — e.g., `pip install flask werkzeug` will report werkzeug as having
+ * dependents (flask) even though the user installed it explicitly.
+ */
 export async function refreshPipDirectPackageNames(
     environment: PythonEnvironment,
     log?: LogOutputChannel,

--- a/src/managers/builtin/utils.ts
+++ b/src/managers/builtin/utils.ts
@@ -235,7 +235,7 @@ export async function refreshPipPackages(
             data = await execPipList(environment, log);
         }
 
-        return parsePipListJson(data);
+        return parsePipListJson(data, log);
     } catch (e) {
         log?.error('Error refreshing packages', e);
         showErrorMessageWithLogs(SysManagerStrings.packageRefreshError, log);

--- a/src/managers/builtin/utils.ts
+++ b/src/managers/builtin/utils.ts
@@ -23,7 +23,7 @@ import {
 } from '../common/nativePythonFinder';
 import { shortenVersionString, sortEnvironments } from '../common/utils';
 import { runPython, runUV, shouldUseUv } from './helpers';
-import { parsePipListJson, PipPackage } from './pipListUtils';
+import { parsePipListJson, parseUvTree, PipPackage } from './pipListUtils';
 
 const PIXI_EXTENSION_ID = 'renan-r-santos.pixi-code';
 const PIXI_RECOMMEND_DONT_ASK_KEY = 'pixi-extension-recommend-dont-ask';
@@ -241,6 +241,26 @@ export async function refreshPipPackages(
         showErrorMessageWithLogs(SysManagerStrings.packageRefreshError, log);
         return undefined;
     }
+}
+
+export async function refreshPipDirectPackageNames(
+    environment: PythonEnvironment,
+    log?: LogOutputChannel,
+): Promise<string[] | undefined> {
+    const useUv = await shouldUseUv(log, environment.environmentPath.fsPath);
+    if (useUv) {
+        const treeOutput = await runUV(
+            ['pip', 'tree', '--python', environment.execInfo.run.executable, '--depth=0'],
+            undefined,
+            log,
+            undefined,
+            PIP_LIST_TIMEOUT_MS,
+        );
+        return parseUvTree(treeOutput);
+    }
+    const data = await execPipList(environment, log, ['--not-required']);
+    const packages = parsePipList(data);
+    return packages.map((pkg) => pkg.name);
 }
 
 export async function managePackages(

--- a/src/managers/builtin/utils.ts
+++ b/src/managers/builtin/utils.ts
@@ -259,7 +259,7 @@ export async function refreshPipDirectPackageNames(
         return parseUvTree(treeOutput);
     }
     const data = await execPipList(environment, log, ['--not-required']);
-    const packages = parsePipList(data);
+    const packages = parsePipListJson(data);
     return packages.map((pkg) => pkg.name);
 }
 

--- a/src/managers/builtin/utils.ts
+++ b/src/managers/builtin/utils.ts
@@ -200,7 +200,7 @@ async function execPipList(environment: PythonEnvironment, log?: LogOutputChanne
     try {
         return await runPython(
             environment.execInfo.run.executable,
-            ['-m', 'pip', 'list', '--format=json'],
+            ['-m', 'pip', 'list', '--format=json', ...(args ?? [])],
             undefined,
             log,
             undefined,

--- a/src/managers/common/packageChanges.ts
+++ b/src/managers/common/packageChanges.ts
@@ -46,16 +46,13 @@ export async function updatePackagesAndNotify(
     environment: PythonEnvironment,
     before: Package[] | undefined,
     onChanges: PackageChangesCallback,
-): Promise<void> {
-    const after = (await packageManager.getPackages(environment, { skipCache: true })) ?? [];
+): Promise<Package[] | undefined> {
+    const [after, afterDirectDependenciesNames] = await Promise.all([
+        packageManager.getPackages(environment, { skipCache: true }).then((pkgs) => pkgs ?? []),
+        // Handle transitive dependencies (best-effort, don't break package refresh on failure)
+        packageManager.getDirectPackageNames?.(environment).catch(() => undefined),
+    ]);
 
-    // Handle transitive dependencies (best-effort, don't break package refresh on failure)
-    let afterDirectDependenciesNames: Set<string> | undefined;
-    try {
-        afterDirectDependenciesNames = await packageManager.getDirectPackageNames?.(environment);
-    } catch {
-        // If direct package detection fails, leave isTransitive undefined rather than breaking refresh
-    }
     if (afterDirectDependenciesNames && afterDirectDependenciesNames.size > 0) {
         for (const pkg of after) {
             (pkg as { isTransitive?: boolean }).isTransitive = !afterDirectDependenciesNames.has(pkg.name);
@@ -67,4 +64,6 @@ export async function updatePackagesAndNotify(
     if (changes.length > 0) {
         onChanges(changes);
     }
+
+    return after;
 }

--- a/src/managers/common/packageChanges.ts
+++ b/src/managers/common/packageChanges.ts
@@ -48,11 +48,17 @@ export async function updatePackagesAndNotify(
     onChanges: PackageChangesCallback,
 ): Promise<void> {
     const after = (await packageManager.getPackages(environment, { skipCache: true })) ?? [];
+
+    // Handle transitive dependencies
     const afterDirectDependenciesNames =
-        (await packageManager.fetchDirectPackageNames?.(environment)) ?? new Set<string>();
-    for (const pkg of after) {
-        pkg.isTransitive = !afterDirectDependenciesNames.has(pkg.name);
+        (await packageManager.getDirectPackageNames?.(environment)) ?? new Set<string>();
+    if (afterDirectDependenciesNames.size > 0) {
+        for (const pkg of after) {
+            pkg.isTransitive = !afterDirectDependenciesNames.has(pkg.name);
+        }
     }
+
+    // Fire change event
     const changes = getPackageChanges(before ?? [], after);
     if (changes.length > 0) {
         onChanges(changes);

--- a/src/managers/common/packageChanges.ts
+++ b/src/managers/common/packageChanges.ts
@@ -48,6 +48,11 @@ export async function updatePackagesAndNotify(
     onChanges: PackageChangesCallback,
 ): Promise<void> {
     const after = (await packageManager.getPackages(environment, { skipCache: true })) ?? [];
+    const afterDirectDependenciesNames =
+        (await packageManager.fetchDirectPackageNames?.(environment)) ?? new Set<string>();
+    for (const pkg of after) {
+        pkg.isTransitive = !afterDirectDependenciesNames.has(pkg.name);
+    }
     const changes = getPackageChanges(before ?? [], after);
     if (changes.length > 0) {
         onChanges(changes);

--- a/src/managers/common/packageChanges.ts
+++ b/src/managers/common/packageChanges.ts
@@ -49,12 +49,16 @@ export async function updatePackagesAndNotify(
 ): Promise<void> {
     const after = (await packageManager.getPackages(environment, { skipCache: true })) ?? [];
 
-    // Handle transitive dependencies
-    const afterDirectDependenciesNames =
-        (await packageManager.getDirectPackageNames?.(environment)) ?? new Set<string>();
-    if (afterDirectDependenciesNames.size > 0) {
+    // Handle transitive dependencies (best-effort, don't break package refresh on failure)
+    let afterDirectDependenciesNames: Set<string> | undefined;
+    try {
+        afterDirectDependenciesNames = await packageManager.getDirectPackageNames?.(environment);
+    } catch {
+        // If direct package detection fails, leave isTransitive undefined rather than breaking refresh
+    }
+    if (afterDirectDependenciesNames && afterDirectDependenciesNames.size > 0) {
         for (const pkg of after) {
-            pkg.isTransitive = !afterDirectDependenciesNames.has(pkg.name);
+            (pkg as { isTransitive?: boolean }).isTransitive = !afterDirectDependenciesNames.has(pkg.name);
         }
     }
 

--- a/src/managers/common/packageChanges.ts
+++ b/src/managers/common/packageChanges.ts
@@ -54,19 +54,19 @@ export async function updatePackagesAndNotify(
         packageManager.getDirectPackageNames?.(environment).catch(() => undefined),
     ]);
 
-    if (afterDirectDependenciesNames && afterDirectDependenciesNames.size > 0) {
-        for (const pkg of after) {
-            (pkg as { isTransitive?: boolean }).isTransitive = !afterDirectDependenciesNames.has(
-                normalizePackageName(pkg.name),
-            );
-        }
-    }
+    // Enrich packages with transitive dependency info (best-effort, creates new objects to respect readonly)
+    const enriched = afterDirectDependenciesNames && afterDirectDependenciesNames.size > 0
+        ? after.map((pkg) => ({
+              ...pkg,
+              isTransitive: !afterDirectDependenciesNames.has(normalizePackageName(pkg.name)),
+          }))
+        : after;
 
     // Fire change event
-    const changes = getPackageChanges(before ?? [], after);
+    const changes = getPackageChanges(before ?? [], enriched);
     if (changes.length > 0) {
         onChanges(changes);
     }
 
-    return after;
+    return enriched;
 }

--- a/src/managers/common/packageChanges.ts
+++ b/src/managers/common/packageChanges.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { Package, PackageChangeKind, PackageManager, PythonEnvironment } from '../../api';
+import { normalizePackageName } from '../builtin/utils';
 
 /**
  * Callback invoked with the computed changes when at least one change is detected.
@@ -15,17 +16,17 @@ export type PackageChangesCallback = (changes: { kind: PackageChangeKind; pkg: P
  * @returns An array of changes indicating which packages were added or removed.
  */
 export function getPackageChanges(before: Package[], after: Package[]): { kind: PackageChangeKind; pkg: Package }[] {
-    const beforeSet = new Set(before.map(({ name, version }) => `${name}==${version}`));
-    const afterSet = new Set(after.map(({ name, version }) => `${name}==${version}`));
+    const beforeSet = new Set(before.map(({ name, version }) => `${normalizePackageName(name)}==${version}`));
+    const afterSet = new Set(after.map(({ name, version }) => `${normalizePackageName(name)}==${version}`));
     const changes: { kind: PackageChangeKind; pkg: Package }[] = [];
 
     for (const pkg of after) {
-        if (!beforeSet.has(`${pkg.name}==${pkg.version}`)) {
+        if (!beforeSet.has(`${normalizePackageName(pkg.name)}==${pkg.version}`)) {
             changes.push({ kind: PackageChangeKind.add, pkg });
         }
     }
     for (const pkg of before) {
-        if (!afterSet.has(`${pkg.name}==${pkg.version}`)) {
+        if (!afterSet.has(`${normalizePackageName(pkg.name)}==${pkg.version}`)) {
             changes.push({ kind: PackageChangeKind.remove, pkg });
         }
     }
@@ -55,7 +56,9 @@ export async function updatePackagesAndNotify(
 
     if (afterDirectDependenciesNames && afterDirectDependenciesNames.size > 0) {
         for (const pkg of after) {
-            (pkg as { isTransitive?: boolean }).isTransitive = !afterDirectDependenciesNames.has(pkg.name);
+            (pkg as { isTransitive?: boolean }).isTransitive = !afterDirectDependenciesNames.has(
+                normalizePackageName(pkg.name),
+            );
         }
     }
 

--- a/src/managers/conda/condaPackageManager.ts
+++ b/src/managers/conda/condaPackageManager.ts
@@ -95,16 +95,21 @@ export class CondaPackageManager implements PackageManager, Disposable {
         );
     }
 
-    async refresh(environment: PythonEnvironment): Promise<void> {
-        await withProgress(
+    async refresh(environment: PythonEnvironment): Promise<Package[] | undefined> {
+        return withProgress(
             {
                 location: ProgressLocation.Window,
                 title: CondaStrings.condaRefreshingPackages,
             },
             async () => {
-                await updatePackagesAndNotify(this, environment, this.packages.get(environment.envId.id), (changes) => {
-                    this._onDidChangePackages.fire({ environment, manager: this, changes });
-                });
+                return updatePackagesAndNotify(
+                    this,
+                    environment,
+                    this.packages.get(environment.envId.id),
+                    (changes) => {
+                        this._onDidChangePackages.fire({ environment, manager: this, changes });
+                    },
+                );
             },
         );
     }

--- a/src/managers/poetry/poetryPackageManager.ts
+++ b/src/managers/poetry/poetryPackageManager.ts
@@ -264,7 +264,7 @@ export class PoetryPackageManager implements PackageManager, Disposable {
         return poetryPackages.map((pkg) => this.api.createPackageItem(pkg, environment, this));
     }
 
-    async fetchDirectPackageNames(_environment: PythonEnvironment): Promise<Set<string> | undefined> {
+    async getDirectPackageNames(_environment: PythonEnvironment): Promise<Set<string> | undefined> {
         try {
             const topLevelResult = await runPoetry(['show', '--no-ansi', '--tree'], undefined, this.log);
             const names = topLevelResult

--- a/src/managers/poetry/poetryPackageManager.ts
+++ b/src/managers/poetry/poetryPackageManager.ts
@@ -108,15 +108,15 @@ export class PoetryPackageManager implements PackageManager, Disposable {
         );
     }
 
-    async refresh(environment: PythonEnvironment): Promise<void> {
-        await withProgress(
+    async refresh(environment: PythonEnvironment): Promise<Package[] | undefined> {
+        return withProgress(
             {
                 location: ProgressLocation.Window,
                 title: 'Refreshing Poetry packages',
             },
             async () => {
                 try {
-                    await updatePackagesAndNotify(
+                    return await updatePackagesAndNotify(
                         this,
                         environment,
                         this.packages.get(environment.envId.id),
@@ -133,6 +133,7 @@ export class PoetryPackageManager implements PackageManager, Disposable {
                             this.log.show();
                         }
                     });
+                    return undefined;
                 }
             },
         );

--- a/src/managers/poetry/poetryPackageManager.ts
+++ b/src/managers/poetry/poetryPackageManager.ts
@@ -272,7 +272,7 @@ export class PoetryPackageManager implements PackageManager, Disposable {
             const names = topLevelResult
                 .split('\n')
                 .map((line) => line.trim())
-                .map((line) => line.match(/^([a-zA-Z0-9_-]+)/)?.[1] ?? '')
+                .map((line) => line.match(/^([a-zA-Z0-9._-]+)/)?.[1] ?? '')
                 .filter((name) => !!name)
                 .map(normalizePackageName);
             return new Set(names);

--- a/src/managers/poetry/poetryPackageManager.ts
+++ b/src/managers/poetry/poetryPackageManager.ts
@@ -266,12 +266,12 @@ export class PoetryPackageManager implements PackageManager, Disposable {
 
     async getDirectPackageNames(_environment: PythonEnvironment): Promise<Set<string> | undefined> {
         try {
-            const topLevelResult = await runPoetry(['show', '--no-ansi', '--tree'], undefined, this.log);
+            const topLevelResult = await runPoetry(['show', '--no-ansi', '--top-level'], undefined, this.log);
             const names = topLevelResult
                 .split('\n')
                 .map((line) => line.trim())
-                .map((line) => line.match(/^(\S+)/)?.[1] ?? '') // Extract package name from lines like "├── package (version)"
-                .filter((name) => !!name); // Filter out empty names
+                .map((line) => line.match(/^([a-zA-Z0-9_-]+)/)?.[1] ?? '')
+                .filter((name) => !!name);
             return new Set(names);
         } catch (err) {
             this.log.error(`Error fetching direct package names with Poetry: ${err}`);

--- a/src/managers/poetry/poetryPackageManager.ts
+++ b/src/managers/poetry/poetryPackageManager.ts
@@ -263,6 +263,21 @@ export class PoetryPackageManager implements PackageManager, Disposable {
         // Convert to Package objects using the API
         return poetryPackages.map((pkg) => this.api.createPackageItem(pkg, environment, this));
     }
+
+    async fetchDirectPackageNames(_environment: PythonEnvironment): Promise<Set<string> | undefined> {
+        try {
+            const topLevelResult = await runPoetry(['show', '--no-ansi', '--tree'], undefined, this.log);
+            const names = topLevelResult
+                .split('\n')
+                .map((line) => line.trim())
+                .map((line) => line.match(/^(\S+)/)?.[1] ?? '') // Extract package name from lines like "├── package (version)"
+                .filter((name) => !!name); // Filter out empty names
+            return new Set(names);
+        } catch (err) {
+            this.log.error(`Error fetching direct package names with Poetry: ${err}`);
+            return undefined;
+        }
+    }
 }
 
 export async function runPoetry(

--- a/src/managers/poetry/poetryPackageManager.ts
+++ b/src/managers/poetry/poetryPackageManager.ts
@@ -24,6 +24,7 @@ import {
 } from '../../api';
 import { spawnProcess } from '../../common/childProcess.apis';
 import { showErrorMessage, showInputBox, withProgress } from '../../common/window.apis';
+import { normalizePackageName } from '../builtin/utils';
 import { updatePackagesAndNotify } from '../common/packageChanges';
 import { PoetryManager } from './poetryManager';
 import { getPoetry } from './poetryUtils';
@@ -272,7 +273,8 @@ export class PoetryPackageManager implements PackageManager, Disposable {
                 .split('\n')
                 .map((line) => line.trim())
                 .map((line) => line.match(/^([a-zA-Z0-9_-]+)/)?.[1] ?? '')
-                .filter((name) => !!name);
+                .filter((name) => !!name)
+                .map(normalizePackageName);
             return new Set(names);
         } catch (err) {
             this.log.error(`Error fetching direct package names with Poetry: ${err}`);

--- a/src/test/managers/builtin/normalizePackageName.unit.test.ts
+++ b/src/test/managers/builtin/normalizePackageName.unit.test.ts
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import { normalizePackageName } from '../../../managers/builtin/utils';
+
+suite('normalizePackageName', () => {
+    test('should lowercase names', () => {
+        assert.strictEqual(normalizePackageName('Requests'), 'requests');
+        assert.strictEqual(normalizePackageName('NUMPY'), 'numpy');
+    });
+
+    test('should replace underscores with hyphens', () => {
+        assert.strictEqual(normalizePackageName('my_package'), 'my-package');
+    });
+
+    test('should replace dots with hyphens', () => {
+        assert.strictEqual(normalizePackageName('zope.interface'), 'zope-interface');
+    });
+
+    test('should collapse consecutive separators into a single hyphen', () => {
+        assert.strictEqual(normalizePackageName('my__package'), 'my-package');
+        assert.strictEqual(normalizePackageName('my_-package'), 'my-package');
+        assert.strictEqual(normalizePackageName('my_.package'), 'my-package');
+    });
+
+    test('should handle mixed separators and casing', () => {
+        assert.strictEqual(normalizePackageName('My_Package.Name'), 'my-package-name');
+        assert.strictEqual(normalizePackageName('Foo-Bar_Baz'), 'foo-bar-baz');
+    });
+
+    test('should return already-normalized names unchanged', () => {
+        assert.strictEqual(normalizePackageName('requests'), 'requests');
+        assert.strictEqual(normalizePackageName('my-package'), 'my-package');
+    });
+
+    test('should handle single-word names', () => {
+        assert.strictEqual(normalizePackageName('pip'), 'pip');
+    });
+
+    test('should produce equal results for equivalent package names', () => {
+        const variants = ['My_Package', 'my-package', 'my.package', 'My.Package', 'MY_PACKAGE', 'my_package'];
+        const normalized = variants.map(normalizePackageName);
+        assert.ok(
+            normalized.every((n) => n === normalized[0]),
+            `All variants should normalize to the same value, got: ${JSON.stringify(normalized)}`,
+        );
+    });
+});

--- a/src/test/managers/builtin/pipListUtils.unit.test.ts
+++ b/src/test/managers/builtin/pipListUtils.unit.test.ts
@@ -1,12 +1,28 @@
 import assert from 'assert';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { parsePipListJson } from '../../../managers/builtin/pipListUtils';
+import * as sinon from 'sinon';
+import { LogOutputChannel } from 'vscode';
+import { parsePipListJson, parseUvTree } from '../../../managers/builtin/pipListUtils';
 import { EXTENSION_TEST_ROOT } from '../../constants';
 
 const TEST_DATA_ROOT = path.join(EXTENSION_TEST_ROOT, 'managers', 'builtin');
 
 suite('Pip List JSON Parser tests', () => {
+    let log: LogOutputChannel;
+
+    setup(() => {
+        log = {
+            error: sinon.stub(),
+            warn: sinon.stub(),
+            info: sinon.stub(),
+        } as unknown as LogOutputChannel;
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
     const testNames = ['piplist1', 'piplist2', 'piplist3'];
 
     testNames.forEach((testName) => {
@@ -16,7 +32,7 @@ suite('Pip List JSON Parser tests', () => {
             );
             const pipListOutput = JSON.stringify(expected.packages);
 
-            const actualPackages = parsePipListJson(pipListOutput);
+            const actualPackages = parsePipListJson(pipListOutput, log);
 
             assert.equal(actualPackages.length, expected.packages.length, 'Unexpected number of packages');
             actualPackages.forEach((actualPackage) => {
@@ -36,12 +52,23 @@ suite('Pip List JSON Parser tests', () => {
     });
 
     test('Returns an empty array for invalid JSON input', () => {
-        assert.deepStrictEqual(parsePipListJson('not json'), []);
+        assert.deepStrictEqual(parsePipListJson('not json', log), []);
+    });
+
+    test('Logs error when JSON parsing fails', () => {
+        parsePipListJson('not valid json', log);
+        assert.ok((log.error as sinon.SinonStub).calledOnce, 'Expected error to be logged');
+    });
+
+    test('Returns empty array without logging when no log is provided', () => {
+        const result = parsePipListJson('not valid json');
+        assert.deepStrictEqual(result, []);
     });
 
     test('Skips items without a name or version', () => {
         const actualPackages = parsePipListJson(
             JSON.stringify([{ name: 'pip', version: '24.0' }, { name: 'setuptools' }, { version: '1.0.0' }]),
+            log,
         );
 
         assert.deepStrictEqual(actualPackages, [
@@ -52,5 +79,45 @@ suite('Pip List JSON Parser tests', () => {
                 description: '24.0',
             },
         ]);
+    });
+
+    test('Returns empty array for non-array JSON', () => {
+        const result = parsePipListJson('{"name": "pip"}', log);
+        assert.deepStrictEqual(result, []);
+    });
+
+    test('Returns empty array for empty array JSON', () => {
+        const result = parsePipListJson('[]', log);
+        assert.deepStrictEqual(result, []);
+    });
+});
+
+suite('parseUvTree tests', () => {
+    test('Parses uv pip tree output with depth 0', () => {
+        const input = 'requests v2.31.0\nflask v3.0.0\n';
+        const result = parseUvTree(input);
+        assert.deepStrictEqual(result, ['requests', 'flask']);
+    });
+
+    test('Handles empty output', () => {
+        assert.deepStrictEqual(parseUvTree(''), []);
+    });
+
+    test('Filters blank lines', () => {
+        const input = 'requests v2.31.0\n\n\nflask v3.0.0\n';
+        const result = parseUvTree(input);
+        assert.deepStrictEqual(result, ['requests', 'flask']);
+    });
+
+    test('Handles single package', () => {
+        const input = 'pip v24.0\n';
+        const result = parseUvTree(input);
+        assert.deepStrictEqual(result, ['pip']);
+    });
+
+    test('Trims leading whitespace from indented lines', () => {
+        const input = '  requests v2.31.0\n  flask v3.0.0\n';
+        const result = parseUvTree(input);
+        assert.deepStrictEqual(result, ['requests', 'flask']);
     });
 });

--- a/src/test/managers/common/packageChanges.unit.test.ts
+++ b/src/test/managers/common/packageChanges.unit.test.ts
@@ -181,11 +181,14 @@ suite('packageChanges', () => {
             (packageManager as unknown as Record<string, unknown>).getDirectPackageNames = getDirectPackageNamesStub;
             const onChanges = sinon.stub();
 
-            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+            const result = await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
 
-            assert.strictEqual(after[0].isTransitive, false, 'requests should be direct');
-            assert.strictEqual(after[1].isTransitive, true, 'urllib3 should be transitive');
-            assert.strictEqual(after[2].isTransitive, true, 'charset-normalizer should be transitive');
+            assert.ok(result);
+            assert.strictEqual(result![0].isTransitive, false, 'requests should be direct');
+            assert.strictEqual(result![1].isTransitive, true, 'urllib3 should be transitive');
+            assert.strictEqual(result![2].isTransitive, true, 'charset-normalizer should be transitive');
+            // Original objects should not be mutated
+            assert.strictEqual(after[0].isTransitive, undefined, 'original should not be mutated');
         });
 
         test('does not mark packages transitive when getDirectPackageNames is not implemented', async () => {
@@ -196,10 +199,11 @@ suite('packageChanges', () => {
             getPackagesStub.resolves(after);
             const onChanges = sinon.stub();
 
-            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+            const result = await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
 
-            assert.strictEqual(after[0].isTransitive, undefined, 'should not be set');
-            assert.strictEqual(after[1].isTransitive, undefined, 'should not be set');
+            assert.ok(result);
+            assert.strictEqual(result![0].isTransitive, undefined, 'should not be set');
+            assert.strictEqual(result![1].isTransitive, undefined, 'should not be set');
         });
 
         test('does not mark packages transitive when getDirectPackageNames returns undefined', async () => {
@@ -212,10 +216,11 @@ suite('packageChanges', () => {
             (packageManager as unknown as Record<string, unknown>).getDirectPackageNames = getDirectPackageNamesStub;
             const onChanges = sinon.stub();
 
-            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+            const result = await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
 
-            assert.strictEqual(after[0].isTransitive, undefined, 'should not be set');
-            assert.strictEqual(after[1].isTransitive, undefined, 'should not be set');
+            assert.ok(result);
+            assert.strictEqual(result![0].isTransitive, undefined, 'should not be set');
+            assert.strictEqual(result![1].isTransitive, undefined, 'should not be set');
         });
 
         test('does not mark packages transitive when getDirectPackageNames returns empty set', async () => {
@@ -228,10 +233,11 @@ suite('packageChanges', () => {
             (packageManager as unknown as Record<string, unknown>).getDirectPackageNames = getDirectPackageNamesStub;
             const onChanges = sinon.stub();
 
-            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+            const result = await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
 
-            assert.strictEqual(after[0].isTransitive, undefined, 'should not be set');
-            assert.strictEqual(after[1].isTransitive, undefined, 'should not be set');
+            assert.ok(result);
+            assert.strictEqual(result![0].isTransitive, undefined, 'should not be set');
+            assert.strictEqual(result![1].isTransitive, undefined, 'should not be set');
         });
 
         test('all packages marked direct when all are in direct set', async () => {
@@ -244,10 +250,11 @@ suite('packageChanges', () => {
             (packageManager as unknown as Record<string, unknown>).getDirectPackageNames = getDirectPackageNamesStub;
             const onChanges = sinon.stub();
 
-            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+            const result = await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
 
-            assert.strictEqual(after[0].isTransitive, false, 'requests should be direct');
-            assert.strictEqual(after[1].isTransitive, false, 'flask should be direct');
+            assert.ok(result);
+            assert.strictEqual(result![0].isTransitive, false, 'requests should be direct');
+            assert.strictEqual(result![1].isTransitive, false, 'flask should be direct');
         });
 
         test('all packages marked transitive when none are in direct set', async () => {
@@ -260,10 +267,11 @@ suite('packageChanges', () => {
             (packageManager as unknown as Record<string, unknown>).getDirectPackageNames = getDirectPackageNamesStub;
             const onChanges = sinon.stub();
 
-            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+            const result = await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
 
-            assert.strictEqual(after[0].isTransitive, true, 'urllib3 should be transitive');
-            assert.strictEqual(after[1].isTransitive, true, 'charset-normalizer should be transitive');
+            assert.ok(result);
+            assert.strictEqual(result![0].isTransitive, true, 'urllib3 should be transitive');
+            assert.strictEqual(result![1].isTransitive, true, 'charset-normalizer should be transitive');
         });
 
         test('leaves isTransitive undefined when getDirectPackageNames throws', async () => {
@@ -276,10 +284,11 @@ suite('packageChanges', () => {
             (packageManager as unknown as Record<string, unknown>).getDirectPackageNames = getDirectPackageNamesStub;
             const onChanges = sinon.stub();
 
-            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+            const result = await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
 
-            assert.strictEqual(after[0].isTransitive, undefined, 'should not be set on error');
-            assert.strictEqual(after[1].isTransitive, undefined, 'should not be set on error');
+            assert.ok(result);
+            assert.strictEqual(result![0].isTransitive, undefined, 'should not be set on error');
+            assert.strictEqual(result![1].isTransitive, undefined, 'should not be set on error');
             assert.ok(onChanges.calledOnce, 'should still fire change event');
         });
     });

--- a/src/test/managers/common/packageChanges.unit.test.ts
+++ b/src/test/managers/common/packageChanges.unit.test.ts
@@ -169,5 +169,101 @@ suite('packageChanges', () => {
             assert.ok(changes.some((c: { kind: PackageChangeKind }) => c.kind === PackageChangeKind.add));
             assert.ok(changes.some((c: { kind: PackageChangeKind }) => c.kind === PackageChangeKind.remove));
         });
+
+        test('marks transitive packages when getDirectPackageNames is provided', async () => {
+            const after = [
+                { name: 'requests', version: '2.31.0' } as Package,
+                { name: 'urllib3', version: '2.0.0' } as Package,
+                { name: 'charset-normalizer', version: '3.0.0' } as Package,
+            ];
+            getPackagesStub.resolves(after);
+            const getDirectPackageNamesStub = sinon.stub().resolves(new Set(['requests']));
+            (packageManager as unknown as Record<string, unknown>).getDirectPackageNames = getDirectPackageNamesStub;
+            const onChanges = sinon.stub();
+
+            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+
+            assert.strictEqual(after[0].isTransitive, false, 'requests should be direct');
+            assert.strictEqual(after[1].isTransitive, true, 'urllib3 should be transitive');
+            assert.strictEqual(after[2].isTransitive, true, 'charset-normalizer should be transitive');
+        });
+
+        test('does not mark packages transitive when getDirectPackageNames is not implemented', async () => {
+            const after = [
+                { name: 'requests', version: '2.31.0' } as Package,
+                { name: 'urllib3', version: '2.0.0' } as Package,
+            ];
+            getPackagesStub.resolves(after);
+            const onChanges = sinon.stub();
+
+            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+
+            assert.strictEqual(after[0].isTransitive, undefined, 'should not be set');
+            assert.strictEqual(after[1].isTransitive, undefined, 'should not be set');
+        });
+
+        test('does not mark packages transitive when getDirectPackageNames returns undefined', async () => {
+            const after = [
+                { name: 'requests', version: '2.31.0' } as Package,
+                { name: 'urllib3', version: '2.0.0' } as Package,
+            ];
+            getPackagesStub.resolves(after);
+            const getDirectPackageNamesStub = sinon.stub().resolves(undefined);
+            (packageManager as unknown as Record<string, unknown>).getDirectPackageNames = getDirectPackageNamesStub;
+            const onChanges = sinon.stub();
+
+            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+
+            assert.strictEqual(after[0].isTransitive, undefined, 'should not be set');
+            assert.strictEqual(after[1].isTransitive, undefined, 'should not be set');
+        });
+
+        test('does not mark packages transitive when getDirectPackageNames returns empty set', async () => {
+            const after = [
+                { name: 'requests', version: '2.31.0' } as Package,
+                { name: 'urllib3', version: '2.0.0' } as Package,
+            ];
+            getPackagesStub.resolves(after);
+            const getDirectPackageNamesStub = sinon.stub().resolves(new Set<string>());
+            (packageManager as unknown as Record<string, unknown>).getDirectPackageNames = getDirectPackageNamesStub;
+            const onChanges = sinon.stub();
+
+            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+
+            assert.strictEqual(after[0].isTransitive, undefined, 'should not be set');
+            assert.strictEqual(after[1].isTransitive, undefined, 'should not be set');
+        });
+
+        test('all packages marked direct when all are in direct set', async () => {
+            const after = [
+                { name: 'requests', version: '2.31.0' } as Package,
+                { name: 'flask', version: '3.0.0' } as Package,
+            ];
+            getPackagesStub.resolves(after);
+            const getDirectPackageNamesStub = sinon.stub().resolves(new Set(['requests', 'flask']));
+            (packageManager as unknown as Record<string, unknown>).getDirectPackageNames = getDirectPackageNamesStub;
+            const onChanges = sinon.stub();
+
+            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+
+            assert.strictEqual(after[0].isTransitive, false, 'requests should be direct');
+            assert.strictEqual(after[1].isTransitive, false, 'flask should be direct');
+        });
+
+        test('all packages marked transitive when none are in direct set', async () => {
+            const after = [
+                { name: 'urllib3', version: '2.0.0' } as Package,
+                { name: 'charset-normalizer', version: '3.0.0' } as Package,
+            ];
+            getPackagesStub.resolves(after);
+            const getDirectPackageNamesStub = sinon.stub().resolves(new Set(['requests']));
+            (packageManager as unknown as Record<string, unknown>).getDirectPackageNames = getDirectPackageNamesStub;
+            const onChanges = sinon.stub();
+
+            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+
+            assert.strictEqual(after[0].isTransitive, true, 'urllib3 should be transitive');
+            assert.strictEqual(after[1].isTransitive, true, 'charset-normalizer should be transitive');
+        });
     });
 });

--- a/src/test/managers/common/packageChanges.unit.test.ts
+++ b/src/test/managers/common/packageChanges.unit.test.ts
@@ -265,5 +265,22 @@ suite('packageChanges', () => {
             assert.strictEqual(after[0].isTransitive, true, 'urllib3 should be transitive');
             assert.strictEqual(after[1].isTransitive, true, 'charset-normalizer should be transitive');
         });
+
+        test('leaves isTransitive undefined when getDirectPackageNames throws', async () => {
+            const after = [
+                { name: 'requests', version: '2.31.0' } as Package,
+                { name: 'urllib3', version: '2.0.0' } as Package,
+            ];
+            getPackagesStub.resolves(after);
+            const getDirectPackageNamesStub = sinon.stub().rejects(new Error('command failed'));
+            (packageManager as unknown as Record<string, unknown>).getDirectPackageNames = getDirectPackageNamesStub;
+            const onChanges = sinon.stub();
+
+            await updatePackagesAndNotify(packageManager, environment, undefined, onChanges);
+
+            assert.strictEqual(after[0].isTransitive, undefined, 'should not be set on error');
+            assert.strictEqual(after[1].isTransitive, undefined, 'should not be set on error');
+            assert.ok(onChanges.calledOnce, 'should still fire change event');
+        });
     });
 });


### PR DESCRIPTION
This pull request attempts to identify transitive packages in the user environment, and show indicators in the UI. 

## Problem
<img width="605" height="739" alt="image" src="https://github.com/user-attachments/assets/b48ee5cf-d20b-4dc6-b91c-3f61967a5a98" />

All installed packages, regardless of hierarchy are displayed equally in the sidebar. However, the relationships between them is not entirely obvious through the UI. This may cause (less experienced) users to get confused when they see packages they haven't explicitly installed, or to modify/delete transitive packages, potentially affecting their direct packages. 

Hence, there needs to be a way to clearly distinguish between them, and provide guardrails to prevent unintended behaviour. 

## Proposal
Direct packages are detected through the built in commands of the package managers
| Package Manager | Command | Description |
| -------------------  | ----------- | ------------- |
| pip                        |  `pip list --not-required --format=json` | Lists packages not required (direct, non-transitive) by other packages in a JSON format. |
| uv                         | `uv pip tree --depth 0` | Lists a dependency tree of all the packages with depth 0 (i.e., doesn't include transitive packages). |
| poetry                   | `poetry show --top-level --no-ansi` | Lists the top level packages |
| conda                   | `conda env export --from-history` * | Lists explicitly installed packages (note: this does not differenciate between direct/transitive) |

Packages shown are clearly identified as "Direct packages" or "Transitive" in the UI. Controls for uninstalling transitive packages are hidden to avoid unwanted behaviors. 

<img width="502" height="318" alt="image" src="https://github.com/user-attachments/assets/cbbef2bd-a700-4f91-a58b-4cc1bd99e98c" />

Closes #524 


