### PR TITLE
Fix #1599: onDidChangePythonProjects never fires on runtime project a…

### DIFF
--- a/src/features/pythonApi.ts
+++ b/src/features/pythonApi.ts
@@ -94,12 +94,16 @@ export class PythonEnvironmentApiImpl implements PythonEnvironmentApi {
             this.envVarManager.onDidChangeEnvironmentVariables((e) => this._onDidChangeEnvironmentVariables.fire(e)),
             this.projectManager.onDidChangeProjects(() => {
                 const current = this.projectManager.getProjects();
-                const added = current.filter(
-                    (c) => !this.previousProjects.some((p) => p.uri.toString() === c.uri.toString()),
-                );
-                const removed = this.previousProjects.filter(
-                    (p) => !current.some((c) => c.uri.toString() === p.uri.toString()),
-                );
+                const currentByUri = new Map(current.map((p) => [p.uri.toString(), p] as const));
+                const previousByUri = new Map(this.previousProjects.map((p) => [p.uri.toString(), p] as const));
+
+                const added = [...currentByUri.entries()]
+                    .filter(([uri]) => !previousByUri.has(uri))
+                    .map(([, project]) => project);
+                const removed = [...previousByUri.entries()]
+                    .filter(([uri]) => !currentByUri.has(uri))
+                    .map(([, project]) => project);
+
                 this.previousProjects = current;
                 if (added.length > 0 || removed.length > 0) {
                     traceInfo(

--- a/src/features/pythonApi.ts
+++ b/src/features/pythonApi.ts
@@ -33,6 +33,7 @@ import {
 } from '../api';
 import { traceError, traceInfo } from '../common/logging';
 import { pickEnvironmentManager } from '../common/pickers/managers';
+import { timeout } from '../common/utils/asyncUtils';
 import { createDeferred } from '../common/utils/deferred';
 import { checkUri } from '../common/utils/pathUtils';
 import { handlePythonPath } from '../common/utils/pythonPath';
@@ -44,7 +45,6 @@ import {
     PythonPackageImpl,
     PythonProjectManager,
 } from '../internal.api';
-import { timeout } from '../common/utils/asyncUtils';
 import { waitForAllEnvManagers, waitForEnvManager, waitForEnvManagerId } from './common/managerReady';
 import { EnvVarManager } from './execution/envVariableManager';
 import { runAsTask } from './execution/runAsTask';
@@ -58,12 +58,15 @@ import { TerminalManager } from './terminal/terminalManager';
 const GET_ENVIRONMENT_TIMEOUT_MS = 1000;
 const GET_ENVIRONMENT_TIMED_OUT = Symbol('getEnvironmentTimedOut');
 
-class PythonEnvironmentApiImpl implements PythonEnvironmentApi {
+export class PythonEnvironmentApiImpl implements PythonEnvironmentApi {
     private readonly _onDidChangeEnvironments = new EventEmitter<DidChangeEnvironmentsEventArgs>();
     private readonly _onDidChangeEnvironment = new EventEmitter<DidChangeEnvironmentEventArgs>();
     private readonly _onDidChangePythonProjects = new EventEmitter<DidChangePythonProjectsEventArgs>();
     private readonly _onDidChangePackages = new EventEmitter<DidChangePackagesEventArgs>();
     private readonly _onDidChangeEnvironmentVariables = new EventEmitter<DidChangeEnvironmentVariablesEventArgs>();
+    // Tracks the last-known project set so we can compute an added/removed delta
+    // whenever the underlying project manager reports a change (fix for #1599).
+    private previousProjects: readonly PythonProject[] = [];
 
     constructor(
         private readonly envManagers: EnvironmentManagers,
@@ -73,6 +76,8 @@ class PythonEnvironmentApiImpl implements PythonEnvironmentApi {
         private readonly envVarManager: EnvVarManager,
         private readonly disposables: Disposable[] = [],
     ) {
+        this.previousProjects = this.projectManager.getProjects();
+
         this.disposables.push(
             this._onDidChangeEnvironment,
             this._onDidChangeEnvironments,
@@ -87,6 +92,22 @@ class PythonEnvironmentApiImpl implements PythonEnvironmentApi {
                 );
             }),
             this.envVarManager.onDidChangeEnvironmentVariables((e) => this._onDidChangeEnvironmentVariables.fire(e)),
+            this.projectManager.onDidChangeProjects(() => {
+                const current = this.projectManager.getProjects();
+                const added = current.filter(
+                    (c) => !this.previousProjects.some((p) => p.uri.toString() === c.uri.toString()),
+                );
+                const removed = this.previousProjects.filter(
+                    (p) => !current.some((c) => c.uri.toString() === p.uri.toString()),
+                );
+                this.previousProjects = current;
+                if (added.length > 0 || removed.length > 0) {
+                    traceInfo(
+                        `Python API: Projects changed. Added: ${added.length}, Removed: ${removed.length}`,
+                    );
+                    this._onDidChangePythonProjects.fire({ added, removed });
+                }
+            }),
         );
     }
 

--- a/src/test/features/pythonApi.unit.test.ts
+++ b/src/test/features/pythonApi.unit.test.ts
@@ -40,7 +40,7 @@ suite('PythonEnvironmentApiImpl - onDidChangePythonProjects', () => {
         });
 
         // 6. Simulate adding a project
-        const newProject = { uri: Uri.file('/fake/path') } as unknown as PythonProject;
+        const newProject = { uri: Uri.joinPath(Uri.file(process.cwd()), 'fake', 'path') } as unknown as PythonProject;
         currentProjects = [newProject]; // Update the mock's state
         
         // Fire the internal event
@@ -51,5 +51,15 @@ suite('PythonEnvironmentApiImpl - onDidChangePythonProjects', () => {
         assert.strictEqual((firedEventPayload as { added: PythonProject[] }).added.length, 1, 'Should have 1 added project');
         assert.strictEqual((firedEventPayload as { added: PythonProject[] }).added[0].uri.fsPath, newProject.uri.fsPath);
         assert.strictEqual((firedEventPayload as { removed: PythonProject[] }).removed.length, 0, 'Should have 0 removed projects');
+
+        // 8. Simulate removing the project
+        firedEventPayload = null;
+        currentProjects = [];
+        onDidChangeProjectsEmitter.fire();
+
+        assert.ok(firedEventPayload, 'Event should have fired');
+        assert.strictEqual((firedEventPayload as { added: PythonProject[] }).added.length, 0, 'Should have 0 added projects');
+        assert.strictEqual((firedEventPayload as { removed: PythonProject[] }).removed.length, 1, 'Should have 1 removed project');
+        assert.strictEqual((firedEventPayload as { removed: PythonProject[] }).removed[0].uri.fsPath, newProject.uri.fsPath);
     });
 });

--- a/src/test/features/pythonApi.unit.test.ts
+++ b/src/test/features/pythonApi.unit.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'assert';
+import { EventEmitter, Uri } from 'vscode';
+import { PythonProject } from '../../api';
+import { PythonEnvironmentApiImpl } from '../../features/pythonApi';
+import { PythonProjectManager } from '../../internal.api';
+
+suite('PythonEnvironmentApiImpl - onDidChangePythonProjects', () => {
+    test('Fires event with correct added and removed projects', async () => {
+        // 1. Create a mock EventEmitter to simulate the internal project manager
+        const onDidChangeProjectsEmitter = new EventEmitter<void>();
+        
+        // 2. Mock the PythonProjectManager
+        let currentProjects: PythonProject[] = [];
+        const mockProjectManager = {
+            getProjects: () => currentProjects,
+            onDidChangeProjects: onDidChangeProjectsEmitter.event,
+        } as unknown as PythonProjectManager;
+
+        // 3. Mock the other required constructor arguments using ConstructorParameters
+        type ApiArgs = ConstructorParameters<typeof PythonEnvironmentApiImpl>;
+        
+        const mockEnvManagers = { onDidChangeActiveEnvironment: new EventEmitter().event } as unknown as ApiArgs[0];
+        const mockProjectCreators = {} as unknown as ApiArgs[2];
+        const mockTerminalManager = {} as unknown as ApiArgs[3];
+        const mockEnvVarManager = { onDidChangeEnvironmentVariables: new EventEmitter().event } as unknown as ApiArgs[4];
+
+        // 4. Initialize the API instance
+        const api = new PythonEnvironmentApiImpl(
+            mockEnvManagers,
+            mockProjectManager,
+            mockProjectCreators,
+            mockTerminalManager,
+            mockEnvVarManager
+        );
+
+        // 5. Listen to the public event we are testing
+        let firedEventPayload: unknown = null;
+        api.onDidChangePythonProjects((e: unknown) => {
+            firedEventPayload = e;
+        });
+
+        // 6. Simulate adding a project
+        const newProject = { uri: Uri.file('/fake/path') } as unknown as PythonProject;
+        currentProjects = [newProject]; // Update the mock's state
+        
+        // Fire the internal event
+        onDidChangeProjectsEmitter.fire();
+
+        // 7. Assert the public event fired with the correct delta
+        assert.ok(firedEventPayload, 'Event should have fired');
+        assert.strictEqual((firedEventPayload as { added: PythonProject[] }).added.length, 1, 'Should have 1 added project');
+        assert.strictEqual((firedEventPayload as { added: PythonProject[] }).added[0].uri.fsPath, newProject.uri.fsPath);
+        assert.strictEqual((firedEventPayload as { removed: PythonProject[] }).removed.length, 0, 'Should have 0 removed projects');
+    });
+});


### PR DESCRIPTION
## Summary
Fixes #1599 — `PythonEnvironmentApi.onDidChangePythonProjects` never fired when projects were added or removed at runtime. The internal project list updated correctly, but the public event was never forwarded, so consumers (notably Pylance's per-folder interpreter support) never got notified and required a restart to pick up new projects.

## Root cause
`PythonEnvironmentApiImpl`'s constructor subscribed to environment-change events but never subscribed to`projectManager.onDidChangeProjects`, so `_onDidChangePythonProjects.fire(...)` was never called.

## Fix
- Added a `previousProjects` field on `PythonEnvironmentApiImpl` that tracks the last-known project set.
- Subscribed to `projectManager.onDidChangeProjects` in the constructor.  On each internal change, compute the added/removed delta by diffing  project URIs against the previous snapshot, update the snapshot, and  fire `_onDidChangePythonProjects` with `{ added, removed }` when the  set actually changed.

Diffing by URI (rather than relying on the manager's internal eventpayload) was needed because the manager currently emits the full projectarray rather than a delta, and `DidChangePythonProjectsEventArgs` expects`added`/`removed`.

## Testing
- `npm run compile` — clean build.
- Manually verified via `getPythonProjects()` that the set updates as expected; confirmed the new subscription fires on `addPythonProject()` and `removePythonProject()` calls.