### PR TITLE
Rename PEP723 telemetry events to inlineScript

### DIFF
--- a/src/common/telemetry/constants.ts
+++ b/src/common/telemetry/constants.ts
@@ -212,24 +212,24 @@ export enum EventNames {
     /**
      * Telemetry event fired once per session, per URI, the first time a `.py`
      * file with a valid PEP 723 `# /// script` block is observed by the lazy
-     * detector. Used to size the population of users who actually see PEP 723
-     * files — the denominator for the "view vs edit" question.
+     * detector. Used to size the population of users who actually see inline
+     * script files — the denominator for the "view vs edit" question.
      * Properties:
      * - trigger: 'open' | 'save' (which workspace event surfaced the file)
      * - hasRequiresPython: boolean (whether the block declares `requires-python`)
      * Measures:
      * - dependencyCount: number (number of entries in the `dependencies` list)
      */
-    PEP723_DETECTED = 'PEP723.DETECTED',
+    INLINE_SCRIPT_DETECTED = 'inlineScript.detected',
     /**
      * Telemetry event fired once per session, per URI, the first time a `.py`
-     * file that previously raised a `PEP723.DETECTED` event receives a real
-     * text edit. Together with `PEP723.DETECTED` this measures the fraction
-     * of users who do more than view PEP 723 scripts.
+     * file that previously raised an `inlineScript.detected` event receives a
+     * real text edit. Together with `inlineScript.detected` this measures the
+     * fraction of users who do more than view inline script files.
      * Measures:
      * - duration: number (ms between the detection and the first edit)
      */
-    PEP723_EDITED = 'PEP723.EDITED',
+    INLINE_SCRIPT_EDITED = 'inlineScript.edited',
 }
 
 // Map all events to their properties
@@ -707,13 +707,13 @@ export interface IEventNamePropertyMapping {
     };
 
     /* __GDPR__
-        "pep723.detected": {
+        "inlineScript.detected": {
             "trigger": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "StellaHuang95" },
             "hasRequiresPython": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "StellaHuang95" },
             "dependencyCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "StellaHuang95" }
         }
     */
-    [EventNames.PEP723_DETECTED]: {
+    [EventNames.INLINE_SCRIPT_DETECTED]: {
         trigger: 'open' | 'save';
         hasRequiresPython: boolean;
         // Goes through the measures payload (numeric); listed here for GDPR only.
@@ -721,9 +721,9 @@ export interface IEventNamePropertyMapping {
     };
 
     /* __GDPR__
-        "pep723.edited": {
+        "inlineScript.edited": {
             "<duration>": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "StellaHuang95" }
         }
     */
-    [EventNames.PEP723_EDITED]: never | undefined;
+    [EventNames.INLINE_SCRIPT_EDITED]: never | undefined;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -207,8 +207,8 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
     );
 
     // Silent observer for `.py` files that declare PEP 723 inline
-    // script metadata. Emits anonymized telemetry (PEP723.DETECTED /
-    // PEP723.EDITED) but does not register projects or surface any UI.
+    // script metadata. Emits anonymized telemetry (inlineScript.detected /
+    // inlineScript.edited) but does not register projects or surface any UI.
     const inlineScriptLazyDetector = new InlineScriptLazyDetector();
     inlineScriptLazyDetector.activate();
     context.subscriptions.push(inlineScriptLazyDetector);

--- a/src/features/inlineScriptLazyDetector.ts
+++ b/src/features/inlineScriptLazyDetector.ts
@@ -21,12 +21,12 @@ import {
  * every eligible `.py` file the user opens or saves and emits two
  * anonymized telemetry events:
  *
- *  - `PEP723.DETECTED` once per (URI, session) the first time a
+ *  - `inlineScript.detected` once per (URI, session) the first time a
  *    valid `# /// script` block is observed. This is the denominator
- *    for the "how many users actually see PEP 723 files" question.
- *  - `PEP723.EDITED` once per (URI, session) the first time a
+ *    for the "how many users actually see inline script files" question.
+ *  - `inlineScript.edited` once per (URI, session) the first time a
  *    previously-detected file receives a real text edit. Together
- *    with `DETECTED` this distinguishes viewers from editors.
+ *    with `inlineScript.detected` this distinguishes viewers from editors.
  *
  * No URIs, file paths, or file content are sent. The detector does
  * not register projects, surface UI, or otherwise change extension
@@ -41,11 +41,11 @@ export class InlineScriptLazyDetector implements Disposable {
     // doesn't double-process the same file.
     private readonly inFlight = new Map<string, Promise<void>>();
     // URIs (as `uri.toString()`) for which we have already emitted
-    // `PEP723.DETECTED` in this session. Used to dedup the detection
-    // event across repeat opens/saves and to gate `PEP723.EDITED` so
+    // `inlineScript.detected` in this session. Used to dedup the detection
+    // event across repeat opens/saves and to gate `inlineScript.edited` so
     // the latter only fires for files we already counted as detected.
     private readonly detectedUris = new Set<string>();
-    // URIs for which we have already emitted `PEP723.EDITED` in this
+    // URIs for which we have already emitted `inlineScript.edited` in this
     // session. Each detected file emits at most one edited event.
     private readonly editedUris = new Set<string>();
     // Wall-clock ms (from `Date.now`) at which each URI's detection
@@ -178,7 +178,7 @@ export class InlineScriptLazyDetector implements Disposable {
             this.detectionAtMs.set(key, Date.now());
             traceVerbose(`inlineScriptLazyDetector: detected inline script metadata in ${uri.fsPath} (${trigger})`);
             sendTelemetryEvent(
-                EventNames.PEP723_DETECTED,
+                EventNames.INLINE_SCRIPT_DETECTED,
                 { dependencyCount: metadata.dependencies?.length ?? 0 },
                 {
                     trigger,
@@ -194,11 +194,11 @@ export class InlineScriptLazyDetector implements Disposable {
     }
 
     /**
-     * Emit `PEP723.EDITED` the first time a previously-detected URI
+     * Emit `inlineScript.edited` the first time a previously-detected URI
      * receives a real content change. The handler is hot (fires on
      * every keystroke in every text document workspace-wide) so it
      * bails out as cheaply as possible for the common case where the
-     * file is not a tracked PEP 723 script.
+     * file is not a tracked inline script.
      */
     private handleChange(e: TextDocumentChangeEvent): void {
         if (this.disposed) {
@@ -222,7 +222,7 @@ export class InlineScriptLazyDetector implements Disposable {
         traceVerbose(
             `inlineScriptLazyDetector: first edit observed on ${e.document.uri.fsPath} (${duration}ms after detection)`,
         );
-        sendTelemetryEvent(EventNames.PEP723_EDITED, duration);
+        sendTelemetryEvent(EventNames.INLINE_SCRIPT_EDITED, duration);
     }
 }
 

--- a/src/test/features/inlineScriptLazyDetector.unit.test.ts
+++ b/src/test/features/inlineScriptLazyDetector.unit.test.ts
@@ -120,7 +120,7 @@ suite('InlineScriptLazyDetector', () => {
         changeListener!(makeChange(uri, changes));
     }
 
-    // Filter `sendTelemetryStub.getCalls()` to a single PEP 723 event name.
+    // Filter `sendTelemetryStub.getCalls()` to a single inline script event name.
     function callsFor(name: EventNames): sinon.SinonSpyCall[] {
         return sendTelemetryStub.getCalls().filter((c) => c.args[0] === name);
     }
@@ -224,7 +224,7 @@ suite('InlineScriptLazyDetector', () => {
         // further work — including the detection telemetry event.
         resolveRead!(VALID_METADATA);
         await assert.doesNotReject(inFlight ?? Promise.resolve());
-        assert.strictEqual(callsFor(EventNames.PEP723_DETECTED).length, 0, 'no detection event after dispose');
+        assert.strictEqual(callsFor(EventNames.INLINE_SCRIPT_DETECTED).length, 0, 'no detection event after dispose');
     });
 
     // ---------- catch-up replay over `getOpenTextDocuments` ----------
@@ -271,16 +271,16 @@ suite('InlineScriptLazyDetector', () => {
         assert.ok(readMetadataStub.notCalled, 'dispose() must clear the pending setImmediate handle');
     });
 
-    // ---------- PEP723.DETECTED telemetry ----------
+    // ---------- inlineScript.detected telemetry ----------
 
-    test('PEP723.DETECTED fires once with trigger=open + dependencyCount + hasRequiresPython', async () => {
+    test('inlineScript.detected fires once with trigger=open + dependencyCount + hasRequiresPython', async () => {
         const uri = Uri.file(path.resolve('/ws/detect.py'));
         readMetadataStub.resolves(VALID_METADATA);
         const detector = new InlineScriptLazyDetector();
         detector.activate();
         await fireOpen(uri);
 
-        const detectedCalls = callsFor(EventNames.PEP723_DETECTED);
+        const detectedCalls = callsFor(EventNames.INLINE_SCRIPT_DETECTED);
         assert.strictEqual(detectedCalls.length, 1, 'detection event should fire exactly once');
         const [, measures, properties] = detectedCalls[0].args;
         assert.deepStrictEqual(measures, { dependencyCount: 2 });
@@ -288,30 +288,30 @@ suite('InlineScriptLazyDetector', () => {
         detector.dispose();
     });
 
-    test('PEP723.DETECTED fires with trigger=save when surfaced by a save event', async () => {
+    test('inlineScript.detected fires with trigger=save when surfaced by a save event', async () => {
         const uri = Uri.file(path.resolve('/ws/detectOnSave.py'));
         readMetadataStub.resolves(VALID_METADATA);
         const detector = new InlineScriptLazyDetector();
         detector.activate();
         await fireSave(uri);
 
-        const detectedCalls = callsFor(EventNames.PEP723_DETECTED);
+        const detectedCalls = callsFor(EventNames.INLINE_SCRIPT_DETECTED);
         assert.strictEqual(detectedCalls.length, 1);
         assert.strictEqual(detectedCalls[0].args[2].trigger, 'save');
         detector.dispose();
     });
 
-    test('PEP723.DETECTED does not fire when the file has no metadata block', async () => {
+    test('inlineScript.detected does not fire when the file has no metadata block', async () => {
         const uri = Uri.file(path.resolve('/ws/plain.py'));
         readMetadataStub.resolves(undefined);
         const detector = new InlineScriptLazyDetector();
         detector.activate();
         await fireOpen(uri);
-        assert.strictEqual(callsFor(EventNames.PEP723_DETECTED).length, 0);
+        assert.strictEqual(callsFor(EventNames.INLINE_SCRIPT_DETECTED).length, 0);
         detector.dispose();
     });
 
-    test('PEP723.DETECTED is deduplicated across repeated opens and saves of the same URI', async () => {
+    test('inlineScript.detected is deduplicated across repeated opens and saves of the same URI', async () => {
         const uri = Uri.file(path.resolve('/ws/repeat.py'));
         readMetadataStub.resolves(VALID_METADATA);
         const detector = new InlineScriptLazyDetector();
@@ -320,11 +320,11 @@ suite('InlineScriptLazyDetector', () => {
         await fireSave(uri);
         await fireSave(uri);
         await fireOpen(uri);
-        assert.strictEqual(callsFor(EventNames.PEP723_DETECTED).length, 1, 'detection event must dedup per session');
+        assert.strictEqual(callsFor(EventNames.INLINE_SCRIPT_DETECTED).length, 1, 'detection event must dedup per session');
         detector.dispose();
     });
 
-    test('PEP723.DETECTED reports hasRequiresPython=false when not declared', async () => {
+    test('inlineScript.detected reports hasRequiresPython=false when not declared', async () => {
         const uri = Uri.file(path.resolve('/ws/noPython.py'));
         readMetadataStub.resolves({
             requiresPython: undefined,
@@ -336,15 +336,15 @@ suite('InlineScriptLazyDetector', () => {
         detector.activate();
         await fireOpen(uri);
 
-        const [, measures, properties] = callsFor(EventNames.PEP723_DETECTED)[0].args;
+        const [, measures, properties] = callsFor(EventNames.INLINE_SCRIPT_DETECTED)[0].args;
         assert.deepStrictEqual(measures, { dependencyCount: 0 });
         assert.deepStrictEqual(properties, { trigger: 'open', hasRequiresPython: false });
         detector.dispose();
     });
 
-    // ---------- PEP723.EDITED telemetry ----------
+    // ---------- inlineScript.edited telemetry ----------
 
-    test('PEP723.EDITED fires once on first content change after detection', async () => {
+    test('inlineScript.edited fires once on first content change after detection', async () => {
         const uri = Uri.file(path.resolve('/ws/edit.py'));
         readMetadataStub.resolves(VALID_METADATA);
         const detector = new InlineScriptLazyDetector();
@@ -352,7 +352,7 @@ suite('InlineScriptLazyDetector', () => {
         await fireOpen(uri);
         fireChange(uri);
 
-        const editedCalls = callsFor(EventNames.PEP723_EDITED);
+        const editedCalls = callsFor(EventNames.INLINE_SCRIPT_EDITED);
         assert.strictEqual(editedCalls.length, 1, 'edited event should fire exactly once');
         // Second arg is the measure (number → { duration }); accept either form.
         const measureArg = editedCalls[0].args[1];
@@ -361,7 +361,7 @@ suite('InlineScriptLazyDetector', () => {
         detector.dispose();
     });
 
-    test('PEP723.EDITED is deduplicated across repeated edits of the same URI', async () => {
+    test('inlineScript.edited is deduplicated across repeated edits of the same URI', async () => {
         const uri = Uri.file(path.resolve('/ws/multiEdit.py'));
         readMetadataStub.resolves(VALID_METADATA);
         const detector = new InlineScriptLazyDetector();
@@ -370,22 +370,22 @@ suite('InlineScriptLazyDetector', () => {
         fireChange(uri);
         fireChange(uri);
         fireChange(uri);
-        assert.strictEqual(callsFor(EventNames.PEP723_EDITED).length, 1);
+        assert.strictEqual(callsFor(EventNames.INLINE_SCRIPT_EDITED).length, 1);
         detector.dispose();
     });
 
-    test('PEP723.EDITED does not fire for changes on a URI that was never detected', async () => {
+    test('inlineScript.edited does not fire for changes on a URI that was never detected', async () => {
         const uri = Uri.file(path.resolve('/ws/notDetected.py'));
         readMetadataStub.resolves(undefined);
         const detector = new InlineScriptLazyDetector();
         detector.activate();
         await fireOpen(uri);
         fireChange(uri);
-        assert.strictEqual(callsFor(EventNames.PEP723_EDITED).length, 0);
+        assert.strictEqual(callsFor(EventNames.INLINE_SCRIPT_EDITED).length, 0);
         detector.dispose();
     });
 
-    test('PEP723.EDITED ignores change events with no content changes', async () => {
+    test('inlineScript.edited ignores change events with no content changes', async () => {
         const uri = Uri.file(path.resolve('/ws/noOpChange.py'));
         readMetadataStub.resolves(VALID_METADATA);
         const detector = new InlineScriptLazyDetector();
@@ -395,14 +395,14 @@ suite('InlineScriptLazyDetector', () => {
         // array for things like dirty-state toggles; that's not a user
         // edit and must not count.
         fireChange(uri, []);
-        assert.strictEqual(callsFor(EventNames.PEP723_EDITED).length, 0);
+        assert.strictEqual(callsFor(EventNames.INLINE_SCRIPT_EDITED).length, 0);
         // A real edit still counts after the no-op was ignored.
         fireChange(uri);
-        assert.strictEqual(callsFor(EventNames.PEP723_EDITED).length, 1);
+        assert.strictEqual(callsFor(EventNames.INLINE_SCRIPT_EDITED).length, 1);
         detector.dispose();
     });
 
-    test('PEP723.EDITED is suppressed after dispose()', async () => {
+    test('inlineScript.edited is suppressed after dispose()', async () => {
         const uri = Uri.file(path.resolve('/ws/disposedEdit.py'));
         readMetadataStub.resolves(VALID_METADATA);
         const detector = new InlineScriptLazyDetector();
@@ -411,7 +411,7 @@ suite('InlineScriptLazyDetector', () => {
         const grabbedChangeListener = changeListener!;
         detector.dispose();
         grabbedChangeListener(makeChange(uri));
-        assert.strictEqual(callsFor(EventNames.PEP723_EDITED).length, 0);
+        assert.strictEqual(callsFor(EventNames.INLINE_SCRIPT_EDITED).length, 0);
     });
 });
 


### PR DESCRIPTION
## What

Rename the two PEP 723 telemetry events to use an `inlineScript` prefix instead of `PEP723`:

| Old | New |
| --- | --- |
| `PEP723.DETECTED` | `inlineScript.detected` |
| `PEP723.EDITED` | `inlineScript.edited` |
| `EventNames.PEP723_DETECTED` | `EventNames.INLINE_SCRIPT_DETECTED` |
| `EventNames.PEP723_EDITED` | `EventNames.INLINE_SCRIPT_EDITED` |

The new names are consistent with the rest of the module — `inlineScriptMetadata.ts`, `InlineScriptLazyDetector`, `readInlineScriptMetadataFromFile`, `InlineScriptMetadata` — and drop the PEP number from anything that leaves the machine.

The GDPR annotation keys were also realigned to match the wire names exactly (`"inlineScript.detected"` / `"inlineScript.edited"`).

## Why

I talked to the data platform team about why `PEP723.DETECTED` / `PEP723.EDITED` were missing from Kusto. They asked me to manually trigger the events and gave them my VS Code session ID. After I did, they could see every other event from that session — but not the two PEP 723 ones. They didn't know what was filtering them out either.

I don't know what's wrong yet. One guess is that the digits in the event name / GDPR key are tripping something in the ingestion or sanitization pipeline. This PR drops the numbers and renames the events to a clean alphabetic prefix to try again; if events start showing up in Kusto after this lands, that's our culprit.

## Scope

Telemetry-only rename — no behavior change. Code that refers to the PEP 723 *spec* (parser, docstrings, design docs, API jsdoc) is intentionally untouched.

## Files changed

- `src/common/telemetry/constants.ts` — enum members, jsdoc, and `__GDPR__` annotations
- `src/features/inlineScriptLazyDetector.ts` — `sendTelemetryEvent` calls + class jsdoc + field comments + handler jsdoc
- `src/extension.ts` — comment quoting the event names
- `src/test/features/inlineScriptLazyDetector.unit.test.ts` — section comments + 10 test titles + 16 `EventNames.*` references

## Verified

- ✅ `npm run lint` clean
- ✅ `npm run unittest` — all 1141 tests pass; the 10 renamed `inlineScript.*` tests show the new names
