### PR TITLE
CI: fix lock issues workflow token validation

### DIFF
--- a/.github/workflows/lock-issues.yml
+++ b/.github/workflows/lock-issues.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Lock Issues'
-        uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
+        uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '30'


### PR DESCRIPTION
## Summary
- Bump `dessant/lock-threads` in the lock issues workflow from v6.0.0 to v6.0.2
- Pick up the upstream fix that raises `github-token` validation from 100 to 1000 characters

## Validation
- `git diff --check -- .github/workflows/lock-issues.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/lock-issues.yml"); puts "YAML parsed"'`

`actionlint` was not available locally, and Go was not installed for the fallback runner.