### PR TITLE
Fix TypeError on deactivate

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -727,6 +727,8 @@ export async function disposeAll(disposables: IDisposable[]): Promise<void> {
 
 export async function deactivate(context: ExtensionContext) {
     await disposeAll(context.subscriptions);
-    context.subscriptions.length = 0; // Clear subscriptions to prevent memory leaks
+    if (context.subscriptions?.length) {
+        context.subscriptions.length = 0; // Clear subscriptions to prevent memory leaks
+    }
     traceInfo('Python Environments extension deactivated.');
 }


### PR DESCRIPTION
Fixes a TypeError caused due to a missing check on the `deactivate` method.

Fixes #1557