### PR TITLE
CI: Allow multiple labels

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -19,6 +19,6 @@ jobs:
       - name: 'PR impact specified'
         uses: mheap/github-action-required-labels@388fd6af37b34cdfe5a23b37060e763217e58b03 # v5.5.0
         with:
-          mode: exactly
+          mode: minimum
           count: 1
           labels: 'bug, debt, feature-request, no-changelog'


### PR DESCRIPTION
Right now, CI checks for PRs to be labeled as: bug, debt, feature-request, no-changelog.

However, there could be instances in which a PR is related to more than one of those labels, or any additional label.

As an example, PRs fail if test files are not edited, unless the "skip tests" label is present.

This modifies the behavior to require **at least one of the labels to be present**.