### PR TITLE
Bump version to 1.37.0 for prerelease

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-python-envs",
-    "version": "1.36.0",
+    "version": "1.37.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-python-envs",
-            "version": "1.36.0",
+            "version": "1.37.0",
             "dependencies": {
                 "@iarna/toml": "^2.2.5",
                 "@renovatebot/pep440": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-python-envs",
     "displayName": "Python Environments",
     "description": "Provides a unified python environment experience",
-    "version": "1.36.0",
+    "version": "1.37.0",
     "publisher": "ms-python",
     "preview": true,
     "engines": {


### PR DESCRIPTION
## Summary
- Bump the extension package version to 1.37.0 for the next prerelease cycle.
- Refresh package-lock.json with npm.

## Verification
- npm install --package-lock-only