### PR TITLE
Fix Git Bash conda activation when conda init bash was run (#1370)

### DIFF
--- a/src/managers/conda/condaUtils.ts
+++ b/src/managers/conda/condaUtils.ts
@@ -523,6 +523,7 @@ async function buildShellActivationMapForConda(
                 envIdentifier,
                 envManager.sourcingInformation.condaFolder,
                 condaShPath,
+                envManager.sourcingInformation.shellInitStatus,
             );
             return shellMaps;
         }
@@ -605,6 +606,7 @@ export async function windowsExceptionGenerateConfig(
     prefix: string,
     condaFolder: string,
     condaShPath?: string,
+    shellInitStatus?: ShellCondaInitStatus,
 ): Promise<ShellCommandMaps> {
     const shellActivation: Map<string, PythonCommandRunConfiguration[]> = new Map();
     const shellDeactivation: Map<string, PythonCommandRunConfiguration[]> = new Map();
@@ -625,7 +627,12 @@ export async function windowsExceptionGenerateConfig(
     // is bash-compatible; on Windows, sourceInitPath may point to "activate.bat", which
     // cannot be sourced by Git Bash, so in that case we skip emitting a Git Bash activation.
     let bashActivate: PythonCommandRunConfiguration[];
-    if (condaShPath) {
+    if (shellInitStatus?.bash) {
+        traceVerbose(
+            'Skipping `source conda.sh` for Git Bash because `conda init bash` was detected in the user shell profile',
+        );
+        bashActivate = [{ executable: 'conda', args: ['activate', quotedPrefix] }];
+    } else if (condaShPath) {
         bashActivate = [
             { executable: 'source', args: [condaShPath.replace(/\\/g, '/')] },
             { executable: 'conda', args: ['activate', quotedPrefix] },

--- a/src/test/managers/conda/condaUtils.windowsActivation.unit.test.ts
+++ b/src/test/managers/conda/condaUtils.windowsActivation.unit.test.ts
@@ -118,6 +118,133 @@ suite('Conda Utils - windowsExceptionGenerateConfig', () => {
         });
     });
 
+    suite('Git Bash activation when `conda init bash` was detected (#1370)', () => {
+        test('Skips `source conda.sh` and emits only `conda activate <prefix>` when shellInitStatus.bash is true', async () => {
+            getCondaHookPs1PathStub.resolves('C:\\conda\\shell\\condabin\\conda-hook.ps1');
+            const sourceInitPath = 'C:\\conda\\Scripts\\activate.bat';
+            const prefix = 'myenv';
+            const condaFolder = 'C:\\conda';
+            const condaShPath = 'C:\\conda\\etc\\profile.d\\conda.sh';
+
+            const result = await windowsExceptionGenerateConfig(sourceInitPath, prefix, condaFolder, condaShPath, {
+                bash: true,
+            });
+
+            const gitBashActivation = result.shellActivation.get(ShellConstants.GITBASH);
+            assert.ok(gitBashActivation, 'Git Bash activation should be defined');
+            assert.strictEqual(
+                gitBashActivation.length,
+                1,
+                'Should have a single `conda activate` command when conda init bash is detected',
+            );
+            assert.strictEqual(gitBashActivation[0].executable, 'conda');
+            assert.deepStrictEqual(gitBashActivation[0].args, ['activate', 'myenv']);
+        });
+
+        test('Skips `source conda.sh` even when condaShPath is not provided', async () => {
+            getCondaHookPs1PathStub.resolves(undefined);
+            const sourceInitPath = 'C:\\conda\\Scripts\\activate.bat';
+            const prefix = 'myenv';
+            const condaFolder = 'C:\\conda';
+
+            const result = await windowsExceptionGenerateConfig(sourceInitPath, prefix, condaFolder, undefined, {
+                bash: true,
+            });
+
+            const gitBashActivation = result.shellActivation.get(ShellConstants.GITBASH);
+            assert.ok(gitBashActivation, 'Git Bash activation should be defined');
+            assert.strictEqual(gitBashActivation.length, 1);
+            assert.strictEqual(gitBashActivation[0].executable, 'conda');
+            assert.deepStrictEqual(gitBashActivation[0].args, ['activate', 'myenv']);
+        });
+
+        test('Quotes prefix paths that contain spaces', async () => {
+            getCondaHookPs1PathStub.resolves(undefined);
+            const prefixWithSpaces = 'C:\\Users\\John Doe\\envs\\myenv';
+
+            const result = await windowsExceptionGenerateConfig(
+                'C:\\conda\\Scripts\\activate.bat',
+                prefixWithSpaces,
+                'C:\\conda',
+                'C:\\conda\\etc\\profile.d\\conda.sh',
+                { bash: true },
+            );
+
+            const gitBashActivation = result.shellActivation.get(ShellConstants.GITBASH);
+            assert.ok(gitBashActivation);
+            assert.strictEqual(gitBashActivation.length, 1);
+            assert.strictEqual(gitBashActivation[0].executable, 'conda');
+            assert.ok(gitBashActivation[0].args, 'args should be defined');
+            assert.strictEqual(gitBashActivation[0].args[0], 'activate');
+            assert.ok(
+                gitBashActivation[0].args[1].startsWith('"') && gitBashActivation[0].args[1].endsWith('"'),
+                'prefix containing spaces should be quoted',
+            );
+        });
+
+        test('Still emits `source conda.sh + conda activate` when shellInitStatus.bash is false', async () => {
+            getCondaHookPs1PathStub.resolves(undefined);
+            const condaShPath = 'C:\\conda\\etc\\profile.d\\conda.sh';
+
+            const result = await windowsExceptionGenerateConfig(
+                'C:\\conda\\Scripts\\activate.bat',
+                'myenv',
+                'C:\\conda',
+                condaShPath,
+                { bash: false },
+            );
+
+            const gitBashActivation = result.shellActivation.get(ShellConstants.GITBASH);
+            assert.ok(gitBashActivation);
+            assert.strictEqual(gitBashActivation.length, 2);
+            assert.strictEqual(gitBashActivation[0].executable, 'source');
+            assert.strictEqual(gitBashActivation[1].executable, 'conda');
+        });
+
+        test('Still emits `source conda.sh + conda activate` when shellInitStatus is undefined', async () => {
+            getCondaHookPs1PathStub.resolves(undefined);
+            const condaShPath = 'C:\\conda\\etc\\profile.d\\conda.sh';
+
+            const result = await windowsExceptionGenerateConfig(
+                'C:\\conda\\Scripts\\activate.bat',
+                'myenv',
+                'C:\\conda',
+                condaShPath,
+            );
+
+            const gitBashActivation = result.shellActivation.get(ShellConstants.GITBASH);
+            assert.ok(gitBashActivation);
+            assert.strictEqual(gitBashActivation.length, 2);
+            assert.strictEqual(gitBashActivation[0].executable, 'source');
+            assert.strictEqual(gitBashActivation[1].executable, 'conda');
+        });
+
+        test('Does not affect PowerShell or CMD activation when shellInitStatus.bash is true', async () => {
+            getCondaHookPs1PathStub.resolves('C:\\conda\\shell\\condabin\\conda-hook.ps1');
+            const sourceInitPath = 'C:\\conda\\Scripts\\activate.bat';
+
+            const result = await windowsExceptionGenerateConfig(
+                sourceInitPath,
+                'myenv',
+                'C:\\conda',
+                'C:\\conda\\etc\\profile.d\\conda.sh',
+                { bash: true },
+            );
+
+            const pwshActivation = result.shellActivation.get(ShellConstants.PWSH);
+            assert.ok(pwshActivation);
+            assert.strictEqual(pwshActivation.length, 2);
+            assert.strictEqual(pwshActivation[0].executable, 'C:\\conda\\shell\\condabin\\conda-hook.ps1');
+            assert.strictEqual(pwshActivation[1].executable, 'conda');
+
+            const cmdActivation = result.shellActivation.get(ShellConstants.CMD);
+            assert.ok(cmdActivation);
+            assert.strictEqual(cmdActivation.length, 2);
+            assert.strictEqual(cmdActivation[0].executable, sourceInitPath);
+            assert.strictEqual(cmdActivation[1].executable, 'conda');
+        });
+    });
+
     suite('PowerShell activation', () => {
         test('Uses ps1 hook when available', async () => {
             // Arrange


### PR DESCRIPTION
Closes #1370

## Context

On Windows, when a user has run `conda init bash` and has `auto_activate_base` enabled (conda default), opening a Git Bash terminal in VS Code with auto-activation enabled causes every subsequent `conda` command to fail with:

```
bash: /cygdrive/c/Users/<user>/anaconda3/Scripts/conda.exe: No such file or directory
```

The terminal still displays `(base)` and appears active, but conda is silently broken until the user closes and reopens the terminal.

## Root cause

A chain of three independent systems creates the failure:

1. The user's `~/.bashrc` (modified by `conda init bash`) initializes conda on shell startup — defines the `conda` shell function and sets `CONDA_EXE` correctly.
2. `auto_activate_base = true` activates `(base)`, which prepends `anaconda3/Library/usr/bin` to `PATH`. That directory ships **Anaconda's own (Cygwin-style) `cygpath`**, which now shadows Git Bash's MSYS `cygpath`. The two emit different path formats:
   - Git Bash's `cygpath C:\foo` → `/c/foo` ✅ (Git Bash understands)
   - Anaconda's `cygpath C:\foo` → `/cygdrive/c/foo` ❌ (Git Bash does NOT understand)
3. The extension then injects:
   ```bash
   source <conda>/etc/profile.d/conda.sh && conda activate <env>
   ```
   The first line of `conda.sh` is:
   ```bash
   export CONDA_EXE="$(cygpath 'C:/.../conda.exe')"
   ```
   Re-sourcing now runs the shadowed Cygwin `cygpath`, producing `/cygdrive/c/...`. `CONDA_EXE` is corrupted. The `conda` shell function (which delegates to `$CONDA_EXE`) fails for every subsequent invocation.

The corruption is entirely caused by **re-sourcing `conda.sh` in a terminal that already initialized conda**. If we skip the re-sourcing, the original (correct) `CONDA_EXE` remains intact and conda keeps working.

## Why the existing safeguards do not catch this

`buildShellActivationMapForConda` has a P1 short-circuit that skips re-sourcing when `isActiveOnLaunch` is true. That flag is derived from `process.env.CONDA_SHLVL` **at VS Code startup**. The user launches VS Code normally (not from a conda-active shell), so `CONDA_SHLVL` is unset at the VS Code process level and the safeguard never fires — even though conda will be active inside every new terminal.

The extension already has a separate signal that *does* fire in this scenario: `checkCondaInitInShellProfiles()` reads the user's shell profiles and reports `shellInitStatus.bash = true` when `conda initialize` is present. The non-Windows path already accepts this signal, but only uses it as a fallback when sourcing scripts are missing. The Windows path doesn't accept it at all.

## The fix

Pass `shellInitStatus` through to `windowsExceptionGenerateConfig` and add an early branch in the Git Bash logic:

```typescript
if (shellInitStatus?.bash) {
    // .bashrc/.bash_profile already defines `conda` and sets CONDA_EXE
    // correctly. Re-sourcing conda.sh here would corrupt CONDA_EXE on
    // Windows when base is active (#1370).
    bashActivate = [{ executable: 'conda', args: ['activate', quotedPrefix] }];
}
```

The new branch is the **first** condition checked. When the user has run `conda init bash`, we emit only `conda activate <prefix>` instead of `source conda.sh && conda activate <prefix>`.


## Why this fixes the issue

The bug is triggered by re-running `cygpath` (in a shadowed PATH context) inside `conda.sh`. By skipping the redundant `source`, we never re-execute that line, so `CONDA_EXE` retains the correct value set by the original `conda init bash` hook in the user's shell profile. The `conda activate` call then uses the already-loaded `conda` shell function with the correct `CONDA_EXE`, and everything works.
