### PR TITLE
Introduce package manager command classes

### DIFF
--- a/src/managers/base/commands/availableVersions.ts
+++ b/src/managers/base/commands/availableVersions.ts
@@ -1,0 +1,31 @@
+import type { Pep440Version } from '@renovatebot/pep440';
+import { explain as parsePep440Version } from '@renovatebot/pep440';
+import { BaseExecuteArgs, PackageManagerCommand } from './packageManagerCommand';
+
+/**
+ * Arguments for available versions command execution (change per execution).
+ */
+export interface AvailableVersionsExecuteArgs extends BaseExecuteArgs {
+    packageName: string;
+    pythonVersion: string;
+    includePrerelease?: boolean;
+}
+
+/**
+ * Template class for availableVersions commands.
+ * Subclasses implement concrete package-manager-specific logic.
+ */
+export abstract class AvailableVersionsCommand extends PackageManagerCommand {
+    protected static readonly configSection = 'availableVersionsCommandArgs';
+    protected abstract buildCommand(executeArgs: AvailableVersionsExecuteArgs): string[];
+    protected parseVersions(versions: string[], includePrerelease?: boolean): Pep440Version[] {
+        let parsed = Array.from(new Set(versions))
+            .map((version) => parsePep440Version(version.trim()))
+            .filter((version): version is Pep440Version => version !== null);
+        if (includePrerelease === false) {
+            parsed = parsed.filter((version) => !/[ab]|rc|dev/i.test(version.public));
+        }
+        return parsed;
+    }
+    abstract execute(executeArgs: AvailableVersionsExecuteArgs): Promise<Pep440Version[]>;
+}

--- a/src/managers/base/commands/availableVersions.ts
+++ b/src/managers/base/commands/availableVersions.ts
@@ -23,7 +23,7 @@ export abstract class AvailableVersionsCommand extends PackageManagerCommand {
             .map((version) => parsePep440Version(version.trim()))
             .filter((version): version is Pep440Version => version !== null);
         if (includePrerelease === false) {
-            parsed = parsed.filter((version) => !/[ab]|rc|dev/i.test(version.public));
+            parsed = parsed.filter((version) => !version.is_prerelease);
         }
         return parsed;
     }

--- a/src/managers/base/commands/index.ts
+++ b/src/managers/base/commands/index.ts
@@ -1,0 +1,7 @@
+export { AvailableVersionsCommand, type AvailableVersionsExecuteArgs } from './availableVersions';
+export { InstallCommand, type InstallExecuteArgs } from './install';
+export { ListCommand } from './list';
+export { ListDirectNamesCommand } from './listDirectNames';
+export { BaseExecuteArgs, CommandConstructorOptions, PackageManagerCommand } from './packageManagerCommand';
+export { UninstallCommand, type UninstallExecuteArgs } from './uninstall';
+export { VersionCommand } from './version';

--- a/src/managers/base/commands/install.ts
+++ b/src/managers/base/commands/install.ts
@@ -1,0 +1,19 @@
+import { BaseExecuteArgs, PackageManagerCommand } from './packageManagerCommand';
+
+/**
+ * Arguments for install command execution (change per execution).
+ */
+export interface InstallExecuteArgs extends BaseExecuteArgs {
+    packages: { packageName: string; version?: string }[];
+    upgrade?: boolean;
+}
+
+/**
+ * Template class for install commands.
+ * Subclasses implement concrete package-manager-specific logic.
+ */
+export abstract class InstallCommand extends PackageManagerCommand {
+    protected static readonly configSection = 'installCommandArgs';
+    protected abstract buildCommand(executeArgs: InstallExecuteArgs): string[];
+    abstract execute(executeArgs: InstallExecuteArgs): Promise<void>;
+}

--- a/src/managers/base/commands/list.ts
+++ b/src/managers/base/commands/list.ts
@@ -1,0 +1,12 @@
+import { PackageInfo } from '../../../api';
+import { BaseExecuteArgs, PackageManagerCommand } from './packageManagerCommand';
+
+/**
+ * Template class for list commands.
+ * Subclasses implement concrete package-manager-specific logic.
+ */
+export abstract class ListCommand extends PackageManagerCommand {
+    protected static readonly configSection = 'listCommandArgs';
+    protected timeout = 30000;
+    abstract execute(executeArgs?: BaseExecuteArgs): Promise<PackageInfo[]>;
+}

--- a/src/managers/base/commands/listDirectNames.ts
+++ b/src/managers/base/commands/listDirectNames.ts
@@ -1,0 +1,11 @@
+import { BaseExecuteArgs, PackageManagerCommand } from './packageManagerCommand';
+
+/**
+ * Template class for listDirectNames commands.
+ * Subclasses implement concrete package-manager-specific logic.
+ */
+export abstract class ListDirectNamesCommand extends PackageManagerCommand {
+    protected static readonly configSection = 'listDirectNamesCommandArgs';
+    protected timeout = 30000;
+    abstract execute(executeArgs?: BaseExecuteArgs): Promise<Set<string>>;
+}

--- a/src/managers/base/commands/packageManagerCommand.ts
+++ b/src/managers/base/commands/packageManagerCommand.ts
@@ -1,0 +1,46 @@
+import { CancellationToken, LogOutputChannel, WorkspaceConfiguration } from 'vscode';
+import { getConfiguration } from '../../../common/workspace.apis';
+
+/**
+ * Base interface for all command execute arguments.
+ * Provides optional cancellation token that all commands can use.
+ */
+export interface BaseExecuteArgs {
+    cancellationToken?: CancellationToken;
+}
+
+/**
+ * Constructor options shared by all package manager commands.
+ */
+export interface CommandConstructorOptions {
+    pythonExecutable: string;
+    cwd?: string;
+    log?: LogOutputChannel;
+}
+
+/**
+ * Base class for all package manager commands.
+ * Provides common properties and minimal interface for subclasses.
+ */
+export abstract class PackageManagerCommand {
+    protected static readonly configSection?: string;
+
+    protected pythonExecutable: string;
+    protected cwd?: string;
+    protected log?: LogOutputChannel;
+    protected timeout: number = 300000;
+    protected config?: WorkspaceConfiguration;
+
+    constructor(options: CommandConstructorOptions) {
+        this.pythonExecutable = options.pythonExecutable;
+        this.cwd = options.cwd;
+        this.log = options.log;
+        const configSection = (this.constructor as typeof PackageManagerCommand).configSection;
+        this.config = configSection ? getConfiguration(`python-envs.packageManager.${configSection}`) : undefined;
+    }
+
+    /**
+     * Subclasses implement to build the command arguments.
+     */
+    protected abstract buildCommand(executeArgs: BaseExecuteArgs): string[];
+}

--- a/src/managers/base/commands/uninstall.ts
+++ b/src/managers/base/commands/uninstall.ts
@@ -1,0 +1,18 @@
+import { BaseExecuteArgs, PackageManagerCommand } from './packageManagerCommand';
+
+/**
+ * Arguments for uninstall command execution (change per execution).
+ */
+export interface UninstallExecuteArgs extends BaseExecuteArgs {
+    packages: { packageName: string; version?: string }[];
+}
+
+/**
+ * Template class for uninstall commands.
+ * Subclasses implement concrete package-manager-specific logic.
+ */
+export abstract class UninstallCommand extends PackageManagerCommand {
+    protected static readonly configSection = 'uninstallCommandArgs';
+    protected abstract buildCommand(executeArgs: UninstallExecuteArgs): string[];
+    abstract execute(executeArgs: UninstallExecuteArgs): Promise<void>;
+}

--- a/src/managers/base/commands/version.ts
+++ b/src/managers/base/commands/version.ts
@@ -1,0 +1,11 @@
+import type { Pep440Version } from '@renovatebot/pep440';
+import { BaseExecuteArgs, PackageManagerCommand } from './packageManagerCommand';
+
+/**
+ * Template class for version commands.
+ * Subclasses implement concrete package-manager-specific logic.
+ */
+export abstract class VersionCommand extends PackageManagerCommand {
+    protected static readonly configSection = 'versionCommandArgs';
+    abstract execute(executeArgs?: BaseExecuteArgs): Promise<Pep440Version | undefined>;
+}

--- a/src/managers/builtin/commands/availableVersions.ts
+++ b/src/managers/builtin/commands/availableVersions.ts
@@ -1,0 +1,93 @@
+import type { Pep440Version } from '@renovatebot/pep440';
+import { AvailableVersionsCommand, type AvailableVersionsExecuteArgs } from '../../base/commands/index';
+import { runPython, runUV } from '../helpers';
+
+/**
+ * Pip available versions command.
+ * Parsed command: `python -m pip index versions <package> --json --python-version <version>`
+ * Official documentation: https://pip.pypa.io/en/stable/cli/pip_index/
+ */
+export class PipAvailableVersionsCommand extends AvailableVersionsCommand {
+    protected buildCommand(executeArgs: AvailableVersionsExecuteArgs): string[] {
+        return [
+            '-m',
+            'pip',
+            'index',
+            'versions',
+            executeArgs.packageName,
+            '--json',
+            '--python-version',
+            executeArgs.pythonVersion,
+        ];
+    }
+
+    async execute(executeArgs: AvailableVersionsExecuteArgs): Promise<Pep440Version[]> {
+        const output = await runPython(
+            this.pythonExecutable,
+            this.buildCommand(executeArgs),
+            undefined,
+            this.log,
+            executeArgs.cancellationToken,
+            this.timeout,
+        );
+        const match = output.match(/{[\s\S]*}/);
+        if (!match) {
+            return [];
+        }
+
+        try {
+            const parsed = JSON.parse(match[0]) as { versions?: string[] };
+            return this.parseVersions(
+                Array.isArray(parsed.versions) ? parsed.versions : [],
+                executeArgs.includePrerelease,
+            );
+        } catch {
+            return [];
+        }
+    }
+}
+
+/**
+ * UV available versions command.
+ * Parsed command: `uv tool run pip index versions <package> --json --python-version <version>`
+ * Official documentation: https://docs.astral.sh/uv/pip/
+ */
+export class UvAvailableVersionsCommand extends AvailableVersionsCommand {
+    protected buildCommand(executeArgs: AvailableVersionsExecuteArgs): string[] {
+        return [
+            'tool',
+            'run',
+            'pip',
+            'index',
+            'versions',
+            executeArgs.packageName,
+            '--json',
+            '--python-version',
+            executeArgs.pythonVersion,
+        ];
+    }
+
+    async execute(executeArgs: AvailableVersionsExecuteArgs): Promise<Pep440Version[]> {
+        const output = await runUV(
+            this.buildCommand(executeArgs),
+            undefined,
+            this.log,
+            executeArgs.cancellationToken,
+            this.timeout,
+        );
+        const match = output.match(/{[\s\S]*}/);
+        if (!match) {
+            return [];
+        }
+
+        try {
+            const parsed = JSON.parse(match[0]) as { versions?: string[] };
+            return this.parseVersions(
+                Array.isArray(parsed.versions) ? parsed.versions : [],
+                executeArgs.includePrerelease,
+            );
+        } catch {
+            return [];
+        }
+    }
+}

--- a/src/managers/builtin/commands/factory.ts
+++ b/src/managers/builtin/commands/factory.ts
@@ -1,0 +1,13 @@
+import { CommandConstructorOptions } from '../../base/commands/index';
+import { shouldUseUv } from '../helpers';
+
+type CommandConstructor<T> = new (options: CommandConstructorOptions) => T;
+
+export async function createPipOrUvCommand<T, P extends T, U extends T>(
+    options: CommandConstructorOptions,
+    environmentPath: string,
+    PipCommand: CommandConstructor<P>,
+    UvCommand: CommandConstructor<U>,
+): Promise<T> {
+    return (await shouldUseUv(options.log, environmentPath)) ? new UvCommand(options) : new PipCommand(options);
+}

--- a/src/managers/builtin/commands/index.ts
+++ b/src/managers/builtin/commands/index.ts
@@ -1,0 +1,6 @@
+export { PipAvailableVersionsCommand, UvAvailableVersionsCommand } from './availableVersions';
+export { PipInstallCommand, UvInstallCommand } from './install';
+export { PipListCommand, UvListCommand } from './list';
+export { PipListDirectNamesCommand, UvListDirectNamesCommand } from './listDirectNames';
+export { PipUninstallCommand, UvUninstallCommand } from './uninstall';
+export { PipVersionCommand, UvVersionCommand } from './version';

--- a/src/managers/builtin/commands/install.ts
+++ b/src/managers/builtin/commands/install.ts
@@ -1,0 +1,52 @@
+import { InstallCommand, type InstallExecuteArgs } from '../../base/commands/index';
+import { runPython, runUV } from '../helpers';
+import { processEditableInstallArgs } from '../utils';
+
+/**
+ * Pip install command.
+ * Parsed command: `python -m pip install [--upgrade] <package>`
+ * Official documentation: https://pip.pypa.io/en/stable/cli/pip_install/
+ */
+export class PipInstallCommand extends InstallCommand {
+    protected buildCommand(executeArgs: InstallExecuteArgs): string[] {
+        let args = ['-m', 'pip', 'install'];
+        if (executeArgs.upgrade) {
+            args.push('--upgrade');
+        }
+        const processedArgs = processEditableInstallArgs(executeArgs.packages.map((pkg) => pkg.packageName));
+        args.push(...processedArgs);
+        return args;
+    }
+
+    async execute(executeArgs: InstallExecuteArgs): Promise<void> {
+        await runPython(
+            this.pythonExecutable,
+            this.buildCommand(executeArgs),
+            undefined,
+            this.log,
+            executeArgs.cancellationToken,
+            this.timeout,
+        );
+    }
+}
+
+/**
+ * UV install command.
+ * Parsed command: `uv pip install --python <path> [--upgrade] <package>`
+ * Official documentation: https://docs.astral.sh/uv/pip/
+ */
+export class UvInstallCommand extends InstallCommand {
+    protected buildCommand(executeArgs: InstallExecuteArgs): string[] {
+        let args = ['pip', 'install', '--python', this.pythonExecutable];
+        if (executeArgs.upgrade) {
+            args.push('--upgrade');
+        }
+        const processedArgs = processEditableInstallArgs(executeArgs.packages.map((pkg) => pkg.packageName));
+        args.push(...processedArgs);
+        return args;
+    }
+
+    async execute(executeArgs: InstallExecuteArgs): Promise<void> {
+        await runUV(this.buildCommand(executeArgs), undefined, this.log, executeArgs.cancellationToken, this.timeout);
+    }
+}

--- a/src/managers/builtin/commands/list.ts
+++ b/src/managers/builtin/commands/list.ts
@@ -1,0 +1,86 @@
+import { PackageInfo } from '../../../api';
+import { ListCommand, type BaseExecuteArgs } from '../../base/commands/index';
+import { runPython, runUV } from '../helpers';
+
+/**
+ * Pip list command.
+ * Parsed command: `python -m pip list --format=json`
+ * Official documentation: https://pip.pypa.io/en/stable/cli/pip_list/
+ */
+export class PipListCommand extends ListCommand {
+    protected buildCommand(): string[] {
+        return ['-m', 'pip', 'list', '--format=json'];
+    }
+
+    async execute(executeArgs?: BaseExecuteArgs): Promise<PackageInfo[]> {
+        const output = await runPython(
+            this.pythonExecutable,
+            this.buildCommand(),
+            undefined,
+            this.log,
+            executeArgs?.cancellationToken,
+            this.timeout,
+        );
+        let json: unknown;
+        try {
+            json = JSON.parse(output);
+        } catch (e) {
+            this.log?.error(`Failed to parse pip list output: ${e}`);
+            return [];
+        }
+        if (!Array.isArray(json)) {
+            this.log?.error('Invalid output from pip list command');
+            return [];
+        }
+
+        return json
+            .filter(({ name, version }) => !!name && !!version)
+            .map(({ name, version }) => ({
+                name,
+                version,
+                displayName: name,
+                description: version,
+            }));
+    }
+}
+
+/**
+ * UV list command.
+ * Parsed command: `uv pip list --format=json --python <path>`
+ * Official documentation: https://docs.astral.sh/uv/pip/
+ */
+export class UvListCommand extends ListCommand {
+    protected buildCommand(): string[] {
+        return ['pip', 'list', '--format=json', '--python', this.pythonExecutable];
+    }
+
+    async execute(executeArgs?: BaseExecuteArgs): Promise<PackageInfo[]> {
+        const output = await runUV(
+            this.buildCommand(),
+            undefined,
+            this.log,
+            executeArgs?.cancellationToken,
+            this.timeout,
+        );
+        let json: unknown;
+        try {
+            json = JSON.parse(output);
+        } catch (e) {
+            this.log?.error(`Failed to parse uv pip list output: ${e}`);
+            return [];
+        }
+        if (!Array.isArray(json)) {
+            this.log?.error('Invalid output from uv pip list command');
+            return [];
+        }
+
+        return json
+            .filter(({ name, version }) => !!name && !!version)
+            .map(({ name, version }) => ({
+                name,
+                version,
+                displayName: name,
+                description: version,
+            }));
+    }
+}

--- a/src/managers/builtin/commands/list.ts
+++ b/src/managers/builtin/commands/list.ts
@@ -4,12 +4,12 @@ import { runPython, runUV } from '../helpers';
 
 /**
  * Pip list command.
- * Parsed command: `python -m pip list --format=json`
+ * Parsed command: `python -m pip list --format=json` --disable-pip-version-check
  * Official documentation: https://pip.pypa.io/en/stable/cli/pip_list/
  */
 export class PipListCommand extends ListCommand {
     protected buildCommand(): string[] {
-        return ['-m', 'pip', 'list', '--format=json'];
+        return ['-m', 'pip', 'list', '--format=json', '--disable-pip-version-check'];
     }
 
     async execute(executeArgs?: BaseExecuteArgs): Promise<PackageInfo[]> {

--- a/src/managers/builtin/commands/listDirectNames.ts
+++ b/src/managers/builtin/commands/listDirectNames.ts
@@ -1,0 +1,78 @@
+import { ListDirectNamesCommand, type BaseExecuteArgs } from '../../base/commands/index';
+import { runPython, runUV } from '../helpers';
+import { normalizePackageName } from '../utils';
+
+/**
+ * Pip list direct names command.
+ * Parsed command: `python -m pip list --format=json --not-required`
+ * Official documentation: https://pip.pypa.io/en/stable/cli/pip_list/
+ */
+export class PipListDirectNamesCommand extends ListDirectNamesCommand {
+    protected buildCommand(): string[] {
+        return ['-m', 'pip', 'list', '--format=json', '--not-required'];
+    }
+
+    async execute(executeArgs?: BaseExecuteArgs): Promise<Set<string>> {
+        const output = await runPython(
+            this.pythonExecutable,
+            this.buildCommand(),
+            undefined,
+            this.log,
+            executeArgs?.cancellationToken,
+            this.timeout,
+        );
+        let packages: unknown;
+        try {
+            packages = JSON.parse(output);
+        } catch (e) {
+            this.log?.error(`Failed to parse pip list output: ${e}`);
+            return new Set();
+        }
+        if (!Array.isArray(packages)) {
+            this.log?.error('Invalid output from pip list command');
+            return new Set();
+        }
+
+        return new Set(packages.filter(({ name }) => !!name).map(({ name }) => normalizePackageName(name)));
+    }
+}
+
+/**
+ * UV list direct names command.
+ * Parsed command: `uv pip tree --python <python> --depth=0`
+ * Official documentation: https://docs.astral.sh/uv/pip/
+ */
+export class UvListDirectNamesCommand extends ListDirectNamesCommand {
+    protected buildCommand(): string[] {
+        return ['pip', 'tree', '--python', this.pythonExecutable, '--depth=0'];
+    }
+
+    async execute(executeArgs?: BaseExecuteArgs): Promise<Set<string>> {
+        const output = await runUV(
+            this.buildCommand(),
+            undefined,
+            this.log,
+            executeArgs?.cancellationToken,
+            this.timeout,
+        );
+        const packageNames = new Set<string>();
+        const lines = output.split('\n');
+
+        for (const line of lines) {
+            // Tree output has top-level packages at the start of the line with no indentation
+            // Dependencies are indented with tree characters (├, └, │, etc.)
+            // We only want lines that start with a package name (not whitespace or tree chars)
+            if (line.length === 0 || /^[\s├└│]/.test(line)) {
+                continue;
+            }
+
+            // Extract package name (first word, before space or end of line)
+            const match = line.match(/^(\S+)/);
+            if (match && match[1]) {
+                packageNames.add(normalizePackageName(match[1]));
+            }
+        }
+
+        return packageNames;
+    }
+}

--- a/src/managers/builtin/commands/uninstall.ts
+++ b/src/managers/builtin/commands/uninstall.ts
@@ -1,0 +1,41 @@
+import { UninstallCommand, type UninstallExecuteArgs } from '../../base/commands/index';
+import { runPython, runUV } from '../helpers';
+
+/**
+ * Pip uninstall command.
+ * Parsed command: `python -m pip uninstall -y <package>`
+ * Official documentation: https://pip.pypa.io/en/stable/cli/pip_uninstall/
+ */
+export class PipUninstallCommand extends UninstallCommand {
+    protected buildCommand(executeArgs: UninstallExecuteArgs): string[] {
+        return ['-m', 'pip', 'uninstall', '-y', ...executeArgs.packages.map((pkg) => pkg.packageName)];
+    }
+
+    async execute(executeArgs: UninstallExecuteArgs): Promise<void> {
+        await runPython(
+            this.pythonExecutable,
+            this.buildCommand(executeArgs),
+            undefined,
+            this.log,
+            executeArgs.cancellationToken,
+            this.timeout,
+        );
+    }
+}
+
+/**
+ * UV uninstall command.
+ * Parsed command: `uv pip uninstall -y --python <path> <package>`
+ * Official documentation: https://docs.astral.sh/uv/pip/
+ */
+export class UvUninstallCommand extends UninstallCommand {
+    protected buildCommand(executeArgs: UninstallExecuteArgs): string[] {
+        const args = ['pip', 'uninstall', '--python', this.pythonExecutable];
+        args.push(...executeArgs.packages.map((pkg) => pkg.packageName));
+        return args;
+    }
+
+    async execute(executeArgs: UninstallExecuteArgs): Promise<void> {
+        await runUV(this.buildCommand(executeArgs), undefined, this.log, executeArgs.cancellationToken, this.timeout);
+    }
+}

--- a/src/managers/builtin/commands/version.ts
+++ b/src/managers/builtin/commands/version.ts
@@ -1,0 +1,47 @@
+import type { Pep440Version } from '@renovatebot/pep440';
+import { explain as parsePep440Version } from '@renovatebot/pep440';
+import { VersionCommand, type BaseExecuteArgs } from '../../base/commands/index';
+import { runPython, runUV } from '../helpers';
+
+/**
+ * Pip version command.
+ * Parsed command: `python -m pip --version`
+ * Official documentation: https://pip.pypa.io/en/stable/cli/pip/
+ */
+export class PipVersionCommand extends VersionCommand {
+    protected buildCommand(): string[] {
+        return ['-m', 'pip', '--version'];
+    }
+
+    async execute(executeArgs?: BaseExecuteArgs): Promise<Pep440Version | undefined> {
+        const output = await runPython(
+            this.pythonExecutable,
+            this.buildCommand(),
+            undefined,
+            this.log,
+            executeArgs?.cancellationToken,
+            this.timeout,
+        );
+
+        const match = output.match(/^pip\s+(\d+\.\d+(?:\.\d+)*)/);
+        return match ? (parsePep440Version(match[1]) ?? undefined) : undefined;
+    }
+}
+
+/**
+ * UV version command.
+ * Parsed command: `uv --version`
+ * Official documentation: https://docs.astral.sh/uv/
+ */
+export class UvVersionCommand extends VersionCommand {
+    protected buildCommand(): string[] {
+        return ['--version'];
+    }
+
+    async execute(): Promise<Pep440Version | undefined> {
+        const output = await runUV(this.buildCommand(), undefined, this.log, undefined, this.timeout);
+
+        const match = output.match(/(\d+\.\d+(?:\.\d+)*)/);
+        return match ? (parsePep440Version(match[1]) ?? undefined) : undefined;
+    }
+}

--- a/src/managers/conda/commands/availableVersions.ts
+++ b/src/managers/conda/commands/availableVersions.ts
@@ -1,0 +1,35 @@
+import type { Pep440Version } from '@renovatebot/pep440';
+import { AvailableVersionsCommand, type AvailableVersionsExecuteArgs } from '../../base/commands/index';
+import { runCondaExecutable } from '../condaUtils';
+
+/**
+ * Conda available versions command.
+ * Parsed command: `conda search <package> --json`
+ * Official documentation: https://docs.conda.io/projects/conda/en/latest/commands/search.html
+ */
+export class CondaAvailableVersionsCommand extends AvailableVersionsCommand {
+    protected buildCommand(executeArgs: AvailableVersionsExecuteArgs): string[] {
+        return ['search', executeArgs.packageName, '--json'];
+    }
+
+    async execute(executeArgs: AvailableVersionsExecuteArgs): Promise<Pep440Version[]> {
+        const output = await runCondaExecutable(
+            this.buildCommand(executeArgs),
+            this.log,
+            executeArgs.cancellationToken,
+        );
+
+        try {
+            const parsed = JSON.parse(output);
+            if (parsed && typeof parsed === 'object' && Array.isArray(parsed[executeArgs.packageName])) {
+                const versions = (parsed[executeArgs.packageName] as Array<{ version?: string }>)
+                    .map((entry) => entry.version?.trim() ?? '')
+                    .filter((version) => !!version);
+                return this.parseVersions(versions, executeArgs.includePrerelease);
+            }
+            return [];
+        } catch {
+            return [];
+        }
+    }
+}

--- a/src/managers/conda/commands/condaCommandOptions.ts
+++ b/src/managers/conda/commands/condaCommandOptions.ts
@@ -1,0 +1,5 @@
+import { CommandConstructorOptions } from '../../base/commands/index';
+
+export interface CondaCommandConstructorOptions extends CommandConstructorOptions {
+    condaEnvironmentPath: string;
+}

--- a/src/managers/conda/commands/index.ts
+++ b/src/managers/conda/commands/index.ts
@@ -1,0 +1,6 @@
+export { CondaAvailableVersionsCommand } from './availableVersions';
+export { CondaCommandConstructorOptions } from './condaCommandOptions';
+export { CondaInstallCommand } from './install';
+export { CondaListCommand } from './list';
+export { CondaUninstallCommand } from './uninstall';
+export { CondaVersionCommand } from './version';

--- a/src/managers/conda/commands/install.ts
+++ b/src/managers/conda/commands/install.ts
@@ -1,0 +1,38 @@
+import { InstallCommand, type InstallExecuteArgs } from '../../base/commands/index';
+import { runCondaExecutable } from '../condaUtils';
+import { CondaCommandConstructorOptions } from './condaCommandOptions';
+
+/**
+ * Conda install command.
+ * Parsed command: `conda install --prefix <environment_path> --yes <package>`
+ * Parsed command (upgrade): `conda install --prefix <environment_path> --yes --update-all <package>`
+ * Official documentation: https://docs.conda.io/projects/conda/en/latest/commands/install.html
+ */
+export class CondaInstallCommand extends InstallCommand {
+    private readonly condaEnvironmentPath: string;
+
+    constructor(options: CondaCommandConstructorOptions) {
+        super(options);
+        this.condaEnvironmentPath = options.condaEnvironmentPath;
+    }
+
+    protected buildCommand(executeArgs: InstallExecuteArgs): string[] {
+        const args = ['install', '--prefix', this.condaEnvironmentPath, '--yes'];
+        if (executeArgs.upgrade) {
+            args.push('--update-all');
+        }
+        args.push(
+            ...executeArgs.packages.map((pkg) => {
+                if (pkg.version) {
+                    return `${pkg.packageName}=${pkg.version}`;
+                }
+                return pkg.packageName;
+            }),
+        );
+        return args;
+    }
+
+    async execute(executeArgs: InstallExecuteArgs): Promise<void> {
+        await runCondaExecutable(this.buildCommand(executeArgs), this.log, executeArgs.cancellationToken);
+    }
+}

--- a/src/managers/conda/commands/list.ts
+++ b/src/managers/conda/commands/list.ts
@@ -1,0 +1,46 @@
+import { PackageInfo } from '../../../api';
+import { ListCommand, type BaseExecuteArgs } from '../../base/commands/index';
+import { runCondaExecutable } from '../condaUtils';
+import { CondaCommandConstructorOptions } from './condaCommandOptions';
+
+/**
+ * Conda list command.
+ * Parsed command: `conda list -p <environment_path> --json`
+ * Official documentation: https://docs.conda.io/projects/conda/en/latest/commands/list.html
+ */
+export class CondaListCommand extends ListCommand {
+    private readonly condaEnvironmentPath: string;
+
+    constructor(options: CondaCommandConstructorOptions) {
+        super(options);
+        this.condaEnvironmentPath = options.condaEnvironmentPath;
+    }
+
+    protected buildCommand(): string[] {
+        return ['list', '-p', this.condaEnvironmentPath, '--json'];
+    }
+
+    async execute(executeArgs?: BaseExecuteArgs): Promise<PackageInfo[]> {
+        const output = await runCondaExecutable(this.buildCommand(), this.log, executeArgs?.cancellationToken);
+        let condaPackages: { name: string; version: string }[];
+        try {
+            condaPackages = JSON.parse(output) as { name: string; version: string }[];
+        } catch {
+            return [];
+        }
+
+        const packages: PackageInfo[] = [];
+        for (const condaPkg of condaPackages) {
+            if (condaPkg.name && condaPkg.version) {
+                packages.push({
+                    name: condaPkg.name,
+                    displayName: condaPkg.name,
+                    version: condaPkg.version,
+                    description: condaPkg.version,
+                });
+            }
+        }
+
+        return packages;
+    }
+}

--- a/src/managers/conda/commands/uninstall.ts
+++ b/src/managers/conda/commands/uninstall.ts
@@ -1,0 +1,27 @@
+import { UninstallCommand, type UninstallExecuteArgs } from '../../base/commands/index';
+import { runCondaExecutable } from '../condaUtils';
+import { CondaCommandConstructorOptions } from './condaCommandOptions';
+
+/**
+ * Conda uninstall command.
+ * Parsed command: `conda remove -y -p <environment_path> <package>`
+ * Official documentation: https://docs.conda.io/projects/conda/en/latest/commands/remove.html
+ */
+export class CondaUninstallCommand extends UninstallCommand {
+    private readonly condaEnvironmentPath: string;
+
+    constructor(options: CondaCommandConstructorOptions) {
+        super(options);
+        this.condaEnvironmentPath = options.condaEnvironmentPath;
+    }
+
+    protected buildCommand(executeArgs: UninstallExecuteArgs): string[] {
+        const args = ['remove', '-y', '-p', this.condaEnvironmentPath];
+        args.push(...executeArgs.packages.map((pkg) => pkg.packageName));
+        return args;
+    }
+
+    async execute(executeArgs: UninstallExecuteArgs): Promise<void> {
+        await runCondaExecutable(this.buildCommand(executeArgs), this.log, executeArgs.cancellationToken);
+    }
+}

--- a/src/managers/conda/commands/version.ts
+++ b/src/managers/conda/commands/version.ts
@@ -1,0 +1,23 @@
+import type { Pep440Version } from '@renovatebot/pep440';
+import { explain as parsePep440Version } from '@renovatebot/pep440';
+import { VersionCommand, type BaseExecuteArgs } from '../../base/commands/index';
+import { runCondaExecutable } from '../condaUtils';
+
+/**
+ * Conda version command.
+ * Parsed command: `conda --version`
+ * Official documentation: https://docs.conda.io/projects/conda/en/latest/commands.html
+ */
+export class CondaVersionCommand extends VersionCommand {
+    protected buildCommand(): string[] {
+        return ['--version'];
+    }
+
+    async execute(executeArgs?: BaseExecuteArgs): Promise<Pep440Version | undefined> {
+        const output = await runCondaExecutable(this.buildCommand(), this.log, executeArgs?.cancellationToken);
+
+        // "conda X.Y.Z"
+        const match = output.match(/conda\s+(\d+\.\d+(?:\.\d+)*)/i);
+        return match ? (parsePep440Version(match[1]) ?? undefined) : undefined;
+    }
+}

--- a/src/managers/poetry/commands/add.ts
+++ b/src/managers/poetry/commands/add.ts
@@ -1,0 +1,27 @@
+import { InstallCommand, type InstallExecuteArgs } from '../../base/commands/index';
+import { runPoetry } from './runPoetry';
+
+/**
+ * Poetry add command.
+ * Parsed command: `poetry add <package> [<package> ...]`
+ * Official documentation: https://python-poetry.org/docs/cli/#add
+ */
+export class PoetryAddCommand extends InstallCommand {
+    protected buildCommand(executeArgs: InstallExecuteArgs): string[] {
+        const args = ['add'];
+        args.push(
+            ...executeArgs.packages.map((pkg) => {
+                if (pkg.version) {
+                    return `${pkg.packageName}@${pkg.version}`;
+                }
+                return pkg.packageName;
+            }),
+        );
+
+        return args;
+    }
+
+    async execute(executeArgs: InstallExecuteArgs): Promise<void> {
+        await runPoetry(this.buildCommand(executeArgs), this.cwd, this.log, executeArgs.cancellationToken);
+    }
+}

--- a/src/managers/poetry/commands/index.ts
+++ b/src/managers/poetry/commands/index.ts
@@ -1,0 +1,5 @@
+export { PoetryAddCommand } from './add';
+export { PoetryRemoveCommand } from './remove';
+export { PoetryShowCommand } from './show';
+export { PoetryShowTopLevelCommand } from './showTopLevel';
+export { PoetryVersionCommand } from './version';

--- a/src/managers/poetry/commands/remove.ts
+++ b/src/managers/poetry/commands/remove.ts
@@ -1,0 +1,17 @@
+import { UninstallCommand, type UninstallExecuteArgs } from '../../base/commands/index';
+import { runPoetry } from './runPoetry';
+
+/**
+ * Poetry remove command.
+ * Parsed command: `poetry remove <package> [<package> ...]`
+ * Official documentation: https://python-poetry.org/docs/cli/#remove
+ */
+export class PoetryRemoveCommand extends UninstallCommand {
+    protected buildCommand(executeArgs: UninstallExecuteArgs): string[] {
+        return ['remove', ...executeArgs.packages.map((pkg) => pkg.packageName)];
+    }
+
+    async execute(executeArgs: UninstallExecuteArgs): Promise<void> {
+        await runPoetry(this.buildCommand(executeArgs), this.cwd, this.log, executeArgs.cancellationToken);
+    }
+}

--- a/src/managers/poetry/commands/runPoetry.ts
+++ b/src/managers/poetry/commands/runPoetry.ts
@@ -1,0 +1,47 @@
+import { CancellationError, CancellationToken, LogOutputChannel } from 'vscode';
+import { spawnProcess } from '../../../common/childProcess.apis';
+import { getPoetry } from '../poetryUtils';
+
+export async function runPoetry(
+    args: string[],
+    cwd?: string,
+    log?: LogOutputChannel,
+    token?: CancellationToken,
+): Promise<string> {
+    const poetry = await getPoetry();
+    if (!poetry) {
+        throw new Error('Poetry executable not found');
+    }
+
+    log?.info(`Running: ${poetry} ${args.join(' ')}`);
+
+    return new Promise<string>((resolve, reject) => {
+        const proc = spawnProcess(poetry, args, { cwd });
+        token?.onCancellationRequested(() => {
+            proc.kill();
+            reject(new CancellationError());
+        });
+        let builder = '';
+        proc.stdout?.on('data', (data) => {
+            const output = data.toString('utf-8');
+            builder += output;
+            log?.append(`poetry: ${output}`);
+        });
+        proc.stderr?.on('data', (data) => {
+            const output = data.toString('utf-8');
+            builder += output;
+            log?.append(`poetry: ${output}`);
+        });
+        proc.on('close', (code) => {
+            if (code !== 0) {
+                reject(new Error(`Failed to run poetry ${args.join(' ')}`));
+                return;
+            }
+            resolve(builder);
+        });
+        proc.on('error', (error) => {
+            log?.error(`Error executing poetry command: ${error}`);
+            reject(error);
+        });
+    });
+}

--- a/src/managers/poetry/commands/show.ts
+++ b/src/managers/poetry/commands/show.ts
@@ -1,0 +1,42 @@
+import { PackageInfo } from '../../../api';
+import { ListCommand, type BaseExecuteArgs } from '../../base/commands/index';
+import { runPoetry } from './runPoetry';
+
+/**
+ * Poetry show command.
+ * Parsed command: `poetry show --no-ansi`
+ * Official documentation: https://python-poetry.org/docs/cli/#show
+ */
+export class PoetryShowCommand extends ListCommand {
+    protected buildCommand(): string[] {
+        return ['show', '--no-ansi'];
+    }
+
+    async execute(executeArgs?: BaseExecuteArgs): Promise<PackageInfo[]> {
+        const output = await runPoetry(this.buildCommand(), this.cwd, this.log, executeArgs?.cancellationToken);
+        const packages: PackageInfo[] = [];
+        try {
+            // Parse poetry show output
+            // Format: name         version    description
+            const lines = output.split('\n');
+            for (const line of lines) {
+                // Updated regex to properly handle lines with the format:
+                // "package (!) version description"
+                const match = line.match(/^(\S+)(?:\s+\([!]\))?\s+(\S+)\s+(.*)/);
+                if (match) {
+                    const [, name, version, description] = match;
+                    packages.push({
+                        name,
+                        displayName: name,
+                        version,
+                        description: `${version} - ${description?.trim() || ''}`,
+                    });
+                }
+            }
+        } catch {
+            return [];
+        }
+
+        return packages;
+    }
+}

--- a/src/managers/poetry/commands/showTopLevel.ts
+++ b/src/managers/poetry/commands/showTopLevel.ts
@@ -1,0 +1,30 @@
+import { ListDirectNamesCommand, type BaseExecuteArgs } from '../../base/commands/index';
+import { normalizePackageName } from '../../builtin/utils';
+import { runPoetry } from './runPoetry';
+
+/**
+ * Poetry show --top-level command.
+ * Parsed command: `poetry show --no-ansi --top-level`
+ * Official documentation: https://python-poetry.org/docs/cli/#show
+ */
+export class PoetryShowTopLevelCommand extends ListDirectNamesCommand {
+    protected buildCommand(): string[] {
+        return ['show', '--no-ansi', '--top-level'];
+    }
+
+    async execute(executeArgs?: BaseExecuteArgs): Promise<Set<string>> {
+        const output = await runPoetry(this.buildCommand(), this.cwd, this.log, executeArgs?.cancellationToken);
+
+        try {
+            const names = output
+                .split('\n')
+                .map((line) => line.trim())
+                .map((line) => line.match(/^([a-zA-Z0-9._-]+)/)?.[1] ?? '')
+                .filter((name) => !!name)
+                .map(normalizePackageName);
+            return new Set(names);
+        } catch {
+            return new Set();
+        }
+    }
+}

--- a/src/managers/poetry/commands/version.ts
+++ b/src/managers/poetry/commands/version.ts
@@ -1,0 +1,26 @@
+import type { Pep440Version } from '@renovatebot/pep440';
+import { explain as parsePep440Version } from '@renovatebot/pep440';
+import { VersionCommand, type BaseExecuteArgs } from '../../base/commands/index';
+import { getPoetryVersion } from '../poetryUtils';
+
+/**
+ * Poetry version command.
+ * Parsed command: `poetry --version`
+ * Official documentation: https://python-poetry.org/docs/cli/#options
+ */
+export class PoetryVersionCommand extends VersionCommand {
+    protected buildCommand(): string[] {
+        return ['--version'];
+    }
+
+    async execute(_executeArgs?: BaseExecuteArgs): Promise<Pep440Version | undefined> {
+        try {
+            // Poetry version is obtained via getPoetryVersion utility which handles poetry --version
+            // We pass the pythonExecutable as the poetry path since it was set to the poetry executable
+            const versionString = await getPoetryVersion(this.pythonExecutable);
+            return versionString ? (parsePep440Version(versionString) ?? undefined) : undefined;
+        } catch {
+            return undefined;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the reusable command-object layer for package management while leaving existing package-manager call sites unchanged.

## Scope

- Adds the `PackageManagerCommand` base class and shared execution options.
- Adds abstract templates for install, uninstall, list, version, available versions, and direct package names.
- Adds concrete Pip/UV, Conda, and Poetry implementations.
- Adds command factories, exports, and command-local execution helpers required by those implementations.
- Preserves the existing executables, flags, environment targeting, prerelease defaults, and list-command timeouts.

## Non-goals

This PR does not add command tests or migrate package managers to the new classes. Those changes are isolated in follow-up PRs #1677 and #1678.

## PR stack

1. This PR: command classes and implementations, based on `main`.
2. #1677: command smoke tests, based on this branch.
3. #1678: adoption and cleanup, based on #1677.

## Testing

- `npm run lint`
- `npm run compile-tests`
- `npm run unittest` (1,448 passing, 4 pending)