### PR TITLE
Add inline-script cache and interpreter utilities (PEP 723 PR 5b/16)

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -2,6 +2,8 @@ import * as path from 'path';
 
 export const ENVS_EXTENSION_ID = 'ms-python.vscode-python-envs';
 export const PYTHON_EXTENSION_ID = 'ms-python.python';
+export const CONDA_MANAGER_ID = `${PYTHON_EXTENSION_ID}:conda`;
+export const INLINE_SCRIPT_MANAGER_ID = `${PYTHON_EXTENSION_ID}:inline-script`;
 export const JUPYTER_EXTENSION_ID = 'ms-toolsai.jupyter';
 export const EXTENSION_ROOT_DIR = path.dirname(__dirname);
 export const ISSUES_URL = 'https://github.com/microsoft/vscode-python-environments/issues';

--- a/src/common/inlineScriptCacheKey.ts
+++ b/src/common/inlineScriptCacheKey.ts
@@ -31,6 +31,40 @@ function normalizeExtras(inner: string): string {
     return deduped.length > 0 ? `[${deduped.join(',')}]` : '';
 }
 
+function normalizeRequirementTail(value: string): string {
+    let result = '';
+    let unquoted = '';
+    let quote: "'" | '"' | undefined;
+    let escaped = false;
+
+    const flushUnquoted = () => {
+        result += unquoted.replace(/\s+/g, ' ').replace(/\s*([<>=!~]=?)\s*/g, '$1');
+        unquoted = '';
+    };
+
+    // Preserve PEP 508 marker literals verbatim; a backslash escapes the next character.
+    for (const character of value) {
+        if (quote) {
+            result += character;
+            if (character === quote && !escaped) {
+                quote = undefined;
+            }
+            escaped = character === '\\' && !escaped;
+            if (character !== '\\') {
+                escaped = false;
+            }
+        } else if (character === "'" || character === '"') {
+            flushUnquoted();
+            quote = character;
+            result += character;
+        } else {
+            unquoted += character;
+        }
+    }
+    flushUnquoted();
+    return result.trim();
+}
+
 /**
  * Canonicalize a PEP 723 dependency entry so common variants of the same
  * requirement produce identical strings. Not a full PEP 508 parser — only
@@ -70,10 +104,12 @@ export function normalizeDependency(dep: string): string {
         rest = rest.slice(extrasMatch[0].length);
     }
 
-    const compactedRest = rest
-        .replace(/\s+/g, ' ')
-        .replace(/\s*([<>=!~]=?)\s*/g, '$1')
-        .trim();
+    const directReference = rest.trim();
+    if (directReference.startsWith('@')) {
+        return `${name}${extras} ${directReference}`;
+    }
+
+    const compactedRest = normalizeRequirementTail(rest);
 
     return `${name}${extras}${compactedRest}`;
 }

--- a/src/common/inlineScriptCacheKey.ts
+++ b/src/common/inlineScriptCacheKey.ts
@@ -31,6 +31,7 @@ function normalizeExtras(inner: string): string {
     return deduped.length > 0 ? `[${deduped.join(',')}]` : '';
 }
 
+/** ` >=  2 ; python_version  <  "3.13"` becomes `>=2 ; python_version<"3.13"`. */
 function normalizeRequirementTail(value: string): string {
     let result = '';
     let unquoted = '';

--- a/src/common/inlineScriptCacheLayout.ts
+++ b/src/common/inlineScriptCacheLayout.ts
@@ -5,16 +5,14 @@ import * as crypto from 'crypto';
 import * as fsapi from 'fs-extra';
 import * as path from 'path';
 import { Uri } from 'vscode';
+import type { PythonEnvironment } from '../api';
+import { INLINE_SCRIPT_MANAGER_ID } from './constants';
 import { traceWarn } from './logging';
+import { normalizePath } from './utils/pathUtils';
 import { isWindows } from './utils/platformUtils';
+import { getVenvPythonPath } from './utils/virtualEnvironment';
 
-/**
- * Versioned name of the cache root under the extension's `globalStorageUri`.
- *
- * Bump the `-v1` suffix together with {@link META_SCHEMA_VERSION} on any
- * incompatible on-disk change, so old envs sit unread and TTL out naturally
- * instead of being migrated in place.
- */
+/** Bump this and {@link META_SCHEMA_VERSION} together for incompatible cache formats. */
 export const INLINE_SCRIPT_CACHE_DIR_NAME = 'script-envs-v1';
 
 export const META_JSON_FILENAME = '.meta.json';
@@ -33,13 +31,20 @@ const MAX_META_JSON_BYTES = 1024 * 1024;
 export interface InlineScriptEnvMeta {
     /** Version of the serialized metadata schema. */
     readonly schemaVersion: typeof META_SCHEMA_VERSION;
-    /** Filesystem path of the script recorded for lifecycle bookkeeping. */
-    readonly scriptFsPath: string;
+    /** Canonical base-interpreter path. */
+    readonly baseInterpreterPath: string;
+    /** Base-interpreter version. */
+    readonly baseInterpreterVersion: string;
     /** Last successful use as a canonical UTC string produced by `Date.toISOString()`. */
     readonly lastUsedAt: string;
-    /** The script's `requires-python` declaration, when present. */
-    readonly requiresPython?: string;
 }
+
+export type InlineScriptMetaReadResult =
+    | { readonly kind: 'valid'; readonly metadata: InlineScriptEnvMeta }
+    | { readonly kind: 'missing' | 'invalid' | 'unavailable' };
+
+export type BaseInterpreterStatus = 'available' | 'missing' | 'unavailable';
+export type CacheEnvironmentInspection = 'expected' | 'stale' | 'uncertain';
 
 /**
  * In-memory summary of one cached entry, populated by the separate disk walk.
@@ -63,36 +68,77 @@ export function getMetaJsonPath(envDir: Uri): Uri {
     return Uri.joinPath(envDir, META_JSON_FILENAME);
 }
 
-/**
- * Read and validate the extension-owned `.meta.json` sidecar in a cached
- * environment directory.
- *
- * This function is intentionally non-destructive. Missing, malformed, or
- * unreadable sidecars return `undefined` so callers can treat the entry as a
- * cache miss. Deleting invalid entries belongs to the dedicated, guarded cache
- * cleanup path because read and permission failures may be transient.
- */
+/** Resolve a cache entry only when it is the requested direct child of the physical cache root. */
+export async function resolveCacheEntryPath(cacheRoot: Uri, envDir: Uri): Promise<string | undefined> {
+    const [resolvedRoot, resolvedEntry] = await Promise.all([
+        fsapi.realpath(cacheRoot.fsPath),
+        fsapi.realpath(envDir.fsPath),
+    ]);
+    const expectedEntry = path.join(resolvedRoot, path.basename(envDir.fsPath));
+    return isDescendantPath(resolvedRoot, resolvedEntry) &&
+        normalizePath(path.resolve(resolvedEntry)) === normalizePath(path.resolve(expectedEntry))
+        ? resolvedEntry
+        : undefined;
+}
+
+/** Verify that a resolved environment is owned by the expected physical cache entry. */
+export async function inspectOwnedCacheEntry(
+    environment: PythonEnvironment,
+    cacheRoot: Uri,
+    envDir: Uri,
+): Promise<CacheEnvironmentInspection> {
+    if (environment.envId.managerId !== INLINE_SCRIPT_MANAGER_ID) {
+        return 'uncertain';
+    }
+    try {
+        const [expectedDir, resolvedPrefix, expectedPython, resolvedPython] = await Promise.all([
+            resolveCacheEntryPath(cacheRoot, envDir),
+            fsapi.realpath(environment.sysPrefix),
+            fsapi.realpath(getVenvPythonPath(envDir.fsPath)),
+            fsapi.realpath(environment.environmentPath.fsPath),
+        ]);
+        if (!expectedDir) {
+            return 'uncertain';
+        }
+        return normalizePath(expectedDir) === normalizePath(resolvedPrefix) &&
+            normalizePath(expectedPython) === normalizePath(resolvedPython)
+            ? 'expected'
+            : 'stale';
+    } catch (error) {
+        traceWarn('inline-script env: failed to inspect cache-entry ownership:', error);
+        return 'uncertain';
+    }
+}
+
+/** Read validated sidecar metadata, returning `undefined` for non-valid state. */
 export async function readMetaJson(envDir: Uri): Promise<InlineScriptEnvMeta | undefined> {
+    const result = await inspectMetaJson(envDir);
+    return result.kind === 'valid' ? result.metadata : undefined;
+}
+
+/** Classify sidecar state; only `unavailable` denotes transient I/O. */
+export async function inspectMetaJson(envDir: Uri): Promise<InlineScriptMetaReadResult> {
     const metaPath = getMetaJsonPath(envDir).fsPath;
 
     try {
-        const stat = await fsapi.stat(metaPath);
+        const stat = await fsapi.lstat(metaPath);
         if (!stat.isFile()) {
             traceWarn(`inline-script meta: not a regular file at ${metaPath}`);
-            return undefined;
+            return { kind: 'invalid' };
         }
         if (stat.size > MAX_META_JSON_BYTES) {
             traceWarn(`inline-script meta: refusing to read ${metaPath} (${stat.size} bytes > cap)`);
-            return undefined;
+            return { kind: 'invalid' };
         }
     } catch (err) {
         if (isFileNotFoundError(err)) {
             traceWarn(`inline-script meta: not found at ${metaPath}`);
+            return { kind: 'missing' };
         } else {
             const code = (err as NodeJS.ErrnoException | undefined)?.code ?? 'unknown';
             traceWarn(`inline-script meta: failed to stat ${metaPath} (code=${code}):`, err);
+            return { kind: 'unavailable' };
         }
-        return undefined;
     }
 
     let raw: string;
@@ -101,7 +147,7 @@ export async function readMetaJson(envDir: Uri): Promise<InlineScriptEnvMeta | u
     } catch (err) {
         const code = (err as NodeJS.ErrnoException | undefined)?.code ?? 'unknown';
         traceWarn(`inline-script meta: failed to read ${metaPath} (code=${code}):`, err);
-        return undefined;
+        return { kind: isFileNotFoundError(err) ? 'missing' : 'unavailable' };
     }
 
     let parsed: unknown;
@@ -109,15 +155,15 @@ export async function readMetaJson(envDir: Uri): Promise<InlineScriptEnvMeta | u
         parsed = JSON.parse(raw);
     } catch (err) {
         traceWarn(`inline-script meta: malformed JSON in ${metaPath}:`, err);
-        return undefined;
+        return { kind: 'invalid' };
     }
 
     const validated = validateMeta(parsed);
     if (!validated) {
         traceWarn(`inline-script meta: invalid shape in ${metaPath}`);
-        return undefined;
+        return { kind: 'invalid' };
     }
-    return validated;
+    return { kind: 'valid', metadata: validated };
 }
 
 /**
@@ -160,15 +206,20 @@ export function selectStaleEntries(entries: ReadonlyArray<CacheEntrySummary>, no
  * Verify that a cached env's base interpreter still exists on disk.
  */
 export async function verifyBaseInterpreterExists(envDir: Uri): Promise<boolean> {
-    return isWindows() ? verifyWindowsBaseInterpreter(envDir) : verifyPosixBaseInterpreter(envDir);
+    return (await getBaseInterpreterStatus(envDir)) === 'available';
 }
 
-async function verifyPosixBaseInterpreter(envDir: Uri): Promise<boolean> {
+/** Classify the base interpreter; `unavailable` denotes transient I/O. */
+export async function getBaseInterpreterStatus(envDir: Uri): Promise<BaseInterpreterStatus> {
+    return isWindows() ? getWindowsBaseInterpreterStatus(envDir) : getPosixBaseInterpreterStatus(envDir);
+}
+
+async function getPosixBaseInterpreterStatus(envDir: Uri): Promise<BaseInterpreterStatus> {
     const launcherPath = Uri.joinPath(envDir, 'bin', 'python').fsPath;
-    return isRegularFile(launcherPath, 'base interpreter');
+    return getRegularFileStatus(launcherPath, 'base interpreter');
 }
 
-async function verifyWindowsBaseInterpreter(envDir: Uri): Promise<boolean> {
+async function getWindowsBaseInterpreterStatus(envDir: Uri): Promise<BaseInterpreterStatus> {
     const pyvenvPath = Uri.joinPath(envDir, 'pyvenv.cfg').fsPath;
     let raw: string;
     try {
@@ -176,37 +227,39 @@ async function verifyWindowsBaseInterpreter(envDir: Uri): Promise<boolean> {
     } catch (err) {
         if (isFileNotFoundError(err)) {
             traceWarn(`inline-script env: missing pyvenv.cfg at ${pyvenvPath}`);
+            return 'missing';
         } else {
             const code = (err as NodeJS.ErrnoException | undefined)?.code ?? 'unknown';
             traceWarn(`inline-script env: failed to read ${pyvenvPath} (code=${code}):`, err);
+            return 'unavailable';
         }
-        return false;
     }
     const home = parsePyvenvHome(raw);
     if (home === undefined) {
         traceWarn(`inline-script env: no 'home =' line in ${pyvenvPath}`);
-        return false;
+        return 'missing';
     }
     const launcherPath = path.join(home, 'python.exe');
-    return isRegularFile(launcherPath, 'base interpreter');
+    return getRegularFileStatus(launcherPath, 'base interpreter');
 }
 
-async function isRegularFile(filePath: string, label: string): Promise<boolean> {
+async function getRegularFileStatus(filePath: string, label: string): Promise<BaseInterpreterStatus> {
     try {
         const stat = await fsapi.stat(filePath);
         if (!stat.isFile()) {
             traceWarn(`inline-script env: ${label} is not a regular file at ${filePath}`);
-            return false;
+            return 'missing';
         }
-        return true;
+        return 'available';
     } catch (err) {
         if (isFileNotFoundError(err)) {
             traceWarn(`inline-script env: ${label} missing at ${filePath}`);
+            return 'missing';
         } else {
             const code = (err as NodeJS.ErrnoException | undefined)?.code ?? 'unknown';
             traceWarn(`inline-script env: failed to stat ${filePath} (code=${code}):`, err);
+            return 'unavailable';
         }
-        return false;
     }
 }
 
@@ -224,6 +277,13 @@ function isFileNotFoundError(err: unknown): boolean {
     return typeof err === 'object' && err !== null && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
 }
 
+function isDescendantPath(rootPath: string, candidatePath: string): boolean {
+    const relative = path.relative(rootPath, candidatePath);
+    return (
+        relative.length > 0 && relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)
+    );
+}
+
 function validateMeta(value: unknown): InlineScriptEnvMeta | undefined {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
         return undefined;
@@ -232,21 +292,30 @@ function validateMeta(value: unknown): InlineScriptEnvMeta | undefined {
     if (obj.schemaVersion !== META_SCHEMA_VERSION) {
         return undefined;
     }
-    if (typeof obj.scriptFsPath !== 'string' || obj.scriptFsPath.length === 0) {
+    if (
+        typeof obj.baseInterpreterPath !== 'string' ||
+        obj.baseInterpreterPath.length === 0 ||
+        obj.baseInterpreterPath.trim() !== obj.baseInterpreterPath ||
+        !path.isAbsolute(obj.baseInterpreterPath)
+    ) {
+        return undefined;
+    }
+    if (
+        typeof obj.baseInterpreterVersion !== 'string' ||
+        obj.baseInterpreterVersion.trim().length === 0 ||
+        obj.baseInterpreterVersion.trim() !== obj.baseInterpreterVersion
+    ) {
         return undefined;
     }
     if (!isCanonicalIsoTimestamp(obj.lastUsedAt)) {
         return undefined;
     }
-    if (obj.requiresPython !== undefined && typeof obj.requiresPython !== 'string') {
-        return undefined;
-    }
 
     return {
         schemaVersion: META_SCHEMA_VERSION,
-        scriptFsPath: obj.scriptFsPath,
+        baseInterpreterPath: obj.baseInterpreterPath,
+        baseInterpreterVersion: obj.baseInterpreterVersion,
         lastUsedAt: obj.lastUsedAt,
-        requiresPython: obj.requiresPython,
     };
 }
 

--- a/src/common/inlineScriptCacheLayout.ts
+++ b/src/common/inlineScriptCacheLayout.ts
@@ -284,6 +284,10 @@ function isDescendantPath(rootPath: string, candidatePath: string): boolean {
     );
 }
 
+function isNonEmptyTrimmedString(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0 && value.trim() === value;
+}
+
 function validateMeta(value: unknown): InlineScriptEnvMeta | undefined {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
         return undefined;
@@ -292,19 +296,10 @@ function validateMeta(value: unknown): InlineScriptEnvMeta | undefined {
     if (obj.schemaVersion !== META_SCHEMA_VERSION) {
         return undefined;
     }
-    if (
-        typeof obj.baseInterpreterPath !== 'string' ||
-        obj.baseInterpreterPath.length === 0 ||
-        obj.baseInterpreterPath.trim() !== obj.baseInterpreterPath ||
-        !path.isAbsolute(obj.baseInterpreterPath)
-    ) {
+    if (!isNonEmptyTrimmedString(obj.baseInterpreterPath) || !path.isAbsolute(obj.baseInterpreterPath)) {
         return undefined;
     }
-    if (
-        typeof obj.baseInterpreterVersion !== 'string' ||
-        obj.baseInterpreterVersion.trim().length === 0 ||
-        obj.baseInterpreterVersion.trim() !== obj.baseInterpreterVersion
-    ) {
+    if (!isNonEmptyTrimmedString(obj.baseInterpreterVersion)) {
         return undefined;
     }
     if (!isCanonicalIsoTimestamp(obj.lastUsedAt)) {

--- a/src/common/inlineScriptInterpreter.ts
+++ b/src/common/inlineScriptInterpreter.ts
@@ -24,7 +24,8 @@ export function pickCompatibleInterpreter(
     installed: ReadonlyArray<PythonEnvironment>,
     requiresPython: string | undefined,
 ): PythonEnvironment | undefined {
-    const constraint = requiresPython && requiresPython.length > 0 ? requiresPython : undefined;
+    const trimmedConstraint = requiresPython?.trim();
+    const constraint = trimmedConstraint ? trimmedConstraint : undefined;
     const candidates = installed.filter((env) => isUsableBaseInterpreter(env, constraint));
     if (candidates.length === 0) {
         return undefined;

--- a/src/test/common/inlineScriptCacheKey.unit.test.ts
+++ b/src/test/common/inlineScriptCacheKey.unit.test.ts
@@ -106,6 +106,23 @@ suite('inlineScriptCacheKey', () => {
             );
         });
 
+        test('whitespace inside quoted marker values is preserved exactly', () => {
+            assert.strictEqual(
+                normalizeDependency('pkg; platform_version == "X  Y"'),
+                'pkg; platform_version=="X  Y"',
+            );
+            assert.notStrictEqual(
+                normalizeDependency('pkg; platform_version == "X Y"'),
+                normalizeDependency('pkg; platform_version == "X  Y"'),
+            );
+        });
+
+        test('escaped quotes do not end marker values', () => {
+            const input = String.raw`pkg; platform_version == "X\"  Y" and python_version >= "3.10"`;
+            const expected = String.raw`pkg; platform_version=="X\"  Y" and python_version>="3.10"`;
+            assert.strictEqual(normalizeDependency(input), expected);
+        });
+
         test('empty and whitespace-only entries normalize to empty string', () => {
             assert.strictEqual(normalizeDependency(''), '');
             assert.strictEqual(normalizeDependency('   '), '');
@@ -117,6 +134,14 @@ suite('inlineScriptCacheKey', () => {
             const result = normalizeDependency(input);
             assert.strictEqual(result, normalizeDependency(input), 'must be idempotent');
             assert.ok(result.includes('requests'), 'leading name should still appear');
+        });
+
+        test('direct-reference URL and marker boundaries are preserved exactly', () => {
+            const conditional = "pkg @ https://example.invalid/pkg! ;python_version == '0'";
+            const unconditional = "pkg @ https://example.invalid/pkg!;python_version=='0'";
+            assert.strictEqual(normalizeDependency(conditional), conditional);
+            assert.strictEqual(normalizeDependency(unconditional), unconditional);
+            assert.notStrictEqual(normalizeDependency(conditional), normalizeDependency(unconditional));
         });
 
         test('leading and trailing whitespace is stripped', () => {
@@ -238,6 +263,30 @@ suite('inlineScriptCacheKey', () => {
             const a = computeCacheKey({ dependencies: ['requests<3'], interpreterPath: interpreter });
             const b = computeCacheKey({ dependencies: ['requests<4'], interpreterPath: interpreter });
             assert.notStrictEqual(a, b);
+        });
+
+        test('meaningful whitespace inside quoted marker values changes the key', () => {
+            const a = computeCacheKey({
+                dependencies: ['pkg; platform_version == "X Y"'],
+                interpreterPath: interpreter,
+            });
+            const b = computeCacheKey({
+                dependencies: ['pkg; platform_version == "X  Y"'],
+                interpreterPath: interpreter,
+            });
+            assert.notStrictEqual(a, b);
+        });
+
+        test('direct-reference URL terminator whitespace changes the key', () => {
+            const conditional = computeCacheKey({
+                dependencies: ["pkg @ https://example.invalid/pkg! ;python_version == '0'"],
+                interpreterPath: interpreter,
+            });
+            const unconditional = computeCacheKey({
+                dependencies: ["pkg @ https://example.invalid/pkg!;python_version=='0'"],
+                interpreterPath: interpreter,
+            });
+            assert.notStrictEqual(conditional, unconditional);
         });
 
         test('changing the interpreter path changes the key', () => {

--- a/src/test/common/inlineScriptCacheLayout.unit.test.ts
+++ b/src/test/common/inlineScriptCacheLayout.unit.test.ts
@@ -2,34 +2,41 @@
 // Licensed under the MIT License.
 
 import assert from 'assert';
+import fsExtra from 'fs-extra';
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { Uri } from 'vscode';
+import { PythonEnvironment } from '../../api';
 import {
     CacheEntrySummary,
     INLINE_SCRIPT_CACHE_DIR_NAME,
     InlineScriptEnvMeta,
     META_JSON_FILENAME,
     META_SCHEMA_VERSION,
+    getBaseInterpreterStatus,
     getMetaJsonPath,
     getScriptEnvCacheRoot,
     getScriptEnvDir,
+    inspectOwnedCacheEntry,
+    inspectMetaJson,
     readMetaJson,
+    resolveCacheEntryPath,
     selectStaleEntries,
     verifyBaseInterpreterExists,
     writeMetaJson,
 } from '../../common/inlineScriptCacheLayout';
 import * as logging from '../../common/logging';
 import * as platformUtils from '../../common/utils/platformUtils';
+import { getVenvPythonPath } from '../../common/utils/virtualEnvironment';
 
 function makeMeta(overrides: Partial<InlineScriptEnvMeta> = {}): InlineScriptEnvMeta {
     return {
         schemaVersion: META_SCHEMA_VERSION,
-        scriptFsPath: '/tmp/script.py',
+        baseInterpreterPath: Uri.file(path.join(os.tmpdir(), 'base-python')).fsPath,
+        baseInterpreterVersion: '3.12.4',
         lastUsedAt: '2026-06-18T22:45:12.000Z',
-        requiresPython: '>=3.11',
         ...overrides,
     };
 }
@@ -133,14 +140,13 @@ suite('inlineScriptCacheLayout', () => {
             );
         });
 
-        test('writeMetaJson serializes optional requiresPython as undefined-erased', async () => {
-            const meta = makeMeta({ requiresPython: undefined });
+        test('writeMetaJson only serializes environment-level metadata', async () => {
+            const meta = makeMeta();
             await writeMetaJson(envDir, meta);
             const onDisk = JSON.parse(await fs.readFile(getMetaJsonPath(envDir).fsPath, 'utf8'));
+            assert.strictEqual(onDisk.baseInterpreterPath, meta.baseInterpreterPath);
+            assert.strictEqual('scriptFsPath' in onDisk, false);
             assert.strictEqual('requiresPython' in onDisk, false);
-            const read = await readMetaJson(envDir);
-            assert.ok(read);
-            assert.strictEqual(read.requiresPython, undefined);
         });
 
         test('writeMetaJson produces human-readable, indented JSON', async () => {
@@ -175,6 +181,46 @@ suite('inlineScriptCacheLayout', () => {
             assert.ok(traceWarnStub.called, 'expected a traceWarn');
         });
 
+        test('classifies missing, malformed, and valid metadata distinctly', async () => {
+            assert.deepStrictEqual(await inspectMetaJson(envDir), { kind: 'missing' });
+            await writeRaw('this is not json');
+            assert.deepStrictEqual(await inspectMetaJson(envDir), { kind: 'invalid' });
+            const metadata = makeMeta();
+            await writeRaw(JSON.stringify(metadata));
+            assert.deepStrictEqual(await inspectMetaJson(envDir), { kind: 'valid', metadata });
+        });
+
+        test('classifies non-ENOENT sidecar stat failures as unavailable', async () => {
+            sinon.stub(fsExtra, 'lstat').rejects(Object.assign(new Error('permission denied'), { code: 'EACCES' }));
+            assert.deepStrictEqual(await inspectMetaJson(envDir), { kind: 'unavailable' });
+        });
+
+        test('classifies non-ENOENT sidecar read failures as unavailable', async () => {
+            await writeRaw(JSON.stringify(makeMeta()));
+            sinon.stub(fsExtra, 'readFile').rejects(Object.assign(new Error('I/O error'), { code: 'EIO' }));
+            assert.deepStrictEqual(await inspectMetaJson(envDir), { kind: 'unavailable' });
+        });
+
+        test('does not follow a sidecar symlink outside the environment', async function () {
+            const externalMetaPath = path.join(tmpDir, 'external-meta.json');
+            const sidecarPath = getMetaJsonPath(envDir).fsPath;
+            await fs.writeJson(externalMetaPath, makeMeta());
+            try {
+                await fs.symlink(externalMetaPath, sidecarPath, 'file');
+            } catch (error) {
+                const code = (error as NodeJS.ErrnoException).code;
+                if (code === 'EPERM' || code === 'EACCES') {
+                    this.skip();
+                    return;
+                }
+                throw error;
+            }
+
+            assert.deepStrictEqual(await inspectMetaJson(envDir), { kind: 'invalid' });
+            assert.strictEqual(await readMetaJson(envDir), undefined);
+            assert.deepStrictEqual(await fs.readJson(externalMetaPath), makeMeta());
+        });
+
         test('returns undefined for malformed JSON', async () => {
             await writeRaw('this is not json');
             const result = await readMetaJson(envDir);
@@ -194,17 +240,37 @@ suite('inlineScriptCacheLayout', () => {
             assert.ok(traceWarnStub.called);
         });
 
-        test('returns undefined when scriptFsPath is missing', async () => {
-            const { scriptFsPath: _omit, ...partial } = makeMeta();
+        test('returns undefined when baseInterpreterPath is missing', async () => {
+            const { baseInterpreterPath: _omit, ...partial } = makeMeta();
             await writeRaw(JSON.stringify(partial));
             const result = await readMetaJson(envDir);
             assert.strictEqual(result, undefined);
         });
 
-        test('returns undefined when scriptFsPath is an empty string', async () => {
-            await writeRaw(JSON.stringify({ ...makeMeta(), scriptFsPath: '' }));
+        test('returns undefined when baseInterpreterPath is an empty string', async () => {
+            await writeRaw(JSON.stringify({ ...makeMeta(), baseInterpreterPath: '' }));
             const result = await readMetaJson(envDir);
             assert.strictEqual(result, undefined);
+        });
+
+        test('returns undefined when baseInterpreterPath is relative', async () => {
+            await writeRaw(JSON.stringify({ ...makeMeta(), baseInterpreterPath: path.join('relative', 'python') }));
+            const result = await readMetaJson(envDir);
+            assert.strictEqual(result, undefined);
+        });
+
+        test('returns undefined when baseInterpreterPath is not a string', async () => {
+            await writeRaw(JSON.stringify({ ...makeMeta(), baseInterpreterPath: 312 }));
+            const result = await readMetaJson(envDir);
+            assert.strictEqual(result, undefined);
+        });
+
+        test('returns undefined when baseInterpreterVersion is missing or blank', async () => {
+            const { baseInterpreterVersion: _omit, ...partial } = makeMeta();
+            await writeRaw(JSON.stringify(partial));
+            assert.strictEqual(await readMetaJson(envDir), undefined);
+            await writeRaw(JSON.stringify({ ...makeMeta(), baseInterpreterVersion: '   ' }));
+            assert.strictEqual(await readMetaJson(envDir), undefined);
         });
 
         test('returns undefined when lastUsedAt is not parseable', async () => {
@@ -213,18 +279,24 @@ suite('inlineScriptCacheLayout', () => {
             assert.strictEqual(result, undefined);
         });
 
-        test('returns undefined when requiresPython is present but not a string', async () => {
-            await writeRaw(JSON.stringify({ ...makeMeta(), requiresPython: 311 }));
-            const result = await readMetaJson(envDir);
-            assert.strictEqual(result, undefined);
-        });
-
-        test('accepts a meta with requiresPython explicitly omitted', async () => {
-            const { requiresPython: _omit, ...partial } = makeMeta();
-            await writeRaw(JSON.stringify(partial));
+        test('drops legacy script-specific fields', async () => {
+            await writeRaw(JSON.stringify({ ...makeMeta(), scriptFsPath: 'script.py', requiresPython: '>=3.11' }));
             const result = await readMetaJson(envDir);
             assert.ok(result);
-            assert.strictEqual(result.requiresPython, undefined);
+            assert.strictEqual('scriptFsPath' in result, false);
+            assert.strictEqual('requiresPython' in result, false);
+        });
+
+        test('rejects the provisional pre-writer v1 sidecar shape', async () => {
+            await writeRaw(
+                JSON.stringify({
+                    schemaVersion: 1,
+                    scriptFsPath: Uri.file(path.join(os.tmpdir(), 'script.py')).fsPath,
+                    lastUsedAt: '2026-06-18T22:45:12.000Z',
+                    requiresPython: '>=3.11',
+                }),
+            );
+            assert.strictEqual(await readMetaJson(envDir), undefined);
         });
 
         test('returns undefined for a top-level non-object payload', async () => {
@@ -243,11 +315,6 @@ suite('inlineScriptCacheLayout', () => {
             // tolerated and dropped on read. Pin that null doesn't
             // break the validator.
             assert.ok(await readMetaJson(envDir));
-        });
-
-        test('returns undefined when requiresPython is explicitly null', async () => {
-            await writeRaw(JSON.stringify({ ...makeMeta(), requiresPython: null }));
-            assert.strictEqual(await readMetaJson(envDir), undefined);
         });
 
         test('returns undefined for a non-canonical ISO timestamp (e.g. "2026")', async () => {
@@ -292,6 +359,28 @@ suite('inlineScriptCacheLayout', () => {
                 args.some((a) => a.includes('not found')),
                 `expected an ENOENT-specific warn; saw: ${JSON.stringify(args)}`,
             );
+        });
+    });
+
+    suite('getBaseInterpreterStatus classification', () => {
+        let tmpDir: string;
+        let envDir: Uri;
+
+        setup(async () => {
+            tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'isclayout-base-status-'));
+            envDir = Uri.file(path.join(tmpDir, 'env'));
+            await fs.ensureDir(envDir.fsPath);
+            sinon.stub(platformUtils, 'isWindows').returns(false);
+        });
+
+        teardown(async () => {
+            await fs.remove(tmpDir);
+        });
+
+        test('distinguishes a missing base interpreter from an unavailable stat', async () => {
+            assert.strictEqual(await getBaseInterpreterStatus(envDir), 'missing');
+            sinon.stub(fsExtra, 'stat').rejects(Object.assign(new Error('I/O error'), { code: 'EIO' }));
+            assert.strictEqual(await getBaseInterpreterStatus(envDir), 'unavailable');
         });
     });
 
@@ -350,6 +439,107 @@ suite('inlineScriptCacheLayout', () => {
             const future = new Date(now.getTime() + TTL_MS);
             const stale = selectStaleEntries([entry('a', future)], now, TTL_MS);
             assert.deepStrictEqual(stale, []);
+        });
+    });
+
+    suite('resolveCacheEntryPath', () => {
+        let tmpDir: string;
+        let cacheRoot: Uri;
+
+        setup(async () => {
+            tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'isclayout-containment-'));
+            cacheRoot = Uri.file(path.join(tmpDir, 'script-envs-v1'));
+            await fs.ensureDir(cacheRoot.fsPath);
+        });
+
+        teardown(async () => {
+            await fs.remove(tmpDir);
+        });
+
+        test('resolves a direct cache entry', async () => {
+            const envDir = Uri.joinPath(cacheRoot, '0123456789abcdef');
+            await fs.ensureDir(envDir.fsPath);
+
+            assert.strictEqual(await resolveCacheEntryPath(cacheRoot, envDir), await fs.realpath(envDir.fsPath));
+        });
+
+        test('rejects the cache root and paths outside it', async () => {
+            const externalEnv = Uri.file(path.join(tmpDir, '0123456789abcdef'));
+            await fs.ensureDir(externalEnv.fsPath);
+
+            assert.strictEqual(await resolveCacheEntryPath(cacheRoot, cacheRoot), undefined);
+            assert.strictEqual(await resolveCacheEntryPath(cacheRoot, externalEnv), undefined);
+        });
+
+        test('surfaces a missing entry', async () => {
+            await assert.rejects(
+                resolveCacheEntryPath(cacheRoot, Uri.joinPath(cacheRoot, '0123456789abcdef')),
+                (error: NodeJS.ErrnoException) => error.code === 'ENOENT',
+            );
+        });
+    });
+
+    suite('inspectOwnedCacheEntry', () => {
+        let tmpDir: string;
+        let cacheRoot: Uri;
+        let envDir: Uri;
+        let environment: PythonEnvironment;
+
+        setup(async () => {
+            tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'isclayout-ownership-'));
+            cacheRoot = Uri.file(path.join(tmpDir, 'script-envs-v1'));
+            envDir = Uri.joinPath(cacheRoot, '0123456789abcdef');
+            const pythonPath = getVenvPythonPath(envDir.fsPath);
+            await fs.outputFile(pythonPath, '');
+            environment = {
+                envId: { id: 'inline-env', managerId: 'ms-python.python:inline-script' },
+                name: 'Python 3.12.4',
+                displayName: 'Python 3.12.4',
+                displayPath: pythonPath,
+                version: '3.12.4',
+                environmentPath: Uri.file(pythonPath),
+                execInfo: { run: { executable: pythonPath } },
+                sysPrefix: envDir.fsPath,
+            };
+        });
+
+        teardown(async () => {
+            await fs.remove(tmpDir);
+        });
+
+        test('accepts an inline-owned environment at the expected cache entry', async () => {
+            assert.strictEqual(await inspectOwnedCacheEntry(environment, cacheRoot, envDir), 'expected');
+        });
+
+        test('does not claim environments owned by another manager', async () => {
+            const otherManager = {
+                ...environment,
+                envId: { ...environment.envId, managerId: 'ms-python.python:system' },
+            };
+            assert.strictEqual(await inspectOwnedCacheEntry(otherManager, cacheRoot, envDir), 'uncertain');
+        });
+
+        test('classifies an inline environment resolving elsewhere as stale', async () => {
+            const externalPrefix = path.join(tmpDir, 'external-env');
+            const externalPython = getVenvPythonPath(externalPrefix);
+            await fs.outputFile(externalPython, '');
+            const mismatched = {
+                ...environment,
+                sysPrefix: externalPrefix,
+                environmentPath: Uri.file(externalPython),
+            };
+
+            assert.strictEqual(await inspectOwnedCacheEntry(mismatched, cacheRoot, envDir), 'stale');
+        });
+
+        test('preserves ownership as uncertain when paths cannot be inspected', async () => {
+            const missing = {
+                ...environment,
+                environmentPath: Uri.file(path.join(tmpDir, 'missing-python')),
+            };
+
+            assert.strictEqual(await inspectOwnedCacheEntry(missing, cacheRoot, envDir), 'uncertain');
+            assert.ok(traceWarnStub.called);
         });
     });
 

--- a/src/test/common/inlineScriptCacheLayout.unit.test.ts
+++ b/src/test/common/inlineScriptCacheLayout.unit.test.ts
@@ -471,6 +471,13 @@ suite('inlineScriptCacheLayout', () => {
             assert.strictEqual(await resolveCacheEntryPath(cacheRoot, externalEnv), undefined);
         });
 
+        test('rejects a nested descendant of the cache root', async () => {
+            const nestedEnv = Uri.joinPath(cacheRoot, 'nested', '0123456789abcdef');
+            await fs.ensureDir(nestedEnv.fsPath);
+
+            assert.strictEqual(await resolveCacheEntryPath(cacheRoot, nestedEnv), undefined);
+        });
+
         test('surfaces a missing entry', async () => {
             await assert.rejects(
                 resolveCacheEntryPath(cacheRoot, Uri.joinPath(cacheRoot, '0123456789abcdef')),
@@ -519,13 +526,23 @@ suite('inlineScriptCacheLayout', () => {
             assert.strictEqual(await inspectOwnedCacheEntry(otherManager, cacheRoot, envDir), 'uncertain');
         });
 
-        test('classifies an inline environment resolving elsewhere as stale', async () => {
+        test('classifies an inline environment with a mismatched sysPrefix as stale', async () => {
+            const externalPrefix = path.join(tmpDir, 'external-env');
+            await fs.ensureDir(externalPrefix);
+            const mismatched = {
+                ...environment,
+                sysPrefix: externalPrefix,
+            };
+
+            assert.strictEqual(await inspectOwnedCacheEntry(mismatched, cacheRoot, envDir), 'stale');
+        });
+
+        test('classifies an inline environment with a mismatched environmentPath as stale', async () => {
             const externalPrefix = path.join(tmpDir, 'external-env');
             const externalPython = getVenvPythonPath(externalPrefix);
             await fs.outputFile(externalPython, '');
             const mismatched = {
                 ...environment,
-                sysPrefix: externalPrefix,
                 environmentPath: Uri.file(externalPython),
             };
 

--- a/src/test/common/inlineScriptInterpreter.unit.test.ts
+++ b/src/test/common/inlineScriptInterpreter.unit.test.ts
@@ -156,6 +156,13 @@ suite('inlineScriptInterpreter', () => {
             assert.strictEqual(picked.version, '3.12.4');
         });
 
+        test('whitespace-only requiresPython is treated as no constraint', () => {
+            const envs = [makeEnv('3.10.0'), makeEnv('3.12.4')];
+            const picked = pickCompatibleInterpreter(envs, '   ');
+            assert.ok(picked, 'whitespace-only constraint must not silently reject all envs');
+            assert.strictEqual(picked.version, '3.12.4');
+        });
+
         test('ranks versions with pre-release / dev / local suffixes by release segments only', () => {
             // 3.12.0a1 and 3.12.0.dev1 both parse to [3,12,0]; stable sort
             // means the first-listed 3.12 entry wins.


### PR DESCRIPTION
> Part of #1602 (PEP 723 inline script env support). Design doc: #1601.

> **Split for review (3 PRs).** Reviewers flagged the original PR 5 as too large, so it is split into three PRs grouped by dependency layer:
> - **5a — generic env-creation utilities — #1651.** Merged.
> - **5b — inline-script cache + interpreter utilities — this PR (#1655).** Rebased on `main`.
> - **5c — `create()` happy path (manager + wiring) — #1656.** Stacked on 5b.
>
> #1651 has merged and this branch has been rebased. The diff now contains only this PR's seven files. **Remaining merge order: 5b → 5c.**

### Roadmap context

This is the second slice of **PR 5 of 16**. See #1651 for the full roadmap table.

| Phase 2: Manager | PR | Status |
|---|---|---|
| | PR 4: `InlineScriptEnvManager` skeleton | merged (#1610) |
| | PR 5a: generic env-creation utilities | merged (#1651) |
| | **PR 5b: inline-script cache + interpreter utilities** | **this PR (#1655)** |
| | PR 5c: `create()` happy path (manager + wiring) | #1656 |

### Why this PR

With the generic primitives from 5a in place, this PR lands the **inline-script-specific utilities** that `create()` (5c) composes: a normalized dependency cache key, cache-layout ownership/status checks, and interpreter-constraint handling. These are pure functions with no manager wiring yet, so they are reviewed on their own.

### What this PR adds

**Cache-key tail normalization** (`src/common/inlineScriptCacheKey.ts`): adds `normalizeRequirementTail`, a quote-aware scanner that collapses whitespace and tightens comparator spacing (`>= 1.0` → `>=1.0`) in a requirement's version/marker tail while **preserving quoted PEP 508 marker literals verbatim** (e.g. `python_version >= "3.11"`). Direct-reference requirements (`pkg @ https://…`) are kept verbatim after the name and extras. The effect is that semantically identical dependency strings normalize to the same cache key, so they reuse the same cached environment.

**Cache-layout additions** (`src/common/inlineScriptCacheLayout.ts`): `resolveCacheEntryPath` (containment under the cache root), `inspectOwnedCacheEntry` (realpath ownership), `getBaseInterpreterStatus` (`available | missing | unavailable`), `inspectMetaJson` (typed sidecar read), and a stricter `validateMeta`. The `.meta.json` sidecar schema is `{ schemaVersion, baseInterpreterPath, baseInterpreterVersion, lastUsedAt }`. Uses `getVenvPythonPath` from merged PR #1651.

**Interpreter-constraint trimming** (`src/common/inlineScriptInterpreter.ts`): `pickCompatibleInterpreter` now trims `requires-python`, so a whitespace-only constraint is treated as no constraint.

**Manager ID constants** (`src/common/constants.ts`): centralizes the conda and inline-script manager IDs used by interpreter filtering.

### Tests

- **`inlineScriptCacheKey.unit.test.ts`** — canonicalization cases including marker literals and direct references.
- **`inlineScriptCacheLayout.unit.test.ts`** — the new containment, ownership, base-interpreter-status, and typed sidecar-read helpers.
- **`inlineScriptInterpreter.unit.test.ts`** — constraint trimming / selection.

On this rebased branch `npm run compile-tests` is clean and `npm run unittest` reports **1467 passing, 0 failing, 5 pending**.

### User impact

**None.** These are pure utilities. Nothing calls the new code paths until the manager lands in 5c (#1656).

### Merge order

#1651 has merged. Merge this PR next, then #1656.
