### PR TITLE
Add site-packages watchers

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -8,6 +8,7 @@ import {
     FileChangeType,
     LogOutputChannel,
     MarkdownString,
+    RelativePattern,
     TaskExecution,
     Terminal,
     TerminalOptions,
@@ -689,6 +690,16 @@ export interface PackageManager {
      */
     getPackages(environment: PythonEnvironment, options?: GetPackagesOptions): Promise<Package[] | undefined>;
 
+    /**
+     * Returns additional filesystem patterns to watch for package install/uninstall changes.
+     *
+     * These patterns are appended to the default site-packages metadata locations.
+     * Implement this for manager-specific locations (for example, conda-meta).
+     *
+     * @param environment - The Python environment whose package paths should be watched.
+     * @returns Relative patterns to watch for package changes.
+     */
+    getPackageWatchTargets?(environment: PythonEnvironment): RelativePattern[];
     /**
      * Event that is fired when packages change.
      */

--- a/examples/sample1/src/api.ts
+++ b/examples/sample1/src/api.ts
@@ -7,6 +7,7 @@ import {
     FileChangeType,
     LogOutputChannel,
     MarkdownString,
+    RelativePattern,
     TaskExecution,
     Terminal,
     TerminalOptions,
@@ -615,6 +616,17 @@ export interface PackageManager {
      * @returns An array of packages, or undefined if the packages could not be retrieved.
      */
     getPackages(environment: PythonEnvironment, options?: GetPackagesOptions): Promise<Package[] | undefined>;
+
+    /**
+     * Returns additional filesystem patterns to watch for package install/uninstall changes.
+     *
+     * These patterns are appended to the default site-packages metadata locations.
+     * Implement this for manager-specific locations (for example, conda-meta).
+     *
+     * @param environment - The Python environment whose package paths should be watched.
+     * @returns Relative patterns to watch for package changes.
+     */
+    getPackageWatchTargets?(environment: PythonEnvironment): RelativePattern[];
 
     /**
      * Event that is fired when packages change.

--- a/package.json
+++ b/package.json
@@ -138,6 +138,12 @@
                     "description": "%python-envs.alwaysUseUv.description%",
                     "default": true,
                     "scope": "machine"
+                },
+                "python-envs.packageWatchers": {
+                    "type": "boolean",
+                    "description": "%python-envs.packageWatchers.description%",
+                    "default": true,
+                    "scope": "machine"
                 }
             }
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -46,5 +46,6 @@
     "python-envs.revealEnvInManagerView.title": "Reveal in Environment Managers View",
     "python-envs.runPetInTerminal.title": "Run Python Environment Tool (PET) in Terminal...",
     "python-envs.managePackageVersion.title": "Manage Package Version",
-    "python-envs.alwaysUseUv.description": "When set to true, uv will be used to manage all virtual environments if available. When set to false, uv will only manage virtual environments explicitly created by uv."
+    "python-envs.alwaysUseUv.description": "When set to true, uv will be used to manage all virtual environments if available. When set to false, uv will only manage virtual environments explicitly created by uv.",
+    "python-envs.packageWatchers.description": "When enabled, file system watchers monitor site-packages for install/uninstall changes and automatically refresh the package list. Disable this if you experience performance issues in large workspaces."
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -8,6 +8,7 @@ import type {
     FileChangeType,
     LogOutputChannel,
     MarkdownString,
+    RelativePattern,
     TaskExecution,
     Terminal,
     TerminalOptions,
@@ -683,6 +684,17 @@ export interface PackageManager {
      * @returns An array of packages, or undefined if the packages could not be retrieved.
      */
     getPackages(environment: PythonEnvironment, options?: GetPackagesOptions): Promise<Package[] | undefined>;
+
+    /**
+     * Returns additional filesystem patterns to watch for package install/uninstall changes.
+     *
+     * These patterns are appended to the default site-packages metadata locations.
+     * Implement this for manager-specific locations (for example, conda-meta).
+     *
+     * @param environment - The Python environment whose package paths should be watched.
+     * @returns Relative patterns to watch for package changes.
+     */
+    getPackageWatchTargets?(environment: PythonEnvironment): RelativePattern[];
 
     /**
      * Event that is fired when packages change.

--- a/src/managers/builtin/main.ts
+++ b/src/managers/builtin/main.ts
@@ -43,7 +43,7 @@ export async function registerSystemPythonFeatures(
     );
 
     disposables.push(
-        await registerPackageWatcherForManager(envManager, pkgManager, log),
-        await registerPackageWatcherForManager(venvManager, pkgManager, log),
+        registerPackageWatcherForManager(envManager, pkgManager, log),
+        registerPackageWatcherForManager(venvManager, pkgManager, log),
     );
 }

--- a/src/managers/builtin/main.ts
+++ b/src/managers/builtin/main.ts
@@ -4,6 +4,7 @@ import { createSimpleDebounce } from '../../common/utils/debounce';
 import { createFileSystemWatcher, onDidDeleteFiles } from '../../common/workspace.apis';
 import { getPythonApi } from '../../features/pythonApi';
 import { NativePythonFinder } from '../common/nativePythonFinder';
+import { registerPackageWatcherForManager } from '../common/packageWatcher';
 import { PipPackageManager } from './pipPackageManager';
 import { SysPythonManager } from './sysPythonManager';
 import { VenvManager } from './venvManager';
@@ -41,38 +42,8 @@ export async function registerSystemPythonFeatures(
         }),
     );
 
-    const packageDebouncedRefresh = createSimpleDebounce(500, async () => {
-        const projects = await api.getPythonProjects();
-        await Promise.all(
-            projects.map(async (project) => {
-                const env = await api.getEnvironment(project.uri);
-                if (!env) {
-                    return;
-                }
-                try {
-                    await api.refreshPackages(env);
-                } catch (ex) {
-                    log.error(
-                        `Failed to refresh packages for environment ${env.envId}: ${ex instanceof Error ? ex.message : String(ex)}`,
-                    );
-                }
-            }),
-        );
-    });
-    const packageWatcher = createFileSystemWatcher(
-        '**/site-packages/*.dist-info/METADATA',
-        false, // don't ignore create events    (pip install)
-        true, // ignore change events          (content changes in METADATA don't affect package list)
-        false, // don't ignore delete events    (pip uninstall)
-    );
     disposables.push(
-        packageDebouncedRefresh,
-        packageWatcher,
-        packageWatcher.onDidCreate(() => {
-            packageDebouncedRefresh.trigger();
-        }),
-        packageWatcher.onDidDelete(() => {
-            packageDebouncedRefresh.trigger();
-        }),
+        await registerPackageWatcherForManager(envManager, pkgManager, log),
+        await registerPackageWatcherForManager(venvManager, pkgManager, log),
     );
 }

--- a/src/managers/common/packageWatcher.ts
+++ b/src/managers/common/packageWatcher.ts
@@ -89,11 +89,11 @@ export function watchPackageChangesForEnvironment(
  * @param log - Logger for diagnostic and error messages.
  * @returns A disposable that removes all watchers and subscriptions when disposed.
  */
-export async function registerPackageWatcherForManager(
+export function registerPackageWatcherForManager(
     envManager: EnvironmentManager,
     packageManager: PackageManager,
     log: LogOutputChannel,
-): Promise<Disposable> {
+): Disposable {
     // One watcher per environment id.
     const watchers = new Map<string, Disposable>();
 

--- a/src/managers/common/packageWatcher.ts
+++ b/src/managers/common/packageWatcher.ts
@@ -5,10 +5,22 @@ import { traceVerbose } from '../../common/logging';
 import { createSimpleDebounce } from '../../common/utils/debounce';
 import { createFileSystemWatcher } from '../../common/workspace.apis';
 
+/**
+ * Derives the file system watch targets for a given Python environment.
+ *
+ * Targets include site-packages `.dist-info/METADATA` files (for pip installs/uninstalls)
+ * and conda-meta JSON files (for conda installs/uninstalls).
+ *
+ * @param env - The Python environment to derive watch targets for.
+ * @returns An array of RelativePattern objects, one per discoverable package location.
+ *          Empty if the environment has no `sysPrefix` or discoverable paths.
+ */
 function getWatchTargets(env: PythonEnvironment): RelativePattern[] {
-    if (!env.sysPrefix) return [];
-    const targets: RelativePattern[] = [];
+    if (!env.sysPrefix) {
+        return [];
+    }
 
+    const targets: RelativePattern[] = [];
     if (process.platform === 'win32') {
         targets.push(
             new RelativePattern(Uri.file(path.join(env.sysPrefix, 'Lib')), 'site-packages/**/*.dist-info/METADATA'),
@@ -21,13 +33,21 @@ function getWatchTargets(env: PythonEnvironment): RelativePattern[] {
             ),
         );
     }
-
-    // Conda
     targets.push(new RelativePattern(Uri.file(path.join(env.sysPrefix, 'conda-meta')), '**/*.json'));
-
     return targets;
 }
 
+/**
+ * Creates a file system watcher for package changes in a single environment.
+ *
+ * Monitors site-packages and conda-meta locations for install/uninstall operations
+ * and triggers a debounced package refresh when changes are detected.
+ *
+ * @param env - The Python environment to watch.
+ * @param packageManager - The package manager to call refresh on when changes occur.
+ * @param log - Logger for diagnostic messages.
+ * @returns A disposable that removes the watcher when disposed.
+ */
 export function watchPackageChangesForEnvironment(
     env: PythonEnvironment,
     packageManager: PackageManager,
@@ -68,9 +88,16 @@ export function watchPackageChangesForEnvironment(
 }
 
 /**
- * Registers package file watchers for all environments managed by the given manager.
+ * Registers automatic file system watchers for the active environment managed by a given manager.
  *
- * This is project-agnostic: if a manager discovers an environment, we watch it.
+ * Creates per-environment watchers that are attached when the active environment changes
+ * and detached when it changes to a different environment. Ensures package changes
+ * (installs/uninstalls) in the active environment are detected and trigger a refresh.
+ *
+ * @param envManager - The environment manager whose active environment should be watched.
+ * @param packageManager - The package manager to call refresh on when changes occur.
+ * @param log - Logger for diagnostic and error messages.
+ * @returns A disposable that removes all watchers and subscriptions when disposed.
  */
 export async function registerPackageWatcherForManager(
     envManager: EnvironmentManager,

--- a/src/managers/common/packageWatcher.ts
+++ b/src/managers/common/packageWatcher.ts
@@ -1,0 +1,113 @@
+import * as path from 'path';
+import { Disposable, LogOutputChannel, RelativePattern, Uri } from 'vscode';
+import { EnvironmentChangeKind, EnvironmentManager, PackageManager, PythonEnvironment } from '../../api';
+import { traceVerbose } from '../../common/logging';
+import { createSimpleDebounce } from '../../common/utils/debounce';
+import { createFileSystemWatcher } from '../../common/workspace.apis';
+
+function getWatchTargets(env: PythonEnvironment): RelativePattern[] {
+    if (!env.sysPrefix) return [];
+    const targets: RelativePattern[] = [];
+
+    if (process.platform === 'win32') {
+        targets.push(
+            new RelativePattern(Uri.file(path.join(env.sysPrefix, 'Lib')), 'site-packages/**/*.dist-info/METADATA'),
+        );
+    } else {
+        targets.push(
+            new RelativePattern(
+                Uri.file(path.join(env.sysPrefix, 'lib')),
+                'python*/site-packages/**/*.dist-info/METADATA',
+            ),
+        );
+    }
+
+    // Conda
+    targets.push(new RelativePattern(Uri.file(path.join(env.sysPrefix, 'conda-meta')), '**/*.json'));
+
+    return targets;
+}
+
+export function watchPackageChangesForEnvironment(
+    env: PythonEnvironment,
+    packageManager: PackageManager,
+    log: LogOutputChannel,
+): Disposable {
+    // Watch targets
+    const watchTargets = getWatchTargets(env);
+    if (watchTargets.length === 0) {
+        traceVerbose(log, `No watch targets for environment ${env.envId}`);
+        return new Disposable(() => undefined);
+    }
+    // Debounced refresh function
+    const debouncedRefresh = createSimpleDebounce(500, async () => {
+        packageManager.refresh(env).catch((ex) => {
+            log.error(
+                `Failed to refresh packages for environment ${env.envId}: ${ex instanceof Error ? ex.message : String(ex)}`,
+            );
+        });
+    });
+    // Create watchers
+    const disposables: Disposable[] = [];
+    for (const target of watchTargets) {
+        const watcher = createFileSystemWatcher(
+            target,
+            true, // create   -> install
+            false, // change   -> ignore
+            true, // delete   -> uninstall
+        );
+        disposables.push(
+            watcher,
+            watcher.onDidCreate(debouncedRefresh.trigger),
+            watcher.onDidDelete(debouncedRefresh.trigger),
+        );
+    }
+
+    return new Disposable(() => disposables.forEach((d) => d.dispose()));
+}
+
+/**
+ * Registers package file watchers for all environments managed by the given manager.
+ *
+ * This is project-agnostic: if a manager discovers an environment, we watch it.
+ */
+export async function registerPackageWatcherForManager(
+    envManager: EnvironmentManager,
+    packageManager: PackageManager,
+    log: LogOutputChannel,
+): Promise<Disposable> {
+    // One watcher per environment id.
+    const watchers = new Map<string, Disposable>();
+
+    const addWatcher = (env: PythonEnvironment): void => {
+        if (!watchers.has(env.envId.id)) {
+            watchers.set(env.envId.id, watchPackageChangesForEnvironment(env, packageManager, log));
+        }
+    };
+
+    const removeWatcher = (envId: string): void => {
+        watchers.get(envId)?.dispose();
+        watchers.delete(envId);
+    };
+
+    // Keep watchers in sync with environment discovery/removal events.
+    const envChangeDisposable = envManager.onDidChangeEnvironments?.((changes) => {
+        changes.forEach((change) => {
+            if (change.kind === EnvironmentChangeKind.add) {
+                addWatcher(change.environment);
+            } else {
+                removeWatcher(change.environment.envId.id);
+            }
+        });
+    });
+
+    // Seed with environments that already exist before this subscription.
+    const environments = await envManager.getEnvironments('all');
+    environments.forEach(addWatcher);
+
+    return new Disposable(() => {
+        envChangeDisposable?.dispose();
+        watchers.forEach((watcher) => watcher.dispose());
+        watchers.clear();
+    });
+}

--- a/src/managers/common/packageWatcher.ts
+++ b/src/managers/common/packageWatcher.ts
@@ -8,34 +8,26 @@ import { createFileSystemWatcher } from '../../common/workspace.apis';
 /**
  * Derives the file system watch targets for a given Python environment.
  *
- * Targets include site-packages `.dist-info/METADATA` files (for pip installs/uninstalls)
- * and conda-meta JSON files (for conda installs/uninstalls).
+ * Targets include site-packages `.dist-info/METADATA` files for pip-style installs.
  *
  * @param env - The Python environment to derive watch targets for.
  * @returns An array of RelativePattern objects, one per discoverable package location.
  *          Empty if the environment has no `sysPrefix` or discoverable paths.
  */
-function getWatchTargets(env: PythonEnvironment): RelativePattern[] {
+function getDefaultPackageWatchTargets(env: PythonEnvironment): RelativePattern[] {
     if (!env.sysPrefix) {
         return [];
     }
-
-    const targets: RelativePattern[] = [];
-    if (process.platform === 'win32') {
-        targets.push(new RelativePattern(path.join(env.sysPrefix, 'Lib'), 'site-packages/**/*.dist-info/METADATA'));
-    } else {
-        targets.push(
-            new RelativePattern(path.join(env.sysPrefix, 'lib'), 'python*/site-packages/**/*.dist-info/METADATA'),
-        );
-    }
-    targets.push(new RelativePattern(path.join(env.sysPrefix, 'conda-meta'), '**/*.json'));
-    return targets;
+    return process.platform === 'win32'
+        ? [new RelativePattern(path.join(env.sysPrefix, 'Lib'), 'site-packages/**/*.dist-info/METADATA')] // Windows
+        : [new RelativePattern(path.join(env.sysPrefix, 'lib'), 'python*/site-packages/**/*.dist-info/METADATA')]; // Unix-like
 }
 
 /**
  * Creates a file system watcher for package changes in a single environment.
  *
- * Monitors site-packages and conda-meta locations for install/uninstall operations
+ * Monitors default site-packages locations and any manager-specific extra locations
+ * for install/uninstall operations.
  * and triggers a debounced package refresh when changes are detected.
  *
  * @param env - The Python environment to watch.
@@ -49,14 +41,17 @@ export function watchPackageChangesForEnvironment(
     log: LogOutputChannel,
 ): Disposable {
     // Watch targets
-    const watchTargets = getWatchTargets(env);
+    const watchTargets = [
+        ...getDefaultPackageWatchTargets(env),
+        ...(packageManager.getPackageWatchTargets?.(env) ?? []),
+    ];
     if (watchTargets.length === 0) {
         traceVerbose(log, `No watch targets for environment ${env.envId}`);
         return new Disposable(() => undefined);
     }
     // Debounced refresh function
     const debouncedRefresh = createSimpleDebounce(500, async () => {
-        console.log(`Package change detected for environment ${env.envId}, refreshing packages...`);
+        traceVerbose(log, `Package change detected for environment ${env.envId.id}, refreshing packages.`);
         packageManager.refresh(env).catch((ex) => {
             log.error(
                 `Failed to refresh packages for environment ${env.envId}: ${ex instanceof Error ? ex.message : String(ex)}`,
@@ -68,9 +63,9 @@ export function watchPackageChangesForEnvironment(
     for (const target of watchTargets) {
         const watcher = createFileSystemWatcher(
             target,
-            true, // create   -> install
+            false, // create   -> install
             false, // change   -> ignore
-            true, // delete   -> uninstall
+            false, // delete   -> uninstall
         );
         disposables.push(
             watcher,

--- a/src/managers/common/packageWatcher.ts
+++ b/src/managers/common/packageWatcher.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { Disposable, LogOutputChannel, RelativePattern, Uri } from 'vscode';
+import { Disposable, LogOutputChannel, RelativePattern } from 'vscode';
 import { EnvironmentManager, PackageManager, PythonEnvironment } from '../../api';
 import { traceVerbose } from '../../common/logging';
 import { createSimpleDebounce } from '../../common/utils/debounce';
@@ -22,18 +22,13 @@ function getWatchTargets(env: PythonEnvironment): RelativePattern[] {
 
     const targets: RelativePattern[] = [];
     if (process.platform === 'win32') {
-        targets.push(
-            new RelativePattern(Uri.file(path.join(env.sysPrefix, 'Lib')), 'site-packages/**/*.dist-info/METADATA'),
-        );
+        targets.push(new RelativePattern(path.join(env.sysPrefix, 'Lib'), 'site-packages/**/*.dist-info/METADATA'));
     } else {
         targets.push(
-            new RelativePattern(
-                Uri.file(path.join(env.sysPrefix, 'lib')),
-                'python*/site-packages/**/*.dist-info/METADATA',
-            ),
+            new RelativePattern(path.join(env.sysPrefix, 'lib'), 'python*/site-packages/**/*.dist-info/METADATA'),
         );
     }
-    targets.push(new RelativePattern(Uri.file(path.join(env.sysPrefix, 'conda-meta')), '**/*.json'));
+    targets.push(new RelativePattern(path.join(env.sysPrefix, 'conda-meta'), '**/*.json'));
     return targets;
 }
 

--- a/src/managers/common/packageWatcher.ts
+++ b/src/managers/common/packageWatcher.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import { Disposable, LogOutputChannel, RelativePattern } from 'vscode';
 import { EnvironmentManager, PackageManager, PythonEnvironment } from '../../api';
-import { traceVerbose } from '../../common/logging';
 import { createSimpleDebounce } from '../../common/utils/debounce';
 import { createFileSystemWatcher, getConfiguration } from '../../common/workspace.apis';
 
@@ -46,31 +45,32 @@ export function watchPackageChangesForEnvironment(
         ...(packageManager.getPackageWatchTargets?.(env) ?? []),
     ];
     if (watchTargets.length === 0) {
-        traceVerbose(log, `No watch targets for environment ${env.envId}`);
+        log.debug(`No watch targets for environment ${env.envId.id}`);
         return new Disposable(() => undefined);
     }
     // Debounced refresh function
     const debouncedRefresh = createSimpleDebounce(500, async () => {
-        traceVerbose(log, `Package change detected for environment ${env.envId.id}, refreshing packages.`);
+        log.debug(`Package change detected for environment ${env.envId.id}, refreshing packages.`);
         packageManager.refresh(env).catch((ex) => {
             log.error(
-                `Failed to refresh packages for environment ${env.envId}: ${ex instanceof Error ? ex.message : String(ex)}`,
+                `Failed to refresh packages for environment ${env.envId.id}: ${ex instanceof Error ? ex.message : String(ex)}`,
             );
         });
     });
     // Create watchers
-    const disposables: Disposable[] = [];
+    const disposables: Disposable[] = [debouncedRefresh];
+    const trigger = debouncedRefresh.trigger.bind(debouncedRefresh);
     for (const target of watchTargets) {
         const watcher = createFileSystemWatcher(
             target,
             false, // create   -> install
-            false, // change   -> ignore
+            true, // change   -> ignore
             false, // delete   -> uninstall
         );
         disposables.push(
             watcher,
-            watcher.onDidCreate(debouncedRefresh.trigger),
-            watcher.onDidDelete(debouncedRefresh.trigger),
+            watcher.onDidCreate(trigger),
+            watcher.onDidDelete(trigger),
         );
     }
 
@@ -117,7 +117,7 @@ export function registerPackageWatcherForManager(
         if (changes.new) {
             addWatcher(changes.new);
         }
-        if (changes.old) {
+        if (changes.old && changes.old.envId.id !== changes.new?.envId.id) {
             removeWatcher(changes.old.envId.id);
         }
     });

--- a/src/managers/common/packageWatcher.ts
+++ b/src/managers/common/packageWatcher.ts
@@ -3,7 +3,7 @@ import { Disposable, LogOutputChannel, RelativePattern } from 'vscode';
 import { EnvironmentManager, PackageManager, PythonEnvironment } from '../../api';
 import { traceVerbose } from '../../common/logging';
 import { createSimpleDebounce } from '../../common/utils/debounce';
-import { createFileSystemWatcher } from '../../common/workspace.apis';
+import { createFileSystemWatcher, getConfiguration } from '../../common/workspace.apis';
 
 /**
  * Derives the file system watch targets for a given Python environment.
@@ -94,6 +94,11 @@ export function registerPackageWatcherForManager(
     packageManager: PackageManager,
     log: LogOutputChannel,
 ): Disposable {
+    const packageWatchersEnabled = getConfiguration('python-envs').get<boolean>('packageWatchers', true);
+    if (!packageWatchersEnabled) {
+        return new Disposable(() => undefined);
+    }
+
     // One watcher per environment id.
     const watchers = new Map<string, Disposable>();
 

--- a/src/managers/common/packageWatcher.ts
+++ b/src/managers/common/packageWatcher.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { Disposable, LogOutputChannel, RelativePattern, Uri } from 'vscode';
-import { EnvironmentChangeKind, EnvironmentManager, PackageManager, PythonEnvironment } from '../../api';
+import { EnvironmentManager, PackageManager, PythonEnvironment } from '../../api';
 import { traceVerbose } from '../../common/logging';
 import { createSimpleDebounce } from '../../common/utils/debounce';
 import { createFileSystemWatcher } from '../../common/workspace.apis';
@@ -41,6 +41,7 @@ export function watchPackageChangesForEnvironment(
     }
     // Debounced refresh function
     const debouncedRefresh = createSimpleDebounce(500, async () => {
+        console.log(`Package change detected for environment ${env.envId}, refreshing packages...`);
         packageManager.refresh(env).catch((ex) => {
             log.error(
                 `Failed to refresh packages for environment ${env.envId}: ${ex instanceof Error ? ex.message : String(ex)}`,
@@ -90,20 +91,14 @@ export async function registerPackageWatcherForManager(
         watchers.delete(envId);
     };
 
-    // Keep watchers in sync with environment discovery/removal events.
-    const envChangeDisposable = envManager.onDidChangeEnvironments?.((changes) => {
-        changes.forEach((change) => {
-            if (change.kind === EnvironmentChangeKind.add) {
-                addWatcher(change.environment);
-            } else {
-                removeWatcher(change.environment.envId.id);
-            }
-        });
+    const envChangeDisposable = envManager.onDidChangeEnvironment?.((changes) => {
+        if (changes.new) {
+            addWatcher(changes.new);
+        }
+        if (changes.old) {
+            removeWatcher(changes.old.envId.id);
+        }
     });
-
-    // Seed with environments that already exist before this subscription.
-    const environments = await envManager.getEnvironments('all');
-    environments.forEach(addWatcher);
 
     return new Disposable(() => {
         envChangeDisposable?.dispose();

--- a/src/managers/conda/condaPackageManager.ts
+++ b/src/managers/conda/condaPackageManager.ts
@@ -1,5 +1,6 @@
 import type { Pep440Version } from '@renovatebot/pep440';
 import { explain as parse, rcompare } from '@renovatebot/pep440';
+import * as path from 'path';
 import {
     CancellationError,
     Disposable,
@@ -8,6 +9,7 @@ import {
     LogOutputChannel,
     MarkdownString,
     ProgressLocation,
+    RelativePattern,
 } from 'vscode';
 import {
     DidChangePackagesEventArgs,
@@ -195,6 +197,14 @@ export class CondaPackageManager implements PackageManager, Disposable {
         } catch {
             return undefined;
         }
+    }
+
+    getPackageWatchTargets(environment: PythonEnvironment): RelativePattern[] {
+        if (!environment.sysPrefix) {
+            return [];
+        }
+
+        return [new RelativePattern(path.join(environment.sysPrefix, 'conda-meta'), '**/*.json')];
     }
 
     dispose() {

--- a/src/managers/conda/main.ts
+++ b/src/managers/conda/main.ts
@@ -56,7 +56,7 @@ export async function registerCondaFeatures(
             packageManager,
             api.registerEnvironmentManager(envManager),
             api.registerPackageManager(packageManager),
-            await registerPackageWatcherForManager(envManager, packageManager, log),
+            registerPackageWatcherForManager(envManager, packageManager, log),
         );
     } catch (ex) {
         await notifyMissingManagerIfDefault('ms-python.python:conda', projectManager, api);

--- a/src/managers/conda/main.ts
+++ b/src/managers/conda/main.ts
@@ -6,6 +6,7 @@ import { sendTelemetryEvent } from '../../common/telemetry/sender';
 import { getPythonApi } from '../../features/pythonApi';
 import { PythonProjectManager } from '../../internal.api';
 import { NativePythonFinder } from '../common/nativePythonFinder';
+import { registerPackageWatcherForManager } from '../common/packageWatcher';
 import { notifyMissingManagerIfDefault } from '../common/utils';
 import { CondaEnvManager } from './condaEnvManager';
 import { CondaPackageManager } from './condaPackageManager';
@@ -55,6 +56,7 @@ export async function registerCondaFeatures(
             packageManager,
             api.registerEnvironmentManager(envManager),
             api.registerPackageManager(packageManager),
+            await registerPackageWatcherForManager(envManager, packageManager, log),
         );
     } catch (ex) {
         await notifyMissingManagerIfDefault('ms-python.python:conda', projectManager, api);

--- a/src/managers/poetry/main.ts
+++ b/src/managers/poetry/main.ts
@@ -4,6 +4,7 @@ import { traceInfo } from '../../common/logging';
 import { getPythonApi } from '../../features/pythonApi';
 import { PythonProjectManager } from '../../internal.api';
 import { NativePythonFinder } from '../common/nativePythonFinder';
+import { registerPackageWatcherForManager } from '../common/packageWatcher';
 import { PoetryManager } from './poetryManager';
 import { PoetryPackageManager } from './poetryPackageManager';
 
@@ -24,5 +25,6 @@ export async function registerPoetryFeatures(
         pkgManager,
         api.registerEnvironmentManager(envManager),
         api.registerPackageManager(pkgManager),
+        await registerPackageWatcherForManager(envManager, pkgManager, outputChannel),
     );
 }

--- a/src/managers/poetry/main.ts
+++ b/src/managers/poetry/main.ts
@@ -25,6 +25,6 @@ export async function registerPoetryFeatures(
         pkgManager,
         api.registerEnvironmentManager(envManager),
         api.registerPackageManager(pkgManager),
-        await registerPackageWatcherForManager(envManager, pkgManager, outputChannel),
+        registerPackageWatcherForManager(envManager, pkgManager, outputChannel),
     );
 }

--- a/src/test/managers/common/packageWatcher.unit.test.ts
+++ b/src/test/managers/common/packageWatcher.unit.test.ts
@@ -309,7 +309,7 @@ suite('Package Watcher', () => {
             });
             const packageManager = createMockPackageManager();
 
-            await registerPackageWatcherForManager(
+            registerPackageWatcherForManager(
                 envManager as EnvironmentManager,
                 packageManager as PackageManager,
                 mockLogOutputChannel as LogOutputChannel,
@@ -342,7 +342,7 @@ suite('Package Watcher', () => {
             });
             const packageManager = createMockPackageManager();
 
-            const disposable = await registerPackageWatcherForManager(
+            const disposable = registerPackageWatcherForManager(
                 envManager as EnvironmentManager,
                 packageManager as PackageManager,
                 mockLogOutputChannel as LogOutputChannel,
@@ -387,7 +387,7 @@ suite('Package Watcher', () => {
             });
             const packageManager = createMockPackageManager();
 
-            const disposable = await registerPackageWatcherForManager(
+            const disposable = registerPackageWatcherForManager(
                 envManager as EnvironmentManager,
                 packageManager as PackageManager,
                 mockLogOutputChannel as LogOutputChannel,
@@ -418,7 +418,7 @@ suite('Package Watcher', () => {
             });
             const packageManager = createMockPackageManager();
 
-            const disposable = await registerPackageWatcherForManager(
+            const disposable = registerPackageWatcherForManager(
                 envManager as EnvironmentManager,
                 packageManager as PackageManager,
                 mockLogOutputChannel as LogOutputChannel,

--- a/src/test/managers/common/packageWatcher.unit.test.ts
+++ b/src/test/managers/common/packageWatcher.unit.test.ts
@@ -116,7 +116,7 @@ suite('Package Watcher', () => {
             const mockWatcher = createMockWatcher();
             createFileSystemWatcherStub.returns(mockWatcher);
 
-            const originalPlatform = (process as any).platform;
+            const originalPlatform = process.platform;
             Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
             try {
@@ -147,7 +147,7 @@ suite('Package Watcher', () => {
             const mockWatcher = createMockWatcher();
             createFileSystemWatcherStub.returns(mockWatcher);
 
-            const originalPlatform = (process as any).platform;
+            const originalPlatform = process.platform;
             Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
 
             try {

--- a/src/test/managers/common/packageWatcher.unit.test.ts
+++ b/src/test/managers/common/packageWatcher.unit.test.ts
@@ -204,7 +204,8 @@ suite('Package Watcher', () => {
             assert.strictEqual(secondPattern.pattern, '**/*.json', 'Should watch JSON files in conda-meta');
         });
 
-        test('should call packageManager.refresh on file create', () => {
+        test('should call packageManager.refresh on file create', async () => {
+            const clock = sandbox.useFakeTimers();
             const mockWatcher = createMockWatcher();
             createFileSystemWatcherStub.returns(mockWatcher);
 
@@ -217,12 +218,22 @@ suite('Package Watcher', () => {
                 mockLogOutputChannel as LogOutputChannel,
             );
 
-            // Verify watcher is created and create events are observed.
-            assert.strictEqual(createFileSystemWatcherStub.callCount, 1, 'Should create watcher for site-packages');
-            assert.strictEqual(createFileSystemWatcherStub.getCall(0).args[1], false, 'Should watch create events');
+            // Fire a create event and advance past debounce
+            mockWatcher._createEmitter.fire(Uri.file('/path/to/pkg.dist-info/METADATA'));
+            clock.tick(600);
+            await clock.tickAsync(0);
+
+            assert.strictEqual(
+                (packageManager.refresh as sinon.SinonStub).callCount,
+                1,
+                'Should call refresh on file create',
+            );
+
+            clock.restore();
         });
 
-        test('should call packageManager.refresh on file delete', () => {
+        test('should call packageManager.refresh on file delete', async () => {
+            const clock = sandbox.useFakeTimers();
             const mockWatcher = createMockWatcher();
             createFileSystemWatcherStub.returns(mockWatcher);
 
@@ -235,9 +246,18 @@ suite('Package Watcher', () => {
                 mockLogOutputChannel as LogOutputChannel,
             );
 
-            // Verify watcher is created and delete events are observed.
-            assert.strictEqual(createFileSystemWatcherStub.callCount, 1, 'Should create watcher for site-packages');
-            assert.strictEqual(createFileSystemWatcherStub.getCall(0).args[3], false, 'Should watch delete events');
+            // Fire a delete event and advance past debounce
+            mockWatcher._deleteEmitter.fire(Uri.file('/path/to/pkg.dist-info/METADATA'));
+            clock.tick(600);
+            await clock.tickAsync(0);
+
+            assert.strictEqual(
+                (packageManager.refresh as sinon.SinonStub).callCount,
+                1,
+                'Should call refresh on file delete',
+            );
+
+            clock.restore();
         });
 
         test('should debounce multiple rapid file events', () => {
@@ -436,7 +456,7 @@ suite('Package Watcher', () => {
 
             const initialCallCount = createFileSystemWatcherStub.callCount;
 
-            // Fire another change for the same environment
+            // Fire another change for the same environment (old === new)
             changeEmitter.fire({
                 uri: env.environmentPath,
                 new: env,
@@ -448,6 +468,12 @@ suite('Package Watcher', () => {
                 createFileSystemWatcherStub.callCount,
                 initialCallCount,
                 'Should not create duplicate watchers for same envId',
+            );
+
+            // Existing watcher should NOT be disposed when old.id === new.id
+            assert.ok(
+                !(mockWatcher.dispose as sinon.SinonStub).called,
+                'Should not dispose existing watcher when environment re-emits with same id',
             );
 
             disposable.dispose();

--- a/src/test/managers/common/packageWatcher.unit.test.ts
+++ b/src/test/managers/common/packageWatcher.unit.test.ts
@@ -104,12 +104,8 @@ suite('Package Watcher', () => {
                 mockLogOutputChannel as LogOutputChannel,
             );
 
-            // Should create watchers for site-packages and conda-meta
-            assert.strictEqual(
-                createFileSystemWatcherStub.callCount,
-                2,
-                'Should create 2 watchers (site-packages + conda-meta)',
-            );
+            // Default should create watcher for site-packages metadata.
+            assert.strictEqual(createFileSystemWatcherStub.callCount, 1, 'Should create 1 watcher (site-packages)');
         });
 
         test('should create correct watch patterns on Windows', () => {
@@ -174,12 +170,15 @@ suite('Package Watcher', () => {
             }
         });
 
-        test('should watch conda-meta for conda packages', () => {
+        test('should append package-manager-provided watch targets to defaults', () => {
             const mockWatcher = createMockWatcher();
             createFileSystemWatcherStub.returns(mockWatcher);
 
             const env = createMockEnvironment({ sysPrefix: '/path/to/env' });
             const packageManager = createMockPackageManager();
+            (packageManager as PackageManager).getPackageWatchTargets = () => [
+                new RelativePattern('/path/to/env/conda-meta', '**/*.json'),
+            ];
 
             watchPackageChangesForEnvironment(
                 env,
@@ -187,11 +186,19 @@ suite('Package Watcher', () => {
                 mockLogOutputChannel as LogOutputChannel,
             );
 
-            const secondCall = createFileSystemWatcherStub.getCall(1);
-            const pattern = secondCall.args[0] as RelativePattern;
+            assert.strictEqual(createFileSystemWatcherStub.callCount, 2, 'Should watch default and custom targets');
 
-            assert.ok(pattern.baseUri.fsPath.includes('conda-meta'), 'Should watch conda-meta');
-            assert.strictEqual(pattern.pattern, '**/*.json', 'Should watch JSON files in conda-meta');
+            const firstCall = createFileSystemWatcherStub.getCall(0);
+            const firstPattern = firstCall.args[0] as RelativePattern;
+            const secondCall = createFileSystemWatcherStub.getCall(1);
+            const secondPattern = secondCall.args[0] as RelativePattern;
+
+            assert.ok(
+                firstPattern.pattern.endsWith('site-packages/**/*.dist-info/METADATA'),
+                'Should keep default site-packages watcher',
+            );
+            assert.ok(secondPattern.baseUri.fsPath.includes('conda-meta'), 'Should append conda-meta target');
+            assert.strictEqual(secondPattern.pattern, '**/*.json', 'Should watch JSON files in conda-meta');
         });
 
         test('should call packageManager.refresh on file create', () => {
@@ -207,12 +214,9 @@ suite('Package Watcher', () => {
                 mockLogOutputChannel as LogOutputChannel,
             );
 
-            // Verify watchers are created which will have create event handlers
-            assert.strictEqual(
-                createFileSystemWatcherStub.callCount,
-                2,
-                'Should create watchers for site-packages and conda-meta',
-            );
+            // Verify watcher is created and create events are observed.
+            assert.strictEqual(createFileSystemWatcherStub.callCount, 1, 'Should create watcher for site-packages');
+            assert.strictEqual(createFileSystemWatcherStub.getCall(0).args[1], false, 'Should watch create events');
         });
 
         test('should call packageManager.refresh on file delete', () => {
@@ -228,12 +232,9 @@ suite('Package Watcher', () => {
                 mockLogOutputChannel as LogOutputChannel,
             );
 
-            // Verify watchers are created which will have delete event handlers
-            assert.strictEqual(
-                createFileSystemWatcherStub.callCount,
-                2,
-                'Should create watchers for site-packages and conda-meta',
-            );
+            // Verify watcher is created and delete events are observed.
+            assert.strictEqual(createFileSystemWatcherStub.callCount, 1, 'Should create watcher for site-packages');
+            assert.strictEqual(createFileSystemWatcherStub.getCall(0).args[3], false, 'Should watch delete events');
         });
 
         test('should debounce multiple rapid file events', () => {
@@ -249,11 +250,11 @@ suite('Package Watcher', () => {
                 mockLogOutputChannel as LogOutputChannel,
             );
 
-            // Verify watchers are created with event handlers for debouncing
+            // Verify watcher is created with event handlers for debouncing.
             assert.strictEqual(
                 createFileSystemWatcherStub.callCount,
-                2,
-                'Should create watchers with debounced event handlers',
+                1,
+                'Should create watcher with debounced event handlers',
             );
         });
 

--- a/src/test/managers/common/packageWatcher.unit.test.ts
+++ b/src/test/managers/common/packageWatcher.unit.test.ts
@@ -31,6 +31,9 @@ suite('Package Watcher', () => {
             debug: sandbox.stub(),
         };
         createFileSystemWatcherStub = sandbox.stub(workspaceApis, 'createFileSystemWatcher');
+        sandbox.stub(workspaceApis, 'getConfiguration').returns({
+            get: (_key: string, defaultValue?: unknown) => defaultValue ?? true,
+        } as ReturnType<typeof workspaceApis.getConfiguration>);
     });
 
     teardown(() => {

--- a/src/test/managers/common/packageWatcher.unit.test.ts
+++ b/src/test/managers/common/packageWatcher.unit.test.ts
@@ -1,0 +1,452 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { EventEmitter, LogOutputChannel, RelativePattern, Uri } from 'vscode';
+import {
+    DidChangeEnvironmentEventArgs,
+    EnvironmentManager,
+    PackageManager,
+    PythonEnvironment,
+    PythonEnvironmentId,
+} from '../../../api';
+import * as workspaceApis from '../../../common/workspace.apis';
+import {
+    registerPackageWatcherForManager,
+    watchPackageChangesForEnvironment,
+} from '../../../managers/common/packageWatcher';
+
+suite('Package Watcher', () => {
+    let sandbox: sinon.SinonSandbox;
+    let createFileSystemWatcherStub: sinon.SinonStub;
+    let mockLogOutputChannel: Partial<LogOutputChannel>;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        mockLogOutputChannel = {
+            error: sandbox.stub(),
+            warn: sandbox.stub(),
+            info: sandbox.stub(),
+            debug: sandbox.stub(),
+        };
+        createFileSystemWatcherStub = sandbox.stub(workspaceApis, 'createFileSystemWatcher');
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    function createMockEnvironment(overrides?: Partial<PythonEnvironment>): PythonEnvironment {
+        const envId: PythonEnvironmentId = {
+            id: 'test-env-id',
+            managerId: 'test-manager',
+            ...overrides?.envId,
+        };
+
+        return {
+            envId,
+            name: 'test-env',
+            displayName: 'Test Environment',
+            displayPath: '/path/to/env',
+            environmentPath: Uri.file('/path/to/env'),
+            version: '3.11.0',
+            sysPrefix: '/path/to/env',
+            execInfo: {
+                run: { executable: '/path/to/env/bin/python' },
+            },
+            ...overrides,
+        } as unknown as PythonEnvironment;
+    }
+
+    function createMockWatcher() {
+        const onDidCreateEmitter = new EventEmitter<Uri>();
+        const onDidDeleteEmitter = new EventEmitter<Uri>();
+        const onDidChangeEmitter = new EventEmitter<Uri>();
+
+        return {
+            onDidCreate: onDidCreateEmitter.event,
+            onDidDelete: onDidDeleteEmitter.event,
+            onDidChange: onDidChangeEmitter.event,
+            dispose: sandbox.stub(),
+            _createEmitter: onDidCreateEmitter,
+            _deleteEmitter: onDidDeleteEmitter,
+            _changeEmitter: onDidChangeEmitter,
+        };
+    }
+
+    function createMockPackageManager(): Partial<PackageManager> {
+        return {
+            refresh: sandbox.stub().resolves([]),
+        };
+    }
+
+    function createMockEnvironmentManager(overrides?: Partial<EnvironmentManager>): Partial<EnvironmentManager> {
+        const changeEmitter = new EventEmitter<DidChangeEnvironmentEventArgs>();
+
+        return {
+            onDidChangeEnvironment: changeEmitter.event,
+            ...overrides,
+        };
+    }
+
+    suite('watchPackageChangesForEnvironment', () => {
+        test('should create file system watchers for watch targets', () => {
+            const mockWatcher = createMockWatcher();
+            createFileSystemWatcherStub.returns(mockWatcher);
+
+            const env = createMockEnvironment();
+            const packageManager = createMockPackageManager();
+
+            watchPackageChangesForEnvironment(
+                env,
+                packageManager as PackageManager,
+                mockLogOutputChannel as LogOutputChannel,
+            );
+
+            // Should create watchers for site-packages and conda-meta
+            assert.strictEqual(
+                createFileSystemWatcherStub.callCount,
+                2,
+                'Should create 2 watchers (site-packages + conda-meta)',
+            );
+        });
+
+        test('should create correct watch patterns on Windows', () => {
+            const mockWatcher = createMockWatcher();
+            createFileSystemWatcherStub.returns(mockWatcher);
+
+            const originalPlatform = (process as any).platform;
+            Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+            try {
+                const env = createMockEnvironment({ sysPrefix: 'C:\\Users\\test\\env' });
+                const packageManager = createMockPackageManager();
+
+                watchPackageChangesForEnvironment(
+                    env,
+                    packageManager as PackageManager,
+                    mockLogOutputChannel as LogOutputChannel,
+                );
+
+                const firstCall = createFileSystemWatcherStub.getCall(0);
+                const pattern = firstCall.args[0] as RelativePattern;
+
+                assert.ok(pattern.baseUri.fsPath.includes('Lib'), 'Should use Lib for Windows');
+                assert.strictEqual(
+                    pattern.pattern,
+                    'site-packages/**/*.dist-info/METADATA',
+                    'Should watch .dist-info METADATA files',
+                );
+            } finally {
+                Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+            }
+        });
+
+        test('should create correct watch patterns on POSIX', () => {
+            const mockWatcher = createMockWatcher();
+            createFileSystemWatcherStub.returns(mockWatcher);
+
+            const originalPlatform = (process as any).platform;
+            Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+            try {
+                const env = createMockEnvironment({ sysPrefix: '/home/test/env' });
+                const packageManager = createMockPackageManager();
+
+                watchPackageChangesForEnvironment(
+                    env,
+                    packageManager as PackageManager,
+                    mockLogOutputChannel as LogOutputChannel,
+                );
+
+                const firstCall = createFileSystemWatcherStub.getCall(0);
+                const pattern = firstCall.args[0] as RelativePattern;
+
+                assert.ok(pattern.baseUri.fsPath.includes('lib'), 'Should use lib for POSIX');
+                assert.strictEqual(
+                    pattern.pattern,
+                    'python*/site-packages/**/*.dist-info/METADATA',
+                    'Should watch .dist-info METADATA files with python* glob',
+                );
+            } finally {
+                Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+            }
+        });
+
+        test('should watch conda-meta for conda packages', () => {
+            const mockWatcher = createMockWatcher();
+            createFileSystemWatcherStub.returns(mockWatcher);
+
+            const env = createMockEnvironment({ sysPrefix: '/path/to/env' });
+            const packageManager = createMockPackageManager();
+
+            watchPackageChangesForEnvironment(
+                env,
+                packageManager as PackageManager,
+                mockLogOutputChannel as LogOutputChannel,
+            );
+
+            const secondCall = createFileSystemWatcherStub.getCall(1);
+            const pattern = secondCall.args[0] as RelativePattern;
+
+            assert.ok(pattern.baseUri.fsPath.includes('conda-meta'), 'Should watch conda-meta');
+            assert.strictEqual(pattern.pattern, '**/*.json', 'Should watch JSON files in conda-meta');
+        });
+
+        test('should call packageManager.refresh on file create', () => {
+            const mockWatcher = createMockWatcher();
+            createFileSystemWatcherStub.returns(mockWatcher);
+
+            const env = createMockEnvironment();
+            const packageManager = createMockPackageManager();
+
+            watchPackageChangesForEnvironment(
+                env,
+                packageManager as PackageManager,
+                mockLogOutputChannel as LogOutputChannel,
+            );
+
+            // Verify watchers are created which will have create event handlers
+            assert.strictEqual(
+                createFileSystemWatcherStub.callCount,
+                2,
+                'Should create watchers for site-packages and conda-meta',
+            );
+        });
+
+        test('should call packageManager.refresh on file delete', () => {
+            const mockWatcher = createMockWatcher();
+            createFileSystemWatcherStub.returns(mockWatcher);
+
+            const env = createMockEnvironment();
+            const packageManager = createMockPackageManager();
+
+            watchPackageChangesForEnvironment(
+                env,
+                packageManager as PackageManager,
+                mockLogOutputChannel as LogOutputChannel,
+            );
+
+            // Verify watchers are created which will have delete event handlers
+            assert.strictEqual(
+                createFileSystemWatcherStub.callCount,
+                2,
+                'Should create watchers for site-packages and conda-meta',
+            );
+        });
+
+        test('should debounce multiple rapid file events', () => {
+            const mockWatcher = createMockWatcher();
+            createFileSystemWatcherStub.returns(mockWatcher);
+
+            const env = createMockEnvironment();
+            const packageManager = createMockPackageManager();
+
+            watchPackageChangesForEnvironment(
+                env,
+                packageManager as PackageManager,
+                mockLogOutputChannel as LogOutputChannel,
+            );
+
+            // Verify watchers are created with event handlers for debouncing
+            assert.strictEqual(
+                createFileSystemWatcherStub.callCount,
+                2,
+                'Should create watchers with debounced event handlers',
+            );
+        });
+
+        test('should dispose watchers when disposable is disposed', () => {
+            const mockWatcher = createMockWatcher();
+            createFileSystemWatcherStub.returns(mockWatcher);
+
+            const env = createMockEnvironment();
+            const packageManager = createMockPackageManager();
+
+            const disposable = watchPackageChangesForEnvironment(
+                env,
+                packageManager as PackageManager,
+                mockLogOutputChannel as LogOutputChannel,
+            );
+
+            disposable.dispose();
+
+            // Should dispose all watchers
+            assert.ok((mockWatcher.dispose as sinon.SinonStub).called, 'Watcher should be disposed');
+        });
+
+        test('should return empty disposable when environment has no sysPrefix', () => {
+            const env = createMockEnvironment({ sysPrefix: undefined });
+            const packageManager = createMockPackageManager();
+
+            const disposable = watchPackageChangesForEnvironment(
+                env,
+                packageManager as PackageManager,
+                mockLogOutputChannel as LogOutputChannel,
+            );
+
+            assert.ok(disposable, 'Should return a disposable');
+            // Should not create any watchers
+            assert.strictEqual(
+                createFileSystemWatcherStub.callCount,
+                0,
+                'Should not create watchers when sysPrefix is missing',
+            );
+        });
+    });
+
+    suite('registerPackageWatcherForManager', () => {
+        test('should create watcher for active environment on startup', async () => {
+            const mockWatcher = createMockWatcher();
+            createFileSystemWatcherStub.returns(mockWatcher);
+
+            const env = createMockEnvironment();
+            const changeEmitter = new EventEmitter<DidChangeEnvironmentEventArgs>();
+            const envManager = createMockEnvironmentManager({
+                onDidChangeEnvironment: changeEmitter.event,
+            });
+            const packageManager = createMockPackageManager();
+
+            await registerPackageWatcherForManager(
+                envManager as EnvironmentManager,
+                packageManager as PackageManager,
+                mockLogOutputChannel as LogOutputChannel,
+            );
+
+            // Simulate environment change to active environment
+            changeEmitter.fire({
+                uri: env.environmentPath,
+                new: env,
+                old: undefined,
+            });
+
+            // Should create watchers for the environment
+            assert.ok(createFileSystemWatcherStub.callCount > 0, 'Should create watchers when environment is set');
+        });
+
+        test('should create new watcher when active environment changes', async () => {
+            const mockWatcher1 = createMockWatcher();
+            const mockWatcher2 = createMockWatcher();
+            createFileSystemWatcherStub.onFirstCall().returns(mockWatcher1);
+            createFileSystemWatcherStub.onSecondCall().returns(mockWatcher2);
+            createFileSystemWatcherStub.returns(mockWatcher2);
+
+            const env1 = createMockEnvironment({ envId: { id: 'env-1', managerId: 'test' } });
+            const env2 = createMockEnvironment({ envId: { id: 'env-2', managerId: 'test' } });
+
+            const changeEmitter = new EventEmitter<DidChangeEnvironmentEventArgs>();
+            const envManager = createMockEnvironmentManager({
+                onDidChangeEnvironment: changeEmitter.event,
+            });
+            const packageManager = createMockPackageManager();
+
+            const disposable = await registerPackageWatcherForManager(
+                envManager as EnvironmentManager,
+                packageManager as PackageManager,
+                mockLogOutputChannel as LogOutputChannel,
+            );
+
+            // Create initial watcher for env1
+            changeEmitter.fire({
+                uri: env1.environmentPath,
+                new: env1,
+                old: undefined,
+            });
+
+            const initialCallCount = createFileSystemWatcherStub.callCount;
+
+            // Simulate environment change to env2
+            changeEmitter.fire({
+                uri: env2.environmentPath,
+                new: env2,
+                old: env1,
+            });
+
+            // Should create new watchers for env2
+            assert.ok(
+                createFileSystemWatcherStub.callCount > initialCallCount,
+                'Should create new watchers for new environment',
+            );
+
+            // Old watcher should be disposed
+            assert.ok((mockWatcher1.dispose as sinon.SinonStub).called, 'Old watcher should be disposed');
+
+            disposable.dispose();
+        });
+
+        test('should dispose all watchers when disposed', async () => {
+            const mockWatcher = createMockWatcher();
+            createFileSystemWatcherStub.returns(mockWatcher);
+
+            const env = createMockEnvironment();
+            const changeEmitter = new EventEmitter<DidChangeEnvironmentEventArgs>();
+            const envManager = createMockEnvironmentManager({
+                onDidChangeEnvironment: changeEmitter.event,
+            });
+            const packageManager = createMockPackageManager();
+
+            const disposable = await registerPackageWatcherForManager(
+                envManager as EnvironmentManager,
+                packageManager as PackageManager,
+                mockLogOutputChannel as LogOutputChannel,
+            );
+
+            // Simulate environment change to setup watcher
+            changeEmitter.fire({
+                uri: env.environmentPath,
+                new: env,
+                old: undefined,
+            });
+
+            disposable.dispose();
+
+            // Should dispose watchers
+            assert.ok((mockWatcher.dispose as sinon.SinonStub).called, 'Watchers should be disposed');
+        });
+
+        test('should not create duplicate watchers for same environment', async () => {
+            const mockWatcher = createMockWatcher();
+            createFileSystemWatcherStub.returns(mockWatcher);
+
+            const env = createMockEnvironment({ envId: { id: 'env-1', managerId: 'test' } });
+
+            const changeEmitter = new EventEmitter<DidChangeEnvironmentEventArgs>();
+            const envManager = createMockEnvironmentManager({
+                onDidChangeEnvironment: changeEmitter.event,
+            });
+            const packageManager = createMockPackageManager();
+
+            const disposable = await registerPackageWatcherForManager(
+                envManager as EnvironmentManager,
+                packageManager as PackageManager,
+                mockLogOutputChannel as LogOutputChannel,
+            );
+
+            // Set watcher for env1
+            changeEmitter.fire({
+                uri: env.environmentPath,
+                new: env,
+                old: undefined,
+            });
+
+            const initialCallCount = createFileSystemWatcherStub.callCount;
+
+            // Fire another change for the same environment
+            changeEmitter.fire({
+                uri: env.environmentPath,
+                new: env,
+                old: env,
+            });
+
+            // Should not create new watchers
+            assert.strictEqual(
+                createFileSystemWatcherStub.callCount,
+                initialCallCount,
+                'Should not create duplicate watchers for same envId',
+            );
+
+            disposable.dispose();
+        });
+    });
+});


### PR DESCRIPTION


https://github.com/user-attachments/assets/9e3a8d01-01c2-4e28-b20b-843bb6ff3076


This pull request refactors and centralizes the logic for watching Python package changes across different environment managers (system, conda, poetry). The new approach introduces a shared utility to handle file system watching for package metadata, ensuring more robust and consistent package refresh behavior when environments change.

Key improvements and changes:

**Centralized Package Watcher Logic:**
- Added a new module, `packageWatcher.ts`, which provides `watchPackageChangesForEnvironment` and `registerPackageWatcherForManager` to handle file watching and package refresh for any environment manager. This replaces duplicated logic in each manager.

**Refactoring of Environment Managers:**
- Updated `main.ts` files for system, conda, and poetry managers to use the new `registerPackageWatcherForManager` function, removing their own package watcher and debounce logic. This simplifies each manager and ensures consistency. [[1]](diffhunk://#diff-450a068335039323c00b342cbfbff615ecf1cda7bd9d73aaed6b8e13d2d9d7f5R7) [[2]](diffhunk://#diff-450a068335039323c00b342cbfbff615ecf1cda7bd9d73aaed6b8e13d2d9d7f5L44-R47) [[3]](diffhunk://#diff-c55f6a95cb5974ab8c7d3e66c62f818b1cb2c044168113aaf8ca4a5378925e8eR9) [[4]](diffhunk://#diff-c55f6a95cb5974ab8c7d3e66c62f818b1cb2c044168113aaf8ca4a5378925e8eR59) [[5]](diffhunk://#diff-27854fc91d92524ea1d6cecfec07dcb12f64204246b5d45097156ddc3a1867ecR7) [[6]](diffhunk://#diff-27854fc91d92524ea1d6cecfec07dcb12f64204246b5d45097156ddc3a1867ecR28)

**Improved Robustness and Maintainability:**
- The new watcher logic automatically tracks the active environment, ensuring watchers are always up-to-date and resources are cleaned up appropriately.

**Platform and Environment Awareness:**
- The watcher targets are now tailored to different platforms (Windows, Unix) and environment types (including conda), ensuring accurate detection of package changes.