### PR TITLE
Add condaEnvCount and managerCount to pet.refresh telemetry

### DIFF
--- a/src/common/telemetry/constants.ts
+++ b/src/common/telemetry/constants.ts
@@ -583,6 +583,8 @@ export interface IEventNamePropertyMapping {
         "pet.refresh": {
             "result": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "owner": "eleanorjboyd" },
             "envCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
+            "condaEnvCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "owner": "eleanorjboyd" },
+            "managerCount": { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true, "owner": "eleanorjboyd" },
             "unresolvedCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
             "workspaceDirCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
             "searchPathCount": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true, "owner": "eleanorjboyd" },
@@ -602,6 +604,10 @@ export interface IEventNamePropertyMapping {
     [EventNames.PET_REFRESH]: {
         result: 'success' | 'timeout' | 'error';
         envCount?: number;
+        /** Number of discovered environments whose kind is Conda. Lets us slice refresh duration by conda footprint. */
+        condaEnvCount?: number;
+        /** Number of discovered environment managers (conda/pyenv/poetry/etc.). */
+        managerCount?: number;
         unresolvedCount?: number;
         workspaceDirCount?: number;
         searchPathCount?: number;

--- a/src/managers/common/nativePythonFinder.ts
+++ b/src/managers/common/nativePythonFinder.ts
@@ -803,6 +803,32 @@ class NativePythonFinderImpl implements NativePythonFinder {
         };
     }
 
+    /**
+     * Computes environment-shape counts from a refresh result for telemetry. These let us slice
+     * refresh duration by how many environments (and how many conda environments) were discovered,
+     * to test whether the slow-refresh cohort is dominated by conda-heavy / many-env setups.
+     */
+    private getEnvShapeProperties(nativeInfo: NativeInfo[]): {
+        envCount: number;
+        condaEnvCount: number;
+        managerCount: number;
+    } {
+        let envCount = 0;
+        let condaEnvCount = 0;
+        let managerCount = 0;
+        for (const info of nativeInfo) {
+            if (isNativeEnvInfo(info)) {
+                envCount++;
+                if (info.kind === NativePythonEnvironmentKind.conda) {
+                    condaEnvCount++;
+                }
+            } else {
+                managerCount++;
+            }
+        }
+        return { envCount, condaEnvCount, managerCount };
+    }
+
     private async doRefresh(options?: NativePythonEnvironmentKind | Uri[]): Promise<NativeInfo[]> {
         let lastError: unknown;
 
@@ -933,7 +959,7 @@ class NativePythonFinderImpl implements NativePythonFinder {
                 },
                 {
                     result: 'success',
-                    envCount: nativeInfo.filter((e) => isNativeEnvInfo(e)).length,
+                    ...this.getEnvShapeProperties(nativeInfo),
                     unresolvedCount,
                     workspaceDirCount,
                     searchPathCount,
@@ -949,7 +975,7 @@ class NativePythonFinderImpl implements NativePythonFinder {
                 sw.elapsedTime,
                 {
                     result: errorType === 'spawn_timeout' ? 'timeout' : 'error',
-                    envCount: nativeInfo.filter((e) => isNativeEnvInfo(e)).length,
+                    ...this.getEnvShapeProperties(nativeInfo),
                     unresolvedCount,
                     attempt,
                     errorType,


### PR DESCRIPTION
## Summary

Adds two environment-shape measures to the `pet.refresh` telemetry event:

- `condaEnvCount` — number of discovered environments whose kind is Conda
- `managerCount` — number of discovered environment managers

The event already carries `envCount` (total discovered environments) and `Duration`. Together with the two new measures, we can slice refresh duration by **total env count** and **conda footprint** in telemetry, directly testing the open hypothesis that the slow-refresh cohort is dominated by conda-heavy / many-env setups.

## Motivation

We have an unexplained elevation in bad-experience rates that our simpler hypotheses (experiment ramp, first-run cost, PET code regression) did not account for. The remaining signal points at engaged users with complex setups, suspected conda-heavy — but we can't confirm this per-session without instrumenting the shape of what PET discovers. This is a minimal instrumentation change to unblock a confident decision (and to later verify whether lazy-Conda helps the right sub-cohort).

## Notes

- No new events; both new fields are measurements on an existing event.