### PR TITLE
Fix false-positive "environment manager not registered" warning on startup

### DIFF
--- a/src/features/interpreterSelection.ts
+++ b/src/features/interpreterSelection.ts
@@ -45,14 +45,12 @@ export interface SettingResolutionError {
     /** The setting that failed */
     setting: 'pythonProjects' | 'defaultEnvManager' | 'defaultInterpreterPath';
     /**
-     * Structured failure kind. Allows callers to handle specific failure modes
-     * (e.g. re-checking whether a manager became registered) without parsing `reason`.
+     * Structured failure kind. Drives both the localized user-facing reason and any
+     * conditional handling (e.g. re-checking whether a manager became registered).
      */
     kind: 'managerNotRegistered' | 'pathUnresolvedVariables' | 'pathCannotResolve';
     /** The configured value */
     configuredValue: string;
-    /** Human-readable reason for failure */
-    reason: string;
 }
 
 /**
@@ -88,7 +86,6 @@ async function resolvePriorityChainCore(
                 setting: 'pythonProjects',
                 kind: 'managerNotRegistered',
                 configuredValue: projectManagerId,
-                reason: `Environment manager '${projectManagerId}' is not registered`,
             };
             errors.push(error);
             traceWarn(`${logPrefix} pythonProjects[] manager '${projectManagerId}' not found, trying next priority`);
@@ -107,7 +104,6 @@ async function resolvePriorityChainCore(
             setting: 'defaultEnvManager',
             kind: 'managerNotRegistered',
             configuredValue: userConfiguredManager,
-            reason: `Environment manager '${userConfiguredManager}' is not registered`,
         };
         errors.push(error);
         traceWarn(`${logPrefix} defaultEnvManager '${userConfiguredManager}' not found, trying next priority`);
@@ -127,7 +123,6 @@ async function resolvePriorityChainCore(
                     setting: 'defaultInterpreterPath',
                     kind: 'pathUnresolvedVariables',
                     configuredValue: userInterpreterPath,
-                    reason: l10n.t('Path contains unresolved variables'),
                 };
                 errors.push(error);
             } else {
@@ -148,7 +143,6 @@ async function resolvePriorityChainCore(
                     setting: 'defaultInterpreterPath',
                     kind: 'pathUnresolvedVariables',
                     configuredValue: userInterpreterPath,
-                    reason: l10n.t('Path contains unresolved variables'),
                 };
                 errors.push(error);
             } else {
@@ -166,7 +160,6 @@ async function resolvePriorityChainCore(
                     setting: 'defaultInterpreterPath',
                     kind: 'pathCannotResolve',
                     configuredValue: userInterpreterPath,
-                    reason: `Could not resolve interpreter path '${userInterpreterPath}'`,
                 };
                 errors.push(error);
                 traceWarn(
@@ -440,6 +433,23 @@ export function resetSettingWarnings(): void {
     warnedSettings.clear();
 }
 
+/**
+ * Build the localized "reason" text shown to the user for a given error kind.
+ * Kept inside this file so the user-facing strings remain co-located with the
+ * notification template that interpolates them, and so all user-visible text
+ * goes through `l10n.t` (no partially-localized warnings).
+ */
+function localizedReasonFor(error: SettingResolutionError): string {
+    switch (error.kind) {
+        case 'managerNotRegistered':
+            return l10n.t("Environment manager '{0}' is not registered", error.configuredValue);
+        case 'pathUnresolvedVariables':
+            return l10n.t('Path contains unresolved variables');
+        case 'pathCannotResolve':
+            return l10n.t("Could not resolve interpreter path '{0}'", error.configuredValue);
+    }
+}
+
 async function notifyUserOfSettingErrors(
     errors: SettingResolutionError[],
     envManagers: EnvironmentManagers,
@@ -473,6 +483,7 @@ async function notifyUserOfSettingErrors(
 
         const settingErrors = liveErrors.filter((e) => e.setting === setting);
         const firstError = settingErrors[0];
+        const reason = localizedReasonFor(firstError);
 
         let message: string;
         let settingKey: string;
@@ -482,7 +493,7 @@ async function notifyUserOfSettingErrors(
                 message = l10n.t(
                     "Python project setting for environment manager '{0}' could not be applied: {1}",
                     firstError.configuredValue,
-                    firstError.reason,
+                    reason,
                 );
                 settingKey = 'python-envs.pythonProjects';
                 break;
@@ -490,7 +501,7 @@ async function notifyUserOfSettingErrors(
                 message = l10n.t(
                     "Default environment manager '{0}' could not be applied: {1}",
                     firstError.configuredValue,
-                    firstError.reason,
+                    reason,
                 );
                 settingKey = 'python-envs.defaultEnvManager';
                 break;
@@ -498,7 +509,7 @@ async function notifyUserOfSettingErrors(
                 message = l10n.t(
                     "Default interpreter path '{0}' could not be resolved: {1}",
                     firstError.configuredValue,
-                    firstError.reason,
+                    reason,
                 );
                 settingKey = 'python.defaultInterpreterPath';
                 break;

--- a/src/features/interpreterSelection.ts
+++ b/src/features/interpreterSelection.ts
@@ -386,8 +386,9 @@ export async function applyInitialEnvironmentSelection(
         }
         resolveGlobalScope()
             .then(async (globalErrors) => {
-                if (globalErrors.length > 0) {
-                    await notifyUserOfSettingErrors(globalErrors, envManagers);
+                const liveGlobalErrors = filterLiveSettingErrors(globalErrors, envManagers);
+                if (liveGlobalErrors.length > 0) {
+                    await notifyUserOfSettingErrors(liveGlobalErrors);
                 }
             })
             .catch((err) => traceError(`[interpreterSelection] Background global scope resolution failed: ${err}`));
@@ -400,9 +401,15 @@ export async function applyInitialEnvironmentSelection(
         allErrors.push(...globalErrors);
     }
 
+    // Drop "manager not registered" errors that became stale during the awaits above
+    // (third-party manager extensions may have finished activating in the meantime).
+    // Used for both the user notification and the telemetry settingErrorCount so they
+    // agree on what counts as a real error.
+    const liveErrors = filterLiveSettingErrors(allErrors, envManagers);
+
     // Notify user if any settings could not be applied (workspace + global when awaited)
-    if (allErrors.length > 0) {
-        await notifyUserOfSettingErrors(allErrors, envManagers);
+    if (liveErrors.length > 0) {
+        await notifyUserOfSettingErrors(liveErrors);
     }
 
     // Numeric values must go via the measures argument (properties are dropped).
@@ -412,7 +419,7 @@ export async function applyInitialEnvironmentSelection(
             duration: selectionStopWatch.elapsedTime,
             workspaceFolderCount: folders.length,
             resolvedFolderCount,
-            settingErrorCount: allErrors.length,
+            settingErrorCount: liveErrors.length,
         },
         {
             globalScopeDeferred: workspaceFolderResolved,
@@ -450,16 +457,20 @@ function localizedReasonFor(error: SettingResolutionError): string {
     }
 }
 
-async function notifyUserOfSettingErrors(
+/**
+ * Drop setting errors that became stale before the notification site.
+ *
+ * The priority chain records "manager not registered" errors at the time it runs,
+ * but several awaits happen before notification/telemetry. A third-party extension
+ * (e.g. Hatch) may finish activating during those awaits and register its manager.
+ * Re-check the current registry: if the manager is now present the error is stale
+ * and would be a false positive both in the user-facing warning and in telemetry.
+ */
+function filterLiveSettingErrors(
     errors: SettingResolutionError[],
     envManagers: EnvironmentManagers,
-): Promise<void> {
-    // The priority chain records "manager not registered" errors at the time it runs,
-    // but several awaits happen before this function is reached. A third-party extension
-    // (e.g. Hatch) may finish activating during those awaits and register its manager.
-    // Re-check the current registry: if the manager is now present the error is stale
-    // and the warning would be a false positive.
-    const liveErrors = errors.filter((e) => {
+): SettingResolutionError[] {
+    return errors.filter((e) => {
         if (e.kind === 'managerNotRegistered' && envManagers.getEnvironmentManager(e.configuredValue)) {
             traceVerbose(
                 `[interpreterSelection] Manager '${e.configuredValue}' is now registered; suppressing stale warning`,
@@ -468,12 +479,15 @@ async function notifyUserOfSettingErrors(
         }
         return true;
     });
-    if (liveErrors.length === 0) {
+}
+
+async function notifyUserOfSettingErrors(errors: SettingResolutionError[]): Promise<void> {
+    if (errors.length === 0) {
         return;
     }
 
     // Group errors by setting type to avoid spamming the user
-    const uniqueSettings = [...new Set(liveErrors.map((e) => e.setting))];
+    const uniqueSettings = [...new Set(errors.map((e) => e.setting))];
 
     for (const setting of uniqueSettings) {
         if (warnedSettings.has(setting)) {
@@ -481,7 +495,7 @@ async function notifyUserOfSettingErrors(
         }
         warnedSettings.add(setting);
 
-        const settingErrors = liveErrors.filter((e) => e.setting === setting);
+        const settingErrors = errors.filter((e) => e.setting === setting);
         const firstError = settingErrors[0];
         const reason = localizedReasonFor(firstError);
 

--- a/src/features/interpreterSelection.ts
+++ b/src/features/interpreterSelection.ts
@@ -44,10 +44,7 @@ export interface PriorityChainResult {
 export interface SettingResolutionError {
     /** The setting that failed */
     setting: 'pythonProjects' | 'defaultEnvManager' | 'defaultInterpreterPath';
-    /**
-     * Structured failure kind. Drives both the localized user-facing reason and any
-     * conditional handling (e.g. re-checking whether a manager became registered).
-     */
+    /** Structured failure kind, used for localization and stale-error re-checks. */
     kind: 'managerNotRegistered' | 'pathUnresolvedVariables' | 'pathCannotResolve';
     /** The configured value */
     configuredValue: string;
@@ -401,13 +398,9 @@ export async function applyInitialEnvironmentSelection(
         allErrors.push(...globalErrors);
     }
 
-    // Drop "manager not registered" errors that became stale during the awaits above
-    // (third-party manager extensions may have finished activating in the meantime).
-    // Used for both the user notification and the telemetry settingErrorCount so they
-    // agree on what counts as a real error.
+    // Drop errors that became stale during the awaits above; see filterLiveSettingErrors.
     const liveErrors = filterLiveSettingErrors(allErrors, envManagers);
 
-    // Notify user if any settings could not be applied (workspace + global when awaited)
     if (liveErrors.length > 0) {
         await notifyUserOfSettingErrors(liveErrors);
     }
@@ -440,12 +433,6 @@ export function resetSettingWarnings(): void {
     warnedSettings.clear();
 }
 
-/**
- * Build the localized "reason" text shown to the user for a given error kind.
- * Kept inside this file so the user-facing strings remain co-located with the
- * notification template that interpolates them, and so all user-visible text
- * goes through `l10n.t` (no partially-localized warnings).
- */
 function localizedReasonFor(error: SettingResolutionError): string {
     switch (error.kind) {
         case 'managerNotRegistered':
@@ -458,13 +445,9 @@ function localizedReasonFor(error: SettingResolutionError): string {
 }
 
 /**
- * Drop setting errors that became stale before the notification site.
- *
- * The priority chain records "manager not registered" errors at the time it runs,
- * but several awaits happen before notification/telemetry. A third-party extension
- * (e.g. Hatch) may finish activating during those awaits and register its manager.
- * Re-check the current registry: if the manager is now present the error is stale
- * and would be a false positive both in the user-facing warning and in telemetry.
+ * Re-check the live registry to drop `managerNotRegistered` errors that became
+ * stale while later awaits ran — a third-party manager extension may have
+ * registered in the meantime, in which case the warning would be a false positive.
  */
 function filterLiveSettingErrors(
     errors: SettingResolutionError[],

--- a/src/features/interpreterSelection.ts
+++ b/src/features/interpreterSelection.ts
@@ -44,9 +44,14 @@ export interface PriorityChainResult {
 export interface SettingResolutionError {
     /** The setting that failed */
     setting: 'pythonProjects' | 'defaultEnvManager' | 'defaultInterpreterPath';
+    /**
+     * Structured failure kind. Allows callers to handle specific failure modes
+     * (e.g. re-checking whether a manager became registered) without parsing `reason`.
+     */
+    kind: 'managerNotRegistered' | 'pathUnresolvedVariables' | 'pathCannotResolve';
     /** The configured value */
     configuredValue: string;
-    /** Reason for failure */
+    /** Human-readable reason for failure */
     reason: string;
 }
 
@@ -81,6 +86,7 @@ async function resolvePriorityChainCore(
             }
             const error: SettingResolutionError = {
                 setting: 'pythonProjects',
+                kind: 'managerNotRegistered',
                 configuredValue: projectManagerId,
                 reason: `Environment manager '${projectManagerId}' is not registered`,
             };
@@ -99,6 +105,7 @@ async function resolvePriorityChainCore(
         }
         const error: SettingResolutionError = {
             setting: 'defaultEnvManager',
+            kind: 'managerNotRegistered',
             configuredValue: userConfiguredManager,
             reason: `Environment manager '${userConfiguredManager}' is not registered`,
         };
@@ -118,6 +125,7 @@ async function resolvePriorityChainCore(
                 );
                 const error: SettingResolutionError = {
                     setting: 'defaultInterpreterPath',
+                    kind: 'pathUnresolvedVariables',
                     configuredValue: userInterpreterPath,
                     reason: l10n.t('Path contains unresolved variables'),
                 };
@@ -138,6 +146,7 @@ async function resolvePriorityChainCore(
                 );
                 const error: SettingResolutionError = {
                     setting: 'defaultInterpreterPath',
+                    kind: 'pathUnresolvedVariables',
                     configuredValue: userInterpreterPath,
                     reason: l10n.t('Path contains unresolved variables'),
                 };
@@ -155,6 +164,7 @@ async function resolvePriorityChainCore(
                 }
                 const error: SettingResolutionError = {
                     setting: 'defaultInterpreterPath',
+                    kind: 'pathCannotResolve',
                     configuredValue: userInterpreterPath,
                     reason: `Could not resolve interpreter path '${userInterpreterPath}'`,
                 };
@@ -384,7 +394,7 @@ export async function applyInitialEnvironmentSelection(
         resolveGlobalScope()
             .then(async (globalErrors) => {
                 if (globalErrors.length > 0) {
-                    await notifyUserOfSettingErrors(globalErrors);
+                    await notifyUserOfSettingErrors(globalErrors, envManagers);
                 }
             })
             .catch((err) => traceError(`[interpreterSelection] Background global scope resolution failed: ${err}`));
@@ -399,7 +409,7 @@ export async function applyInitialEnvironmentSelection(
 
     // Notify user if any settings could not be applied (workspace + global when awaited)
     if (allErrors.length > 0) {
-        await notifyUserOfSettingErrors(allErrors);
+        await notifyUserOfSettingErrors(allErrors, envManagers);
     }
 
     // Numeric values must go via the measures argument (properties are dropped).
@@ -430,9 +440,30 @@ export function resetSettingWarnings(): void {
     warnedSettings.clear();
 }
 
-async function notifyUserOfSettingErrors(errors: SettingResolutionError[]): Promise<void> {
+async function notifyUserOfSettingErrors(
+    errors: SettingResolutionError[],
+    envManagers: EnvironmentManagers,
+): Promise<void> {
+    // The priority chain records "manager not registered" errors at the time it runs,
+    // but several awaits happen before this function is reached. A third-party extension
+    // (e.g. Hatch) may finish activating during those awaits and register its manager.
+    // Re-check the current registry: if the manager is now present the error is stale
+    // and the warning would be a false positive.
+    const liveErrors = errors.filter((e) => {
+        if (e.kind === 'managerNotRegistered' && envManagers.getEnvironmentManager(e.configuredValue)) {
+            traceVerbose(
+                `[interpreterSelection] Manager '${e.configuredValue}' is now registered; suppressing stale warning`,
+            );
+            return false;
+        }
+        return true;
+    });
+    if (liveErrors.length === 0) {
+        return;
+    }
+
     // Group errors by setting type to avoid spamming the user
-    const uniqueSettings = [...new Set(errors.map((e) => e.setting))];
+    const uniqueSettings = [...new Set(liveErrors.map((e) => e.setting))];
 
     for (const setting of uniqueSettings) {
         if (warnedSettings.has(setting)) {
@@ -440,7 +471,7 @@ async function notifyUserOfSettingErrors(errors: SettingResolutionError[]): Prom
         }
         warnedSettings.add(setting);
 
-        const settingErrors = errors.filter((e) => e.setting === setting);
+        const settingErrors = liveErrors.filter((e) => e.setting === setting);
         const firstError = settingErrors[0];
 
         let message: string;

--- a/src/test/features/interpreterSelection.unit.test.ts
+++ b/src/test/features/interpreterSelection.unit.test.ts
@@ -972,7 +972,8 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
     test('should suppress stale warning when manager registers during await (issue #1517)', async () => {
         // Simulate the race: defaultEnvManager is set to 'pypa.hatch:hatch', which is not
         // registered at priority-chain evaluation time, but becomes registered before
-        // notifyUserOfSettingErrors runs. The warning must NOT be shown.
+        // notifyUserOfSettingErrors runs. The warning must NOT be shown — neither from the
+        // awaited workspace path nor from the deferred global `.then(...)` path.
         const hatchManagerId = 'pypa.hatch:hatch';
 
         sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([{ uri: testUri, name: 'test', index: 0 }]);
@@ -1016,6 +1017,19 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
             return mockVenvEnv;
         });
 
+        // The workspace folder will resolve (venv found), so global scope is deferred to
+        // a background `.then(...)`. Use a deferred promise to deterministically wait for
+        // that background work to complete before asserting on showWarningMessage —
+        // otherwise a regression in the deferred-path filtering would fire AFTER the test
+        // returned and silently slip through.
+        let resolveGlobalDone!: () => void;
+        const globalDone = new Promise<void>((resolve) => {
+            resolveGlobalDone = resolve;
+        });
+        mockEnvManagers.setEnvironments.callsFake(async () => {
+            resolveGlobalDone();
+        });
+
         const showWarnStub = sandbox.stub(windowApis, 'showWarningMessage').resolves(undefined);
 
         await applyInitialEnvironmentSelection(
@@ -1025,7 +1039,20 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
             mockApi as unknown as PythonEnvironmentApi,
         );
 
-        // Warning must NOT be shown because the error was stale
+        // Wait for the background global scope to call setEnvironments, then flush
+        // microtasks so the `.then(...)` handler that would call notifyUserOfSettingErrors
+        // has a chance to run before we assert.
+        await globalDone;
+        await new Promise<void>((resolve) => process.nextTick(resolve));
+
+        // Workspace folder should have resolved (venv found) and global scope was attempted
+        assert.ok(mockEnvManagers.setEnvironment.called, 'setEnvironment should be called for workspace folder');
+        assert.ok(
+            mockEnvManagers.setEnvironments.called,
+            'setEnvironments should be called for deferred global scope',
+        );
+
+        // Warning must NOT be shown because the error was stale on both paths
         assert.strictEqual(
             showWarnStub.called,
             false,

--- a/src/test/features/interpreterSelection.unit.test.ts
+++ b/src/test/features/interpreterSelection.unit.test.ts
@@ -968,6 +968,70 @@ suite('Interpreter Selection - applyInitialEnvironmentSelection', () => {
         const warningMessage = showWarnStub.firstCall.args[0] as string;
         assert.ok(warningMessage.includes('/nonexistent/python'), 'Warning message should include the configured path');
     });
+
+    test('should suppress stale warning when manager registers during await (issue #1517)', async () => {
+        // Simulate the race: defaultEnvManager is set to 'pypa.hatch:hatch', which is not
+        // registered at priority-chain evaluation time, but becomes registered before
+        // notifyUserOfSettingErrors runs. The warning must NOT be shown.
+        const hatchManagerId = 'pypa.hatch:hatch';
+
+        sandbox.stub(workspaceApis, 'getWorkspaceFolders').returns([{ uri: testUri, name: 'test', index: 0 }]);
+        sandbox.stub(workspaceApis, 'getConfiguration').returns(createMockConfig([]) as WorkspaceConfiguration);
+        sandbox.stub(helpers, 'getUserConfiguredSetting').callsFake((section: string, key: string) => {
+            if (section === 'python-envs' && key === 'defaultEnvManager') {
+                return hatchManagerId;
+            }
+            return undefined;
+        });
+
+        // Hatch is not registered when the priority chain runs (returns undefined),
+        // but by the time notifyUserOfSettingErrors is called, it is available.
+        const mockHatchManager = {
+            id: hatchManagerId,
+            name: 'hatch',
+            displayName: 'Hatch',
+            get: sandbox.stub().resolves(undefined),
+            set: sandbox.stub().resolves(),
+        } as unknown as sinon.SinonStubbedInstance<InternalEnvironmentManager>;
+
+        let hatchRegistered = false;
+        // Override getEnvironmentManager: returns undefined until hatchRegistered is set, then returns the manager
+        mockEnvManagers.getEnvironmentManager.callsFake((scope: unknown) => {
+            const id = typeof scope === 'string' ? scope : undefined;
+            if (id === hatchManagerId && hatchRegistered) {
+                return mockHatchManager;
+            }
+            if (id === 'ms-python.python:venv') {
+                return mockVenvManager;
+            }
+            if (id === 'ms-python.python:system') {
+                return mockSystemManager;
+            }
+            return undefined;
+        });
+
+        // Simulate Hatch registering during the venv discovery await
+        mockVenvManager.get.callsFake(async () => {
+            hatchRegistered = true; // Hatch "registers" while venv discovery is awaited
+            return mockVenvEnv;
+        });
+
+        const showWarnStub = sandbox.stub(windowApis, 'showWarningMessage').resolves(undefined);
+
+        await applyInitialEnvironmentSelection(
+            mockEnvManagers as unknown as EnvironmentManagers,
+            mockProjectManager as unknown as PythonProjectManager,
+            mockNativeFinder as unknown as NativePythonFinder,
+            mockApi as unknown as PythonEnvironmentApi,
+        );
+
+        // Warning must NOT be shown because the error was stale
+        assert.strictEqual(
+            showWarnStub.called,
+            false,
+            'showWarningMessage must NOT be called when manager registered before notification',
+        );
+    });
 });
 
 suite('Interpreter Selection - resolveGlobalEnvironmentByPriority', () => {


### PR DESCRIPTION
### Summary

Fixes a startup race that produces a spurious warning popup:

> Default environment manager `pypa.hatch:hatch` could not be applied: Environment manager `pypa.hatch:hatch` is not registered

Even though the manager is actually registered and working correctly seconds later. The same race affects any third-party environment-manager extension (e.g. `PyPA.hatch`, `pixi-code`).

Fixes #1517. The same root cause likely produces an equivalent symptom in other contributing extensions (e.g. the `pixi-code` extension, where a similar warning has been reported); this fix is generic and applies to any third-party manager that registers via the public API.

---

### The bug, in plain language

If a user sets `python-envs.defaultEnvManager` to a manager contributed by a separate extension (Hatch, Pixi, etc.), they sometimes see a warning popup at startup claiming the manager is not registered — even though the manager *is* registered and works fine. The popup is a false positive.

It does not reproduce on every machine. Some users hit it every launch, some never; on at least one user's machine, uninstalling system-level `conda` + `poetry` made the popup stop appearing (see issue thread).

---

### Root cause: a race between two concurrent `activate()` timelines

Once `vscode-python-environments` returns its API (`extension.ts` line 712), VS Code starts activating any dependent extensions that declare `"extensionDependencies": ["ms-python.vscode-python-envs"]` (Hatch and Pixi do exactly this). At that moment two `async` functions are running concurrently on the same Node.js event loop in the extension host:

**Timeline A** — our `setImmediate(async () => { … })` block in `extension.ts` (line 568+):

```ts
await createNativePythonFinder(...);                 // spawns pet binary
await Promise.all([
    safeRegister('system',   ...),
    safeRegister('conda',    ...),
    safeRegister('pyenv',    ...),
    safeRegister('pipenv',   ...),
    safeRegister('poetry',   ...),
    safeRegister('shellStartupVars', ...),
]);
await applyInitialEnvironmentSelection(...);          // <-- consults the registry
```

**Timeline B** — `PyPA.hatch.activate()` (or any other contributing extension):

```ts
const api = await getPythonApi();
// ...possibly runs `hatch --version` or other async setup...
api.registerEnvironmentManager(hatchManager);         // <-- writes to the registry
```

Both timelines yield at every `await`. The race target is the registry Map (`src/features/envManagers.ts` line 125, `this._environmentManagers.set(managerId, mgr)` — synchronous, the source of truth).

`applyInitialEnvironmentSelection` → `resolvePriorityChainCore` (`src/features/interpreterSelection.ts` lines 99–114) calls `envManagers.getEnvironmentManager('pypa.hatch:hatch')`. If Timeline B hasn't yet reached `registerEnvironmentManager` when Timeline A executes that lookup, an error is recorded with kind `managerNotRegistered`. Several more `await`s then run; by the time `notifyUserOfSettingErrors` is invoked, the manager often *has* registered — but the warning is shown anyway because the previously-recorded error is never re-evaluated.

#### Why timing varies by machine

The race outcome depends on:

- How quickly `pet` (the bundled Rust binary) streams JSON-RPC discovery messages back to the extension host. Each message is an I/O callback on the main event loop. More installed Python tooling (conda, poetry) → more environments to discover → more event-loop traffic → Hatch's `await child_process` for `hatch --version` resumes later.
- How long the third-party extension's own startup `await`s take.
- General OS-level CPU and disk I/O contention.

Removing conda and poetry from the user's system doesn't "fix" anything in our code path — it just shifts the timing enough that Timeline B usually wins.

---

### The fix

Re-check the live manager registry at notification time, and drop "manager not registered" errors that became stale during the `await`s between when the error was recorded and when the warning is about to be shown.

---

### Why not "fix the race itself"?

This is a real race condition, not just a stale-data bug, so the most architecturally pure fix would be to remove the race entirely — for example, by deferring `applyInitialEnvironmentSelection` until either (a) an expected set of third-party manager registrations has been observed, or (b) some deadline has elapsed.

That kind of fix was considered and rejected for this change because:

1. **The set of "expected" managers is unknown to us.** Third-party env-manager extensions opt in by calling `registerEnvironmentManager` at their own pace. We have no manifest of who is going to register, so any deadline is arbitrary.
2. **Adding deadlines couples activation time to extension-host scheduling.** A safe deadline on a slow machine could delay the user's interpreter selection visibly; an aggressive deadline still has the same race, just on a smaller timescale.
3. **Existing real not-registered errors must still be surfaced quickly.** If a user genuinely typos a manager id, they want the warning fast — not after a multi-second wait.
4. **The blast radius would be much larger.** Reordering activation/selection touches the whole initialization sequence, including pet startup, terminal management, project resolution, and telemetry timing — all of which are currently sequenced around the existing `setImmediate` boundary.

The chosen fix instead changes the *gate* (the notification), not the *race* (the order of activation). It is essentially: "before yelling at the user, confirm the problem is still real."

Future work could pursue the architectural fix as a follow-up, but it should be evaluated independently of #1517.

---

### Tradeoffs and known limits

- If a third-party manager genuinely takes longer to activate than `applyInitialEnvironmentSelection` (e.g. the manager extension's own `activate()` is unusually slow), the popup can still fire. After this fix the user can dismiss it and the manager will continue to work normally; no permanent state is corrupted.
- The fix only filters errors whose `kind === 'managerNotRegistered'`. Real not-registered errors (typo'd ids, uninstalled extension, etc.), unresolved-variable errors, and path-resolution errors still notify as before.
- This applies to both the awaited workspace-scope notification path and the deferred background global-scope notification path; both call sites pass `envManagers` to the updated helper.