### PR TITLE
Fix macOS test launch with VS Code 1.131

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "@types/which": "^3.0.4",
                 "@typescript-eslint/eslint-plugin": "^8.16.0",
                 "@typescript-eslint/parser": "^8.16.0",
-                "@vscode/test-electron": "^2.5.2",
+                "@vscode/test-electron": "^3.1.0",
                 "@vscode/vsce": "^3.9.2",
                 "eslint": "^9.15.0",
                 "glob": "^8.1.0",
@@ -1658,10 +1658,11 @@
             }
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-            "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+            "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "http-proxy-agent": "^7.0.2",
                 "https-proxy-agent": "^7.0.5",
@@ -1670,7 +1671,7 @@
                 "semver": "^7.6.2"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=22"
             }
         },
         "node_modules/@vscode/vsce": {
@@ -8644,9 +8645,9 @@
             }
         },
         "@vscode/test-electron": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-            "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+            "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
             "dev": true,
             "requires": {
                 "http-proxy-agent": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -723,7 +723,7 @@
         "@types/which": "^3.0.4",
         "@typescript-eslint/eslint-plugin": "^8.16.0",
         "@typescript-eslint/parser": "^8.16.0",
-        "@vscode/test-electron": "^2.5.2",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.9.2",
         "eslint": "^9.15.0",
         "glob": "^8.1.0",


### PR DESCRIPTION
### Why

VS Code 1.131 removed the legacy `Contents/MacOS/Electron` compatibility path from its macOS application bundle. `@vscode/test-electron` 2.5.2 still launches that hard-coded path, so all macOS smoke jobs fail with `ENOENT` before VS Code or the extension starts.

This currently blocks the macOS checks on #1656. The upstream issue and fix are microsoft/vscode-test#349 and microsoft/vscode-test#350.

### What

Upgrade `@vscode/test-electron` from 2.5.2 to 3.1.0 and refresh the lockfile. Version 3.1.0 resolves the macOS executable from `CFBundleExecutable` in `Info.plist`, with the old `Electron` path retained as a fallback for older VS Code builds.

This is a development-only dependency change. Version 3.1.0 requires Node 22, which is already used by CI.

### Validation

- `npm run compile-tests`
- `npm run unittest` — 1469 passing, 0 failing, 5 pending
