### PR TITLE
Avoid selecting no-Python Conda base on startup

### DIFF
--- a/src/managers/conda/condaEnvManager.ts
+++ b/src/managers/conda/condaEnvManager.ts
@@ -509,7 +509,10 @@ export class CondaEnvManager implements EnvironmentManager, Disposable {
 
         // If a global environment is still not set, try using the 'base'
         if (!this.globalEnv) {
-            this.globalEnv = this.findEnvironmentByName('base');
+            const base = this.findEnvironmentByName('base');
+            if (base?.version !== 'no-python') {
+                this.globalEnv = base;
+            }
         }
 
         // Find any conda environments that might be associated with the current projects

--- a/src/test/managers/conda/condaEnvManager.initialize.unit.test.ts
+++ b/src/test/managers/conda/condaEnvManager.initialize.unit.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import assert from 'assert';
 import * as sinon from 'sinon';
+import { Uri } from 'vscode';
 import { PythonEnvironmentApi } from '../../../api';
 import * as logging from '../../../common/logging';
 import { EventNames } from '../../../common/telemetry/constants';
@@ -27,6 +28,7 @@ import { makeMockCondaEnvironment as makeEnv } from '../../mocks/pythonEnvironme
 suite('CondaEnvManager.initialize - lazy registration flow', () => {
     let getCondaStub: sinon.SinonStub;
     let getCondaPathSettingStub: sinon.SinonStub;
+    let getCondaForGlobalStub: sinon.SinonStub;
     let refreshCondaEnvsStub: sinon.SinonStub;
     let constructSourcingStub: sinon.SinonStub;
     let notifyMissingStub: sinon.SinonStub;
@@ -37,7 +39,7 @@ suite('CondaEnvManager.initialize - lazy registration flow', () => {
         getCondaStub = sinon.stub(condaUtils, 'getConda');
         getCondaPathSettingStub = sinon.stub(condaUtils, 'getCondaPathSetting').returns(undefined);
         refreshCondaEnvsStub = sinon.stub(condaUtils, 'refreshCondaEnvs').resolves([]);
-        sinon.stub(condaUtils, 'getCondaForGlobal').resolves(undefined);
+        getCondaForGlobalStub = sinon.stub(condaUtils, 'getCondaForGlobal').resolves(undefined);
         constructSourcingStub = sinon.stub(condaSourcingUtils, 'constructCondaSourcingStatus');
         notifyMissingStub = sinon.stub(commonUtils, 'notifyMissingManagerIfDefault').resolves();
         sendTelemetryStub = sinon.stub(telemetrySender, 'sendTelemetryEvent');
@@ -99,6 +101,44 @@ suite('CondaEnvManager.initialize - lazy registration flow', () => {
             { managerName: props.managerName, result: props.result, envCount: props.envCount, toolSource: props.toolSource },
             { managerName: 'conda', result: 'success', envCount: 1, toolSource: 'local' },
         );
+    });
+
+    test('does not use a no-Python base as the implicit global fallback', async () => {
+        getCondaStub.resolves('/usr/bin/conda');
+        constructSourcingStub.resolves({ toString: () => '' } as any);
+        const base = makeEnv('base', Uri.file('/opt/miniconda3').fsPath, 'no-python');
+        refreshCondaEnvsStub.resolves([base]);
+
+        const mgr = createManager();
+        await mgr.initialize();
+
+        assert.strictEqual(await mgr.get(undefined), undefined);
+    });
+
+    test('uses a base with Python as the implicit global fallback', async () => {
+        getCondaStub.resolves('/usr/bin/conda');
+        constructSourcingStub.resolves({ toString: () => '' } as any);
+        const base = makeEnv('base', Uri.file('/opt/miniconda3').fsPath, '3.12.0');
+        refreshCondaEnvsStub.resolves([base]);
+
+        const mgr = createManager();
+        await mgr.initialize();
+
+        assert.strictEqual(await mgr.get(undefined), base);
+    });
+
+    test('retains a persisted no-Python base selection', async () => {
+        getCondaStub.resolves('/usr/bin/conda');
+        constructSourcingStub.resolves({ toString: () => '' } as any);
+        const basePath = Uri.file('/opt/miniconda3').fsPath;
+        const base = makeEnv('base', basePath, 'no-python');
+        refreshCondaEnvsStub.resolves([base]);
+        getCondaForGlobalStub.resolves(basePath);
+
+        const mgr = createManager();
+        await mgr.initialize();
+
+        assert.strictEqual(await mgr.get(undefined), base);
     });
 
     test('success path: conda from explicit setting → toolSource=settings', async () => {


### PR DESCRIPTION
## Context

Fixes [#1689](https://github.com/microsoft/vscode-python-environments/issues/1689).

The reporter uses Conda/Micromamba with:

- `python-envs.defaultEnvManager` set to Conda
- a valid named environment (`c8`) configured through `python.defaultInterpreterPath`
- a Micromamba `base` prefix that legitimately does not contain Python

On startup, the workspace-specific environment resolves successfully to `c8`, but global selection is resolved separately (and may be deferred). The issue log shows that the global path selected the no-Python base through `defaultEnvManager`:

```text
Changed environment from undefined to base (no-python) for: global
[interpreterSelection] global: base (no-python) (source: defaultEnvManager)
```

Passing that automatically selected environment to `CondaEnvManager.set()` invokes the same no-Python check used for explicit user selection, producing the modal `No python found in the selected conda environment: base`.

This can vary by workspace because Conda's global selection is stored in VS Code workspace state. A workspace with a previously persisted usable selection does not take the implicit base fallback, while a fresh workspace commonly does.

## Root cause

When no persisted global Conda selection exists, `CondaEnvManager.loadEnvMap()` unconditionally uses the environment named `base` as its implicit global fallback. A no-Python Conda prefix is valid for discovery and display in the Environment Manager, but it is not a usable Python interpreter and should not be selected automatically.

The explicit-selection flow is different: when a user intentionally selects a no-Python Conda environment, the existing modal offers to install Python into it. That behavior should remain available.

## Fix

Only assign `base` as the implicit global fallback when it contains Python:

```ts
const base = this.findEnvironmentByName('base');
if (base?.version !== 'no-python') {
    this.globalEnv = base;
}
```

With an empty Micromamba base and no persisted global selection, `globalEnv` remains undefined. Initial selection therefore never passes the no-Python base into the modal-producing `set()` path.

## Behavior preserved

- A valid base environment containing Python remains the implicit global fallback.
- Explicitly persisted no-Python selections are restored, preserving user intent.
- Explicitly selecting a no-Python environment still presents the install-Python modal.
- No-Python environments remain in the discovered collection and visible in the Environment Manager.
- Workspace-specific Conda selections, named/prefix environments, discovery, settings, and persistence formats are unchanged.
- Interpreter priority resolution is unchanged; this PR intentionally prevents the invalid implicit selection rather than changing `defaultEnvManager` precedence.

If no usable persisted global selection exists and base has no Python, the effective global environment is now undefined instead of an unusable interpreter.

## Testing

Added coverage for all relevant initialization boundaries:

- no-Python base is not used as the implicit global fallback
- base containing Python remains the implicit global fallback
- explicitly persisted no-Python base remains selected

Validation performed:

- `npm run compile-tests`
- focused Conda initialization, global-selection, and interpreter-selection unit suites (57 passing)