### PR TITLE
Bump version to 1.36.0 for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-python-envs",
-    "version": "1.35.0",
+    "version": "1.36.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-python-envs",
-            "version": "1.35.0",
+            "version": "1.36.0",
             "dependencies": {
                 "@iarna/toml": "^2.2.5",
                 "@renovatebot/pep440": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-python-envs",
     "displayName": "Python Environments",
     "description": "Provides a unified python environment experience",
-    "version": "1.35.0",
+    "version": "1.36.0",
     "publisher": "ms-python",
     "preview": true,
     "engines": {


### PR DESCRIPTION
## Summary
- Bump the extension package version to 1.36.0.
- Refresh package-lock.json with npm.

## Notes
- After syncing to upstream/main, the stable Azure pipeline PET artifact branch is already refs/heads/release/2026.12. The requested 2026.8 -> 2026.10 bump is therefore already superseded on main, so this PR avoids downgrading the PET artifact branch.

## Verification
- npm install --package-lock-only