### PR TITLE
Add inline script activation-time discovery (PEP 723 PR 8/16)

### DIFF
--- a/src/common/inlineScript/cacheLayout.ts
+++ b/src/common/inlineScript/cacheLayout.ts
@@ -204,7 +204,7 @@ export function selectStaleEntries(entries: ReadonlyArray<CacheEntrySummary>, no
 }
 
 /**
- * Verify that a cached env's base interpreter still exists on disk.
+ * Verify that a cached env's launcher and base interpreter still exist on disk.
  */
 export async function verifyBaseInterpreterExists(envDir: Uri): Promise<boolean> {
     return (await getBaseInterpreterStatus(envDir)) === 'available';
@@ -221,6 +221,11 @@ async function getPosixBaseInterpreterStatus(envDir: Uri): Promise<BaseInterpret
 }
 
 async function getWindowsBaseInterpreterStatus(envDir: Uri): Promise<BaseInterpreterStatus> {
+    const launcherStatus = await getRegularFileStatus(getVenvPythonPath(envDir.fsPath), 'cached interpreter launcher');
+    if (launcherStatus !== 'available') {
+        return launcherStatus;
+    }
+
     const pyvenvPath = Uri.joinPath(envDir, 'pyvenv.cfg').fsPath;
     let raw: string;
     try {

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -11,6 +11,7 @@ import {
     DidChangeEnvironmentEventArgs,
     DidChangeEnvironmentsEventArgs,
     EnvironmentManager,
+    EnvironmentChangeKind,
     GetEnvironmentScope,
     GetEnvironmentsScope,
     IconPath,
@@ -60,6 +61,7 @@ import { normalizePath } from '../../../common/utils/pathUtils';
 import { compareReleaseSegments, parseReleaseSegments } from '../../../common/utils/pep440Release';
 import { getVenvPythonPath } from '../../../common/utils/virtualEnvironment';
 import { NativePythonFinder } from '../../common/nativePythonFinder';
+import { sortEnvironments } from '../../common/utils';
 import { resolveSystemPythonEnvironmentPath } from '../utils';
 import * as uvPythonInstaller from '../uvPythonInstaller';
 import {
@@ -78,6 +80,7 @@ const BASE_INTERPRETER_MANAGER_IDS = new Set([
 const CACHE_LOCK_TIMEOUT_MS = 5 * 60 * 1000;
 const CACHE_LOCK_RETRY_MS = 500;
 const CACHED_ASSOCIATION_VALIDATION_INTERVAL_MS = 5_000;
+const DISCOVERY_RETRY_DELAYS_MS = [1_000, 5_000] as const;
 /** Workspace-state key for PEP 723 script path to environment executable associations. */
 export const INLINE_SCRIPT_ENVS_KEY = `${ENVS_EXTENSION_ID}:inline-script:SCRIPT_ENVIRONMENTS`;
 
@@ -124,17 +127,23 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
     private readonly pendingCreations = new Map<string, Promise<PythonEnvironment | undefined>>();
     private readonly directlyResolvedBaseInterpreters = new Map<string, PythonEnvironment>();
     private baseInterpreterInstallationQueue: Promise<void> = Promise.resolve();
+    private collection: PythonEnvironment[] = [];
     private readonly pendingRehydrations = new Map<string, Promise<PythonEnvironment | undefined>>();
     private readonly fsPathToEnv = new Map<string, PythonEnvironment>();
     private readonly fsPathToPersistedEnvPath = new Map<string, string>();
     private readonly cachedAssociationValidatedAt = new Map<string, number>();
     private readonly associationRevisions = new Map<string, number>();
+    private pendingRefresh: Promise<boolean> | undefined;
+    private activationDiscoveryActive = false;
+    private discoveryRetryAttempt = 0;
+    private discoveryRetryTimer: ReturnType<typeof setTimeout> | undefined;
     private persistenceQueue: Promise<void> = Promise.resolve();
     private selectionQueue: Promise<void> = Promise.resolve();
     private cacheMaintenanceQueue: Promise<void> = Promise.resolve();
     private cacheMaintenanceBarrier: Deferred<void> | undefined;
     private pendingCacheMaintenances = 0;
     private activeCreateOperations = 0;
+    private disposed = false;
 
     private readonly _onDidChangeEnvironments = new EventEmitter<DidChangeEnvironmentsEventArgs>();
     public readonly onDidChangeEnvironments: Event<DidChangeEnvironmentsEventArgs> =
@@ -289,10 +298,17 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
     }
 
     async refresh(_scope: RefreshEnvironmentsScope): Promise<void> {
-        return;
+        if (this.disposed) {
+            return;
+        }
+        this.stopActivationDiscovery();
+        await this.getOrStartRefreshPass();
     }
 
-    async getEnvironments(_scope: GetEnvironmentsScope): Promise<PythonEnvironment[]> {
+    async getEnvironments(scope: GetEnvironmentsScope): Promise<PythonEnvironment[]> {
+        if (scope === 'all') {
+            return Array.from(this.collection);
+        }
         return [];
     }
 
@@ -313,6 +329,257 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         return this.enqueueCacheMaintenance(() =>
             this.enqueueSelection(() => this.clearCacheInternal(activeCreatesAtStart)),
         );
+    }
+
+    public startActivationDiscovery(): void {
+        if (this.disposed || this.activationDiscoveryActive) {
+            return;
+        }
+        this.activationDiscoveryActive = true;
+        this.discoveryRetryAttempt = 0;
+        this.runActivationDiscoveryPass();
+    }
+
+    private async getOrStartRefreshPass(): Promise<boolean> {
+        const pending = this.pendingRefresh;
+        if (pending) {
+            return pending;
+        }
+
+        const refresh = this.refreshDiscoveredEnvironments();
+        this.pendingRefresh = refresh;
+        try {
+            return await refresh;
+        } finally {
+            if (this.pendingRefresh === refresh) {
+                this.pendingRefresh = undefined;
+            }
+        }
+    }
+
+    private runActivationDiscoveryPass(): void {
+        if (this.disposed || !this.activationDiscoveryActive) {
+            return;
+        }
+
+        void this.getOrStartRefreshPass()
+            .then((shouldRetry) => {
+                if (this.disposed || !this.activationDiscoveryActive) {
+                    return;
+                }
+                if (!shouldRetry) {
+                    this.stopActivationDiscovery();
+                    return;
+                }
+                this.scheduleActivationDiscoveryRetry();
+            })
+            .catch((error) => {
+                if (this.disposed || !this.activationDiscoveryActive) {
+                    return;
+                }
+                this.log.warn(`Activation-time inline-script discovery failed: ${getErrorMessage(error)}`);
+                this.stopActivationDiscovery();
+            });
+    }
+
+    private async refreshDiscoveredEnvironments(): Promise<boolean> {
+        const cacheRoot = getScriptEnvCacheRoot(this.globalStorageUri);
+        const previousByKey = new Map(
+            this.collection.map((environment) => [this.getDiscoveredEnvironmentKey(environment), environment]),
+        );
+
+        let entryNames: string[];
+        try {
+            entryNames = await fs.readdir(cacheRoot.fsPath);
+        } catch (error) {
+            if (this.isDefinitivelyStalePathError(error)) {
+                entryNames = [];
+            } else {
+                this.log.warn(
+                    `Unable to inspect the inline-script cache root ${cacheRoot.fsPath}: ${getErrorMessage(error)}`,
+                );
+                return true;
+            }
+        }
+
+        const lockedKeys = new Set<string>();
+        const nextByKey = new Map<string, PythonEnvironment>();
+        let shouldRetry = false;
+        for (const entryName of entryNames.sort()) {
+            if (entryName.endsWith('.lock')) {
+                lockedKeys.add(normalizePath(Uri.joinPath(cacheRoot, entryName.slice(0, -5)).fsPath));
+                shouldRetry = true;
+                continue;
+            }
+
+            if (this.disposed) {
+                return false;
+            }
+
+            const envDir = Uri.joinPath(cacheRoot, entryName);
+            const key = normalizePath(envDir.fsPath);
+            const discovered = await this.inspectDiscoveredCacheEntry(cacheRoot, envDir);
+            if (discovered.kind === 'resolved') {
+                nextByKey.set(key, discovered.environment);
+            } else if (discovered.kind === 'preserve') {
+                shouldRetry = true;
+                const previous = previousByKey.get(key);
+                if (previous) {
+                    nextByKey.set(key, previous);
+                }
+            }
+        }
+        for (const [key, previous] of previousByKey) {
+            if (!nextByKey.has(key) && lockedKeys.has(key)) {
+                nextByKey.set(key, previous);
+            }
+        }
+
+        if (this.disposed) {
+            return false;
+        }
+
+        // Preserve previously known entries when a refresh cannot safely classify
+        // them because a build is in progress or the filesystem is transiently unavailable.
+        this.replaceDiscoveredEnvironments(sortEnvironments(Array.from(nextByKey.values())));
+        return shouldRetry;
+    }
+
+    private async inspectDiscoveredCacheEntry(
+        cacheRoot: Uri,
+        envDir: Uri,
+    ): Promise<DiscoveredCacheEntryResult> {
+        try {
+            const stat = await fs.lstat(envDir.fsPath);
+            if (!stat.isDirectory() || stat.isSymbolicLink()) {
+                return { kind: 'skip' };
+            }
+        } catch (error) {
+            return this.isDefinitivelyStalePathError(error) ? { kind: 'skip' } : { kind: 'preserve' };
+        }
+
+        if (await this.isCacheEntryBusy(envDir.fsPath)) {
+            return { kind: 'preserve' };
+        }
+
+        try {
+            if (!(await resolveCacheEntryPath(cacheRoot, envDir))) {
+                return { kind: 'skip' };
+            }
+        } catch (error) {
+            return this.isDefinitivelyStalePathError(error) ? { kind: 'skip' } : { kind: 'preserve' };
+        }
+
+        const sidecarResult = await inspectMetaJson(envDir);
+        if (sidecarResult.kind !== 'valid') {
+            return { kind: sidecarResult.kind === 'unavailable' ? 'preserve' : 'skip' };
+        }
+
+        const baseInterpreterStatus = await getBaseInterpreterStatus(envDir);
+        if (baseInterpreterStatus !== 'available') {
+            return { kind: baseInterpreterStatus === 'unavailable' ? 'preserve' : 'skip' };
+        }
+
+        let environment: PythonEnvironment | undefined;
+        try {
+            environment = await resolveVenvPythonEnvironmentPath(
+                getVenvPythonPath(envDir.fsPath),
+                this.nativeFinder,
+                this.api,
+                this,
+                this.baseManager,
+            );
+        } catch (error) {
+            this.log.warn(
+                `Unable to resolve inline-script cache entry ${envDir.fsPath}: ${getErrorMessage(error)}`,
+            );
+            return { kind: 'preserve' };
+        }
+        if (!environment) {
+            return { kind: 'preserve' };
+        }
+
+        const ownership = await inspectOwnedCacheEntry(environment, cacheRoot, envDir);
+        if (ownership !== 'expected') {
+            return { kind: ownership === 'uncertain' ? 'preserve' : 'skip' };
+        }
+        if (!this.areEqualPythonReleases(environment.version, sidecarResult.metadata.baseInterpreterVersion)) {
+            return { kind: 'skip' };
+        }
+
+        return { kind: 'resolved', environment };
+    }
+
+    private replaceDiscoveredEnvironments(next: PythonEnvironment[]): void {
+        const previousByKey = new Map(
+            this.collection.map((environment) => [this.getDiscoveredEnvironmentKey(environment), environment]),
+        );
+        const nextByKey = new Map(next.map((environment) => [this.getDiscoveredEnvironmentKey(environment), environment]));
+        const changes: DidChangeEnvironmentsEventArgs = [];
+
+        for (const [key, previous] of previousByKey) {
+            const current = nextByKey.get(key);
+            if (!current || !this.isSameDiscoveredEnvironment(previous, current)) {
+                changes.push({ kind: EnvironmentChangeKind.remove, environment: previous });
+            }
+        }
+        for (const [key, current] of nextByKey) {
+            const previous = previousByKey.get(key);
+            if (!previous || !this.isSameDiscoveredEnvironment(previous, current)) {
+                changes.push({ kind: EnvironmentChangeKind.add, environment: current });
+            }
+        }
+
+        this.collection = next;
+        if (changes.length > 0) {
+            this._onDidChangeEnvironments.fire(changes);
+        }
+    }
+
+    private getDiscoveredEnvironmentKey(environment: PythonEnvironment): string {
+        return normalizePath(environment.sysPrefix);
+    }
+
+    private isSameDiscoveredEnvironment(first: PythonEnvironment, second: PythonEnvironment): boolean {
+        return (
+            first.envId.managerId === second.envId.managerId &&
+            normalizePath(first.environmentPath.fsPath) === normalizePath(second.environmentPath.fsPath) &&
+            first.version === second.version
+        );
+    }
+
+    private scheduleActivationDiscoveryRetry(): void {
+        if (this.discoveryRetryTimer) {
+            return;
+        }
+
+        const delayMs = this.getDiscoveryRetryDelayMs(this.discoveryRetryAttempt);
+        if (delayMs === undefined) {
+            this.stopActivationDiscovery();
+            return;
+        }
+
+        this.discoveryRetryAttempt += 1;
+        this.discoveryRetryTimer = setTimeout(() => {
+            this.discoveryRetryTimer = undefined;
+            if (this.disposed || !this.activationDiscoveryActive) {
+                return;
+            }
+            this.runActivationDiscoveryPass();
+        }, delayMs);
+    }
+
+    private getDiscoveryRetryDelayMs(attempt: number): number | undefined {
+        return DISCOVERY_RETRY_DELAYS_MS[attempt];
+    }
+
+    private stopActivationDiscovery(): void {
+        if (this.discoveryRetryTimer) {
+            clearTimeout(this.discoveryRetryTimer);
+            this.discoveryRetryTimer = undefined;
+        }
+        this.activationDiscoveryActive = false;
+        this.discoveryRetryAttempt = 0;
     }
 
     private getScriptUri(scope: CreateEnvironmentScope): Uri | undefined {
@@ -1857,6 +2124,8 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
     }
 
     dispose(): void {
+        this.disposed = true;
+        this.stopActivationDiscovery();
         this._onDidChangeEnvironments.dispose();
         this._onDidChangeEnvironment.dispose();
     }
@@ -1880,3 +2149,7 @@ interface PendingScriptUpdate extends ScriptReference {
     readonly needsPersistence: boolean;
     readonly shouldNotify: boolean;
 }
+
+type DiscoveredCacheEntryResult =
+    | { readonly kind: 'preserve' | 'skip' }
+    | { readonly kind: 'resolved'; readonly environment: PythonEnvironment };

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -498,8 +498,17 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         }
 
         if (checkForSnapshotChanges) {
+            let finalEntryNames: string[] | undefined;
             try {
-                const finalEntryNames = await fs.readdir(cacheRoot.fsPath);
+                finalEntryNames = await fs.readdir(cacheRoot.fsPath);
+            } catch (error) {
+                if (this.isDefinitivelyStalePathError(error)) {
+                    finalEntryNames = [];
+                } else {
+                    shouldRetry = true;
+                }
+            }
+            if (finalEntryNames !== undefined) {
                 const initialEntries = new Set(entryNames);
                 if (
                     finalEntryNames.length !== entryNames.length ||
@@ -507,8 +516,6 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                 ) {
                     shouldRetry = true;
                 }
-            } catch {
-                shouldRetry = true;
             }
         }
 

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -401,19 +401,18 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         return followUp;
     }
 
-    private startSnapshotRefreshAfter(sharedPass: DiscoveryRefreshPass): Promise<boolean> {
-        return sharedPass.promise.then(() => {
-            if (this.disposed || !this.activationDiscoveryActive) {
-                return false;
-            }
-            const pending = this.pendingRefresh;
-            if (pending && pending !== sharedPass) {
-                return pending.checksForSnapshotChanges
-                    ? pending.promise
-                    : this.startSnapshotRefreshAfter(pending);
-            }
-            return this.startRefreshPass(true);
-        });
+    private async startSnapshotRefreshAfter(sharedPass: DiscoveryRefreshPass): Promise<boolean> {
+        await sharedPass.promise;
+        if (this.disposed || !this.activationDiscoveryActive) {
+            return false;
+        }
+        const pending = this.pendingRefresh;
+        if (pending && pending !== sharedPass) {
+            return pending.checksForSnapshotChanges
+                ? pending.promise
+                : this.startSnapshotRefreshAfter(pending);
+        }
+        return this.startRefreshPass(true);
     }
 
     private runActivationDiscoveryPass(): void {

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -3,6 +3,7 @@
 
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import type { Stats } from 'fs';
 import { clean as cleanPep440, satisfies as satisfiesPep440 } from '@renovatebot/pep440';
 import { Disposable, Event, EventEmitter, l10n, LogOutputChannel, MarkdownString, ThemeIcon, Uri } from 'vscode';
 import {
@@ -462,6 +463,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
 
         const lockedKeys = new Set<string>();
         const nextByKey = new Map<string, PythonEnvironment>();
+        const initialFingerprints = new Map<string, string | undefined>();
         let shouldRetry = false;
         for (const entryName of entryNames.sort()) {
             if (entryName.endsWith('.lock')) {
@@ -477,6 +479,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             const envDir = Uri.joinPath(cacheRoot, entryName);
             const key = this.getDiscoveryEntryKey(entryName);
             const discovered = await this.inspectDiscoveredCacheEntry(cacheRoot, envDir);
+            initialFingerprints.set(key, discovered.fingerprint);
             if (discovered.kind === 'resolved') {
                 nextByKey.set(key, discovered.environment);
             } else if (discovered.kind === 'preserve') {
@@ -499,22 +502,55 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
 
         if (checkForSnapshotChanges) {
             let finalEntryNames: string[] | undefined;
+            let finalCacheRootMissing = false;
             try {
                 finalEntryNames = await fs.readdir(cacheRoot.fsPath);
             } catch (error) {
                 if (this.isDefinitivelyStalePathError(error)) {
                     finalEntryNames = [];
+                    finalCacheRootMissing = true;
                 } else {
-                    shouldRetry = true;
+                    this.log.warn(
+                        `Unable to verify the final inline-script cache snapshot ${cacheRoot.fsPath}: ${getErrorMessage(error)}`,
+                    );
+                    return true;
                 }
             }
-            if (finalEntryNames !== undefined) {
+
+            if (finalCacheRootMissing) {
+                shouldRetry ||= entryNames.length > 0;
+                nextByKey.clear();
+            } else if (finalEntryNames !== undefined) {
                 const initialEntries = new Set(entryNames);
-                if (
+                const snapshotChanged =
                     finalEntryNames.length !== entryNames.length ||
-                    finalEntryNames.some((entryName) => !initialEntries.has(entryName))
-                ) {
-                    shouldRetry = true;
+                    finalEntryNames.some((entryName) => !initialEntries.has(entryName));
+                if (snapshotChanged) {
+                    return true;
+                }
+
+                for (const entryName of finalEntryNames) {
+                    if (entryName.endsWith(FILE_LOCK_DIR_SUFFIX)) {
+                        continue;
+                    }
+                    const key = this.getDiscoveryEntryKey(entryName);
+                    let finalFingerprint: string;
+                    try {
+                        finalFingerprint = this.getCacheEntryFingerprint(
+                            await fs.lstat(Uri.joinPath(cacheRoot, entryName).fsPath),
+                        );
+                    } catch (error) {
+                        if (this.isDefinitivelyStalePathError(error)) {
+                            return true;
+                        }
+                        this.log.warn(
+                            `Unable to verify inline-script cache entry ${entryName}: ${getErrorMessage(error)}`,
+                        );
+                        return true;
+                    }
+                    if (initialFingerprints.get(key) !== finalFingerprint) {
+                        return true;
+                    }
                 }
             }
         }
@@ -533,35 +569,47 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         cacheRoot: Uri,
         envDir: Uri,
     ): Promise<DiscoveredCacheEntryResult> {
+        let fingerprint: string | undefined;
         try {
             const stat = await fs.lstat(envDir.fsPath);
+            fingerprint = this.getCacheEntryFingerprint(stat);
             if (!stat.isDirectory() || stat.isSymbolicLink()) {
-                return { kind: 'skip' };
+                return { kind: 'skip', fingerprint };
             }
         } catch (error) {
-            return this.isDefinitivelyStalePathError(error) ? { kind: 'skip' } : { kind: 'preserve' };
+            return this.isDefinitivelyStalePathError(error)
+                ? { kind: 'skip' }
+                : { kind: 'preserve' };
         }
 
         if (await this.isCacheEntryBusy(envDir.fsPath)) {
-            return { kind: 'preserve' };
+            return { kind: 'preserve', fingerprint };
         }
 
         try {
             if (!(await resolveCacheEntryPath(cacheRoot, envDir))) {
-                return { kind: 'skip' };
+                return { kind: 'skip', fingerprint };
             }
         } catch (error) {
-            return this.isDefinitivelyStalePathError(error) ? { kind: 'skip' } : { kind: 'preserve' };
+            return this.isDefinitivelyStalePathError(error)
+                ? { kind: 'skip', fingerprint }
+                : { kind: 'preserve', fingerprint };
         }
 
         const sidecarResult = await inspectMetaJson(envDir);
         if (sidecarResult.kind !== 'valid') {
-            return { kind: sidecarResult.kind === 'unavailable' ? 'preserve' : 'skip' };
+            return {
+                kind: sidecarResult.kind === 'unavailable' ? 'preserve' : 'skip',
+                fingerprint,
+            };
         }
 
         const baseInterpreterStatus = await getBaseInterpreterStatus(envDir);
         if (baseInterpreterStatus !== 'available') {
-            return { kind: baseInterpreterStatus === 'unavailable' ? 'preserve' : 'skip' };
+            return {
+                kind: baseInterpreterStatus === 'unavailable' ? 'preserve' : 'skip',
+                fingerprint,
+            };
         }
 
         let environment: PythonEnvironment | undefined;
@@ -577,21 +625,24 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             this.log.warn(
                 `Unable to resolve inline-script cache entry ${envDir.fsPath}: ${getErrorMessage(error)}`,
             );
-            return { kind: 'preserve' };
+            return { kind: 'preserve', fingerprint };
         }
         if (!environment) {
-            return { kind: 'preserve' };
+            return { kind: 'preserve', fingerprint };
         }
 
         const ownership = await inspectOwnedCacheEntry(environment, cacheRoot, envDir);
         if (ownership !== 'expected') {
-            return { kind: ownership === 'uncertain' ? 'preserve' : 'skip' };
+            return {
+                kind: ownership === 'uncertain' ? 'preserve' : 'skip',
+                fingerprint,
+            };
         }
         if (!this.areEqualPythonReleases(environment.version, sidecarResult.metadata.baseInterpreterVersion)) {
-            return { kind: 'skip' };
+            return { kind: 'skip', fingerprint };
         }
 
-        return { kind: 'resolved', environment };
+        return { kind: 'resolved', environment, fingerprint };
     }
 
     private replaceDiscoveredEnvironments(next: PythonEnvironment[]): void {
@@ -622,6 +673,10 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
 
     private getDiscoveryEntryKey(entryName: string): string {
         return normalizePath(entryName);
+    }
+
+    private getCacheEntryFingerprint(stat: Stats): string {
+        return [stat.dev, stat.ino, stat.birthtimeMs, stat.ctimeMs, stat.mtimeMs].join(':');
     }
 
     private getDiscoveredEnvironmentKey(environment: PythonEnvironment): string {
@@ -2244,5 +2299,9 @@ interface PendingScriptUpdate extends ScriptReference {
 }
 
 type DiscoveredCacheEntryResult =
-    | { readonly kind: 'preserve' | 'skip' }
-    | { readonly kind: 'resolved'; readonly environment: PythonEnvironment };
+    | { readonly kind: 'preserve' | 'skip'; readonly fingerprint?: string }
+    | {
+          readonly kind: 'resolved';
+          readonly environment: PythonEnvironment;
+          readonly fingerprint: string;
+      };

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -80,7 +80,7 @@ const BASE_INTERPRETER_MANAGER_IDS = new Set([
 const CACHE_LOCK_TIMEOUT_MS = 5 * 60 * 1000;
 const CACHE_LOCK_RETRY_MS = 500;
 const CACHED_ASSOCIATION_VALIDATION_INTERVAL_MS = 5_000;
-const DISCOVERY_RETRY_DELAYS_MS = [1_000, 5_000] as const;
+const DISCOVERY_RETRY_DELAYS_MS = [1_000, 5_000, 30_000] as const;
 /** Workspace-state key for PEP 723 script path to environment executable associations. */
 export const INLINE_SCRIPT_ENVS_KEY = `${ENVS_EXTENSION_ID}:inline-script:SCRIPT_ENVIRONMENTS`;
 
@@ -117,6 +117,11 @@ type InstallPythonAndRefreshResult =
     | { readonly kind: 'declined' }
     | { readonly kind: 'failed' };
 
+interface DiscoveryRefreshPass {
+    readonly promise: Promise<boolean>;
+    readonly checksForSnapshotChanges: boolean;
+}
+
 type CacheEntryInspection =
     | { readonly kind: 'absent' | 'stale' | 'uncertain' }
     | { readonly kind: 'reusable'; readonly environment: PythonEnvironment };
@@ -133,7 +138,8 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
     private readonly fsPathToPersistedEnvPath = new Map<string, string>();
     private readonly cachedAssociationValidatedAt = new Map<string, number>();
     private readonly associationRevisions = new Map<string, number>();
-    private pendingRefresh: Promise<boolean> | undefined;
+    private pendingRefresh: DiscoveryRefreshPass | undefined;
+    private pendingSnapshotRefresh: Promise<boolean> | undefined;
     private activationDiscoveryActive = false;
     private discoveryRetryAttempt = 0;
     private discoveryRetryTimer: ReturnType<typeof setTimeout> | undefined;
@@ -302,7 +308,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             return;
         }
         this.stopActivationDiscovery();
-        await this.getOrStartRefreshPass();
+        await this.getOrStartRefreshPass(false);
     }
 
     async getEnvironments(scope: GetEnvironmentsScope): Promise<PythonEnvironment[]> {
@@ -340,21 +346,74 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         this.runActivationDiscoveryPass();
     }
 
-    private async getOrStartRefreshPass(): Promise<boolean> {
+    private getOrStartRefreshPass(checkForSnapshotChanges: boolean): Promise<boolean> {
         const pending = this.pendingRefresh;
+        if (pending) {
+            return checkForSnapshotChanges && !pending.checksForSnapshotChanges
+                ? this.getOrScheduleSnapshotRefresh(pending)
+                : pending.promise;
+        }
+
+        return this.startRefreshPass(checkForSnapshotChanges);
+    }
+
+    private startRefreshPass(checkForSnapshotChanges: boolean): Promise<boolean> {
+        const pass: DiscoveryRefreshPass = {
+            promise: this.refreshDiscoveredEnvironments(checkForSnapshotChanges),
+            checksForSnapshotChanges: checkForSnapshotChanges,
+        };
+        this.pendingRefresh = pass;
+        void pass.promise.then(
+            () => {
+                if (this.pendingRefresh === pass) {
+                    this.pendingRefresh = undefined;
+                }
+            },
+            () => {
+                if (this.pendingRefresh === pass) {
+                    this.pendingRefresh = undefined;
+                }
+            },
+        );
+        return pass.promise;
+    }
+
+    private getOrScheduleSnapshotRefresh(sharedPass: DiscoveryRefreshPass): Promise<boolean> {
+        const pending = this.pendingSnapshotRefresh;
         if (pending) {
             return pending;
         }
 
-        const refresh = this.refreshDiscoveredEnvironments();
-        this.pendingRefresh = refresh;
-        try {
-            return await refresh;
-        } finally {
-            if (this.pendingRefresh === refresh) {
-                this.pendingRefresh = undefined;
+        const followUp = this.startSnapshotRefreshAfter(sharedPass);
+        this.pendingSnapshotRefresh = followUp;
+        void followUp.then(
+            () => {
+                if (this.pendingSnapshotRefresh === followUp) {
+                    this.pendingSnapshotRefresh = undefined;
+                }
+            },
+            () => {
+                if (this.pendingSnapshotRefresh === followUp) {
+                    this.pendingSnapshotRefresh = undefined;
+                }
+            },
+        );
+        return followUp;
+    }
+
+    private startSnapshotRefreshAfter(sharedPass: DiscoveryRefreshPass): Promise<boolean> {
+        return sharedPass.promise.then(() => {
+            if (this.disposed || !this.activationDiscoveryActive) {
+                return false;
             }
-        }
+            const pending = this.pendingRefresh;
+            if (pending && pending !== sharedPass) {
+                return pending.checksForSnapshotChanges
+                    ? pending.promise
+                    : this.startSnapshotRefreshAfter(pending);
+            }
+            return this.startRefreshPass(true);
+        });
     }
 
     private runActivationDiscoveryPass(): void {
@@ -362,7 +421,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             return;
         }
 
-        void this.getOrStartRefreshPass()
+        void this.getOrStartRefreshPass(true)
             .then((shouldRetry) => {
                 if (this.disposed || !this.activationDiscoveryActive) {
                     return;
@@ -382,7 +441,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             });
     }
 
-    private async refreshDiscoveredEnvironments(): Promise<boolean> {
+    private async refreshDiscoveredEnvironments(checkForSnapshotChanges: boolean): Promise<boolean> {
         const cacheRoot = getScriptEnvCacheRoot(this.globalStorageUri);
         const previousByKey = new Map(
             this.collection.map((environment) => [this.getDiscoveredEnvironmentKey(environment), environment]),
@@ -407,7 +466,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         let shouldRetry = false;
         for (const entryName of entryNames.sort()) {
             if (entryName.endsWith('.lock')) {
-                lockedKeys.add(normalizePath(Uri.joinPath(cacheRoot, entryName.slice(0, -5)).fsPath));
+                lockedKeys.add(this.getDiscoveryEntryKey(entryName.slice(0, -5)));
                 shouldRetry = true;
                 continue;
             }
@@ -417,7 +476,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             }
 
             const envDir = Uri.joinPath(cacheRoot, entryName);
-            const key = normalizePath(envDir.fsPath);
+            const key = this.getDiscoveryEntryKey(entryName);
             const discovered = await this.inspectDiscoveredCacheEntry(cacheRoot, envDir);
             if (discovered.kind === 'resolved') {
                 nextByKey.set(key, discovered.environment);
@@ -432,6 +491,25 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         for (const [key, previous] of previousByKey) {
             if (!nextByKey.has(key) && lockedKeys.has(key)) {
                 nextByKey.set(key, previous);
+            }
+        }
+
+        if (this.disposed) {
+            return false;
+        }
+
+        if (checkForSnapshotChanges) {
+            try {
+                const finalEntryNames = await fs.readdir(cacheRoot.fsPath);
+                const initialEntries = new Set(entryNames);
+                if (
+                    finalEntryNames.length !== entryNames.length ||
+                    finalEntryNames.some((entryName) => !initialEntries.has(entryName))
+                ) {
+                    shouldRetry = true;
+                }
+            } catch {
+                shouldRetry = true;
             }
         }
 
@@ -536,8 +614,12 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         }
     }
 
+    private getDiscoveryEntryKey(entryName: string): string {
+        return normalizePath(entryName);
+    }
+
     private getDiscoveredEnvironmentKey(environment: PythonEnvironment): string {
-        return normalizePath(environment.sysPrefix);
+        return this.getDiscoveryEntryKey(path.basename(environment.sysPrefix));
     }
 
     private isSameDiscoveredEnvironment(first: PythonEnvironment, second: PythonEnvironment): boolean {
@@ -1132,10 +1214,15 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
     }
 
     private async isCacheEntryBusy(envDirPath: string): Promise<boolean> {
-        return (
-            this.pendingCreations.has(path.basename(envDirPath)) ||
-            (await fs.pathExists(getFileLockPath(envDirPath)))
-        );
+        if (this.pendingCreations.has(path.basename(envDirPath))) {
+            return true;
+        }
+        try {
+            await fs.lstat(getFileLockPath(envDirPath));
+            return true;
+        } catch (error) {
+            return !isFileNotFoundError(error);
+        }
     }
 
     private bumpAssociationRevision(scriptPath: string): void {

--- a/src/managers/builtin/inlineScript/main.ts
+++ b/src/managers/builtin/inlineScript/main.ts
@@ -29,5 +29,6 @@ export async function registerInlineScriptFeatures(
     const api: PythonEnvironmentApi = await getPythonApi();
     const mgr = new InlineScriptEnvManager(nativeFinder, api, baseManager, globalStorageUri, log);
     disposables.push(mgr, api.registerEnvironmentManager(mgr));
+    setImmediate(() => mgr.startActivationDiscovery());
     traceInfo('Inline-script env manager: registered (internal flag is on)');
 }

--- a/src/test/common/inlineScript/cacheLayout.unit.test.ts
+++ b/src/test/common/inlineScript/cacheLayout.unit.test.ts
@@ -640,18 +640,60 @@ suite('inlineScriptCacheLayout', () => {
                 await fs.writeFile(path.join(envDir.fsPath, 'pyvenv.cfg'), content, 'utf8');
             }
 
+            async function writeLauncher(): Promise<string> {
+                const launcherPath = getVenvPythonPath(envDir.fsPath);
+                await fs.ensureDir(path.dirname(launcherPath));
+                await fs.writeFile(launcherPath, '');
+                return launcherPath;
+            }
+
             test('returns true when pyvenv.cfg.home points to an existing python.exe', async () => {
                 const homeDir = path.join(tmpDir, 'Python313');
                 await fs.ensureDir(homeDir);
                 await fs.writeFile(path.join(homeDir, 'python.exe'), '');
+                await writeLauncher();
                 await writePyvenvCfg(`home = ${homeDir}\ninclude-system-site-packages = false\nversion = 3.13.0\n`);
                 assert.strictEqual(await verifyBaseInterpreterExists(envDir), true);
                 assert.strictEqual(traceWarnStub.called, false, 'no warn on success');
             });
 
+            test('returns false when the cached launcher is missing even if the base python still exists', async () => {
+                const homeDir = path.join(tmpDir, 'Python313');
+                await fs.ensureDir(homeDir);
+                await fs.writeFile(path.join(homeDir, 'python.exe'), '');
+                await writePyvenvCfg(`home = ${homeDir}\n`);
+                assert.strictEqual(await getBaseInterpreterStatus(envDir), 'missing');
+                assert.strictEqual(await verifyBaseInterpreterExists(envDir), false);
+                assert.ok(
+                    traceWarnStub.getCalls().some((c) => String(c.args[0]).includes('cached interpreter launcher')),
+                    'expected a missing-launcher warn',
+                );
+            });
+
+            test('returns false when the cached launcher path is not a regular file', async () => {
+                const homeDir = path.join(tmpDir, 'Python313');
+                await fs.ensureDir(homeDir);
+                await fs.writeFile(path.join(homeDir, 'python.exe'), '');
+                const launcherPath = getVenvPythonPath(envDir.fsPath);
+                await fs.ensureDir(launcherPath);
+                await writePyvenvCfg(`home = ${homeDir}\n`);
+                assert.strictEqual(await getBaseInterpreterStatus(envDir), 'missing');
+                assert.strictEqual(await verifyBaseInterpreterExists(envDir), false);
+                assert.ok(
+                    traceWarnStub.getCalls().some((c) => String(c.args[0]).includes('not a regular file')),
+                    'expected a non-file launcher warn',
+                );
+            });
+
+            test('classifies a transient cached-launcher stat failure as unavailable', async () => {
+                sinon.stub(fsExtra, 'stat').rejects(Object.assign(new Error('I/O error'), { code: 'EIO' }));
+                assert.strictEqual(await getBaseInterpreterStatus(envDir), 'unavailable');
+            });
+
             test('returns false when pyvenv.cfg.home points to a removed python.exe', async () => {
                 const homeDir = path.join(tmpDir, 'Python313');
                 await fs.ensureDir(homeDir);
+                await writeLauncher();
                 await writePyvenvCfg(`home = ${homeDir}\n`);
                 assert.strictEqual(await verifyBaseInterpreterExists(envDir), false);
                 assert.ok(
@@ -661,6 +703,7 @@ suite('inlineScriptCacheLayout', () => {
             });
 
             test('returns false when pyvenv.cfg is missing entirely', async () => {
+                await writeLauncher();
                 assert.strictEqual(await verifyBaseInterpreterExists(envDir), false);
                 assert.ok(
                     traceWarnStub
@@ -671,6 +714,7 @@ suite('inlineScriptCacheLayout', () => {
             });
 
             test('returns false when pyvenv.cfg has no `home =` line', async () => {
+                await writeLauncher();
                 await writePyvenvCfg('include-system-site-packages = false\nversion = 3.13.0\n');
                 assert.strictEqual(await verifyBaseInterpreterExists(envDir), false);
                 assert.ok(
@@ -679,6 +723,7 @@ suite('inlineScriptCacheLayout', () => {
             });
 
             test('returns false when pyvenv.cfg has an empty home value', async () => {
+                await writeLauncher();
                 await writePyvenvCfg('home =\n');
                 assert.strictEqual(await verifyBaseInterpreterExists(envDir), false);
                 assert.ok(
@@ -690,6 +735,7 @@ suite('inlineScriptCacheLayout', () => {
                 const homeDir = path.join(tmpDir, 'Python313');
                 await fs.ensureDir(homeDir);
                 await fs.writeFile(path.join(homeDir, 'python.exe'), '');
+                await writeLauncher();
                 await writePyvenvCfg(`  home   =   ${homeDir}   \n`);
                 assert.strictEqual(await verifyBaseInterpreterExists(envDir), true);
             });
@@ -698,6 +744,7 @@ suite('inlineScriptCacheLayout', () => {
                 const homeDir = path.join(tmpDir, 'Python313');
                 await fs.ensureDir(homeDir);
                 await fs.writeFile(path.join(homeDir, 'python.exe'), '');
+                await writeLauncher();
                 await writePyvenvCfg(`home = ${homeDir}\r\nversion = 3.13.0\r\n`);
                 assert.strictEqual(await verifyBaseInterpreterExists(envDir), true);
             });

--- a/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
+++ b/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
@@ -1588,6 +1588,23 @@ suite('InlineScriptEnvManager', () => {
             assert.deepStrictEqual(await manager.getEnvironments('all'), [environment]);
         });
 
+        test('does not retry when the final cache-root snapshot is definitively absent and empty', async () => {
+            const readdirStub = sinon.stub(fsExtra, 'readdir');
+            readdirStub.onFirstCall().resolves([]);
+            readdirStub.onSecondCall().rejects(Object.assign(new Error('cache root removed'), { code: 'ENOENT' }));
+            const retryManager = manager as unknown as {
+                getDiscoveryRetryDelayMs(attempt: number): number | undefined;
+            };
+            sinon.stub(retryManager, 'getDiscoveryRetryDelayMs').returns(0);
+
+            manager.startActivationDiscovery();
+            await waitForStubCallCount(readdirStub, 2);
+            await new Promise((resolve) => setTimeout(resolve, 25));
+
+            assert.strictEqual(readdirStub.callCount, 2);
+            assert.deepStrictEqual(await manager.getEnvironments('all'), []);
+        });
+
         test('refresh skips missing, invalid, unavailable, and non-directory cache entries', async () => {
             const valid = await createOwnedEnvironment();
             const cacheRoot = cacheLayout.getScriptEnvCacheRoot(globalStorageUri).fsPath;

--- a/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
+++ b/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
@@ -1605,6 +1605,105 @@ suite('InlineScriptEnvManager', () => {
             assert.deepStrictEqual(await manager.getEnvironments('all'), []);
         });
 
+        test('publishes an empty collection when a populated cache root is absent at the final snapshot', async () => {
+            const environment = await createOwnedEnvironment();
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            setResolvedVenvs([environment]);
+            await manager.refresh(undefined);
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironments(listener);
+            const readdirStub = sinon.stub(fsExtra, 'readdir');
+            readdirStub.onFirstCall().resolves([CACHE_KEY]);
+            readdirStub.onSecondCall().rejects(Object.assign(new Error('cache root removed'), { code: 'ENOENT' }));
+            const retryManager = manager as unknown as {
+                getDiscoveryRetryDelayMs(attempt: number): number | undefined;
+            };
+            sinon.stub(retryManager, 'getDiscoveryRetryDelayMs').returns(undefined);
+
+            manager.startActivationDiscovery();
+            await waitForStubCallCount(readdirStub, 2);
+            await waitForCondition(
+                async () => (await manager.getEnvironments('all')).length === 0,
+                'Expected final cache-root absence to remove the staged environment immediately',
+            );
+
+            assert.deepStrictEqual(listener.getCalls().map((call) => call.args[0]), [
+                [{ kind: EnvironmentChangeKind.remove, environment }],
+            ]);
+        });
+
+        test('preserves the prior collection when the final cache-root snapshot is unavailable', async () => {
+            const environment = await createOwnedEnvironment();
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            setResolvedVenvs([environment]);
+            await manager.refresh(undefined);
+            inspectMetaStub.resolves({ kind: 'invalid' });
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironments(listener);
+            const readdirStub = sinon.stub(fsExtra, 'readdir');
+            readdirStub.onFirstCall().resolves([CACHE_KEY]);
+            readdirStub.onSecondCall().rejects(Object.assign(new Error('I/O error'), { code: 'EIO' }));
+            const retryManager = manager as unknown as {
+                getDiscoveryRetryDelayMs(attempt: number): number | undefined;
+            };
+            sinon.stub(retryManager, 'getDiscoveryRetryDelayMs').returns(undefined);
+
+            manager.startActivationDiscovery();
+            await waitForStubCallCount(readdirStub, 2);
+            await new Promise((resolve) => setTimeout(resolve, 25));
+
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [environment]);
+            assert.strictEqual(listener.callCount, 0);
+        });
+
+        test('retries when a cache entry is rebuilt under the same key during inspection', async () => {
+            await createOwnedEnvironment(CACHE_KEY, 'old-generation');
+            const sidecar = await makeSidecar();
+            let releaseInspection: (() => void) | undefined;
+            let signalInspection: (() => void) | undefined;
+            const inspectionStarted = new Promise<void>((resolve) => {
+                signalInspection = resolve;
+            });
+            const inspectionGate = new Promise<void>((resolve) => {
+                releaseInspection = resolve;
+            });
+            inspectMetaStub.resolves({ kind: 'valid', metadata: sidecar });
+            inspectMetaStub.onFirstCall().callsFake(async () => {
+                signalInspection!();
+                await inspectionGate;
+                return { kind: 'invalid' };
+            });
+            let replacement: PythonEnvironment | undefined;
+            resolveVenvStub.callsFake(async () => replacement);
+            const retryManager = manager as unknown as {
+                getDiscoveryRetryDelayMs(attempt: number): number | undefined;
+            };
+            sinon.stub(retryManager, 'getDiscoveryRetryDelayMs').callsFake((attempt) =>
+                attempt === 0 ? 0 : undefined,
+            );
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironments(listener);
+
+            manager.startActivationDiscovery();
+            await inspectionStarted;
+            await fs.move(envDir().fsPath, path.join(tempRoot, 'old-generation'));
+            replacement = await createOwnedEnvironment(CACHE_KEY, 'new-generation');
+            releaseInspection!();
+
+            await waitForStubCall(resolveVenvStub);
+            await waitForCondition(
+                async () => (await manager.getEnvironments('all')).length === 1,
+                'Expected a follow-up scan to publish the rebuilt cache generation',
+            );
+
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [replacement]);
+            assert.deepStrictEqual(listener.getCalls().map((call) => call.args[0]), [
+                [{ kind: EnvironmentChangeKind.add, environment: replacement }],
+            ]);
+        });
+
         test('refresh skips missing, invalid, unavailable, and non-directory cache entries', async () => {
             const valid = await createOwnedEnvironment();
             const cacheRoot = cacheLayout.getScriptEnvCacheRoot(globalStorageUri).fsPath;

--- a/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
+++ b/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
@@ -7,7 +7,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { LogOutputChannel, Uri } from 'vscode';
-import { EnvironmentManager, PythonEnvironment, PythonEnvironmentApi } from '../../../../api';
+import { EnvironmentChangeKind, EnvironmentManager, PythonEnvironment, PythonEnvironmentApi } from '../../../../api';
 import * as cacheKey from '../../../../common/inlineScript/cacheKey';
 import * as cacheLayout from '../../../../common/inlineScript/cacheLayout';
 import * as metadataReader from '../../../../common/inlineScript/metadata';
@@ -211,6 +211,27 @@ suite('InlineScriptEnvManager', () => {
         inspectMetaStub.resolves({ kind: 'valid', metadata });
     }
 
+    async function makeSidecar(
+        overrides: Partial<cacheLayout.InlineScriptEnvMeta> = {},
+    ): Promise<cacheLayout.InlineScriptEnvMeta> {
+        return {
+            schemaVersion: cacheLayout.META_SCHEMA_VERSION,
+            baseInterpreterPath: await fs.realpath(baseExecutable),
+            baseInterpreterVersion: baseEnvironment.version,
+            lastUsedAt: NOW.toISOString(),
+            ...overrides,
+        };
+    }
+
+    function setSidecarResults(results: Record<string, cacheLayout.InlineScriptMetaReadResult>): void {
+        inspectMetaStub.callsFake(async (candidate: Uri) => results[path.basename(candidate.fsPath)] ?? { kind: 'missing' });
+    }
+
+    function setResolvedVenvs(environments: readonly PythonEnvironment[]): void {
+        const byPath = new Map(environments.map((environment) => [normalizePath(environment.environmentPath.fsPath), environment]));
+        resolveVenvStub.callsFake(async (candidatePath: string) => byPath.get(normalizePath(candidatePath)));
+    }
+
     async function createOwnedEnvironment(
         cacheKey: string = CACHE_KEY,
         envId: string = `inline-${cacheKey}`,
@@ -232,6 +253,29 @@ suite('InlineScriptEnvManager', () => {
             await new Promise((resolve) => setTimeout(resolve, 5));
         }
         assert.fail('Expected the stub to be called');
+    }
+
+    async function waitForStubCallCount(stub: sinon.SinonStub, expectedCallCount: number): Promise<void> {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+            if (stub.callCount >= expectedCallCount) {
+                return;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+        assert.fail(`Expected the stub to be called ${expectedCallCount} times`);
+    }
+
+    async function waitForCondition(
+        predicate: () => boolean | Promise<boolean>,
+        message: string,
+    ): Promise<void> {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+            if (await predicate()) {
+                return;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+        assert.fail(message);
     }
 
     function nextTurn(): Promise<void> {
@@ -1472,6 +1516,278 @@ suite('InlineScriptEnvManager', () => {
             assert.strictEqual(await manager.create(scriptUri()), undefined);
             assert.strictEqual(await fs.pathExists(envDir().fsPath), false);
             assert.strictEqual(writeMetaStub.callCount, 0);
+        });
+    });
+
+    suite('activation-time discovery', () => {
+        test('cold-start transient resolution retries and later discovers the environment', async () => {
+            const environment = await createOwnedEnvironment();
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            resolveVenvStub.onFirstCall().resolves(undefined);
+            resolveVenvStub.onSecondCall().resolves(environment);
+            const retryManager = manager as unknown as {
+                getDiscoveryRetryDelayMs(attempt: number): number | undefined;
+            };
+            sinon.stub(retryManager, 'getDiscoveryRetryDelayMs').callsFake((attempt) => (attempt === 0 ? 0 : undefined));
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironments(listener);
+
+            manager.startActivationDiscovery();
+
+            await waitForStubCallCount(resolveVenvStub, 2);
+            await waitForCondition(
+                async () => (await manager.getEnvironments('all')).length === 1,
+                'Expected the follow-up discovery retry to publish the environment',
+            );
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [environment]);
+            assert.deepStrictEqual(listener.firstCall.args[0], [
+                { kind: EnvironmentChangeKind.add, environment },
+            ]);
+        });
+
+        test('refresh discovers valid cached environments and exposes them only through all-scope', async () => {
+            const first = await createOwnedEnvironment();
+            const secondKey = 'fedcba9876543210';
+            const second = await createOwnedEnvironment(secondKey);
+            const sidecar = await makeSidecar();
+            setSidecarResults({
+                [CACHE_KEY]: { kind: 'valid', metadata: sidecar },
+                [secondKey]: { kind: 'valid', metadata: sidecar },
+            });
+            setResolvedVenvs([first, second]);
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironments(listener);
+
+            await manager.refresh(undefined);
+
+            const discovered = await manager.getEnvironments('all');
+            assert.deepStrictEqual(
+                discovered.map((environment) => normalizePath(environment.sysPrefix)).sort(),
+                [first, second].map((environment) => normalizePath(environment.sysPrefix)).sort(),
+            );
+            assert.deepStrictEqual(await manager.getEnvironments('global'), []);
+            assert.strictEqual(listener.callCount, 1);
+            assert.deepStrictEqual(
+                listener.firstCall.args[0].map((change: { kind: EnvironmentChangeKind }) => change.kind),
+                [EnvironmentChangeKind.add, EnvironmentChangeKind.add],
+            );
+        });
+
+        test('refresh skips missing, invalid, unavailable, and non-directory cache entries', async () => {
+            const valid = await createOwnedEnvironment();
+            const cacheRoot = cacheLayout.getScriptEnvCacheRoot(globalStorageUri).fsPath;
+            const invalidKey = 'invalid-sidecar';
+            const unavailableKey = 'unavailable-sidecar';
+            await fs.ensureDir(path.join(cacheRoot, 'missing-sidecar'));
+            await fs.ensureDir(path.join(cacheRoot, invalidKey));
+            await fs.ensureDir(path.join(cacheRoot, unavailableKey));
+            await fs.outputFile(path.join(cacheRoot, 'not-a-directory'), '');
+            const sidecar = await makeSidecar();
+            setSidecarResults({
+                [CACHE_KEY]: { kind: 'valid', metadata: sidecar },
+                [invalidKey]: { kind: 'invalid' },
+                [unavailableKey]: { kind: 'unavailable' },
+            });
+            setResolvedVenvs([valid]);
+
+            await manager.refresh(undefined);
+
+            const discovered = await manager.getEnvironments('all');
+            assert.deepStrictEqual(discovered, [valid]);
+            assert.strictEqual(resolveVenvStub.callCount, 1);
+        });
+
+        test('refresh preserves a previously discovered environment while its cache entry is locked', async () => {
+            const environment = await createOwnedEnvironment();
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            setResolvedVenvs([environment]);
+            await manager.refresh(undefined);
+            resolveVenvStub.resetHistory();
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironments(listener);
+            await fs.remove(environment.sysPrefix);
+            await fs.ensureDir(`${path.resolve(environment.sysPrefix)}.lock`);
+
+            await manager.refresh(undefined);
+
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [environment]);
+            assert.strictEqual(resolveVenvStub.callCount, 0);
+            assert.strictEqual(listener.callCount, 0);
+        });
+
+        test('refresh removes a previously discovered environment when launcher inspection marks it missing', async () => {
+            const environment = await createOwnedEnvironment();
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            setResolvedVenvs([environment]);
+            await manager.refresh(undefined);
+            resolveVenvStub.resetHistory();
+            baseInterpreterStatusStub.resolves('missing');
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironments(listener);
+
+            await manager.refresh(undefined);
+
+            assert.deepStrictEqual(await manager.getEnvironments('all'), []);
+            assert.strictEqual(resolveVenvStub.callCount, 0);
+            assert.deepStrictEqual(listener.firstCall.args[0], [
+                { kind: EnvironmentChangeKind.remove, environment },
+            ]);
+        });
+
+        test('coalesces concurrent refresh requests for the same scan', async () => {
+            const environment = await createOwnedEnvironment();
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            let resolveDiscovery: ((value: PythonEnvironment | undefined) => void) | undefined;
+            resolveVenvStub.callsFake(
+                () =>
+                    new Promise<PythonEnvironment | undefined>((resolve) => {
+                        resolveDiscovery = resolve;
+                    }),
+            );
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironments(listener);
+
+            const firstRefresh = manager.refresh(undefined);
+            const secondRefresh = manager.refresh(undefined);
+            await waitForStubCall(resolveVenvStub);
+            assert.strictEqual(resolveVenvStub.callCount, 1);
+            resolveDiscovery!(environment);
+            await Promise.all([firstRefresh, secondRefresh]);
+
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [environment]);
+            assert.strictEqual(listener.callCount, 1);
+        });
+
+        test('explicit refresh does not schedule a delayed follow-up after an uncertain pass', async () => {
+            const sidecar = await makeSidecar();
+            await createOwnedEnvironment();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            resolveVenvStub.resolves(undefined);
+            const retryManager = manager as unknown as {
+                getDiscoveryRetryDelayMs(attempt: number): number | undefined;
+            };
+            sinon.stub(retryManager, 'getDiscoveryRetryDelayMs').returns(0);
+
+            await manager.refresh(undefined);
+            await new Promise((resolve) => setTimeout(resolve, 25));
+
+            assert.strictEqual(resolveVenvStub.callCount, 1);
+            assert.deepStrictEqual(await manager.getEnvironments('all'), []);
+        });
+
+        test('explicit refresh overlapping bootstrap cancels the later activation retry', async () => {
+            const sidecar = await makeSidecar();
+            await createOwnedEnvironment();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            let resolveDiscovery: ((value: PythonEnvironment | undefined) => void) | undefined;
+            resolveVenvStub.onFirstCall().callsFake(
+                () =>
+                    new Promise<PythonEnvironment | undefined>((resolve) => {
+                        resolveDiscovery = resolve;
+                    }),
+            );
+            resolveVenvStub.onSecondCall().resolves(undefined);
+            const retryManager = manager as unknown as {
+                getDiscoveryRetryDelayMs(attempt: number): number | undefined;
+            };
+            sinon.stub(retryManager, 'getDiscoveryRetryDelayMs').returns(0);
+
+            manager.startActivationDiscovery();
+            await waitForStubCall(resolveVenvStub);
+
+            const refresh = manager.refresh(undefined);
+            resolveDiscovery!(undefined);
+            await refresh;
+            await new Promise((resolve) => setTimeout(resolve, 25));
+
+            assert.strictEqual(resolveVenvStub.callCount, 1);
+            assert.deepStrictEqual(await manager.getEnvironments('all'), []);
+        });
+
+        test('stops retrying after the bounded follow-up attempts', async () => {
+            const sidecar = await makeSidecar();
+            await createOwnedEnvironment();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            resolveVenvStub.resolves(undefined);
+            const retryManager = manager as unknown as {
+                getDiscoveryRetryDelayMs(attempt: number): number | undefined;
+            };
+            sinon.stub(retryManager, 'getDiscoveryRetryDelayMs').callsFake((attempt) => (attempt < 2 ? 0 : undefined));
+
+            manager.startActivationDiscovery();
+            await waitForStubCallCount(resolveVenvStub, 3);
+            await new Promise((resolve) => setTimeout(resolve, 25));
+
+            assert.strictEqual(resolveVenvStub.callCount, 3);
+            assert.deepStrictEqual(await manager.getEnvironments('all'), []);
+        });
+
+        test('refresh fires remove events when a discovered cache entry becomes invalid', async () => {
+            const environment = await createOwnedEnvironment();
+            let sidecarResult: cacheLayout.InlineScriptMetaReadResult = {
+                kind: 'valid',
+                metadata: await makeSidecar(),
+            };
+            inspectMetaStub.callsFake(async () => sidecarResult);
+            setResolvedVenvs([environment]);
+            await manager.refresh(undefined);
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironments(listener);
+            sidecarResult = { kind: 'invalid' };
+
+            await manager.refresh(undefined);
+
+            assert.deepStrictEqual(await manager.getEnvironments('all'), []);
+            assert.strictEqual(listener.callCount, 1);
+            assert.deepStrictEqual(listener.firstCall.args[0], [
+                { kind: EnvironmentChangeKind.remove, environment },
+            ]);
+        });
+
+        test('does not publish discovery results after disposal while refresh is in flight', async () => {
+            const environment = await createOwnedEnvironment();
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            let resolveDiscovery: ((value: PythonEnvironment | undefined) => void) | undefined;
+            resolveVenvStub.callsFake(
+                () =>
+                    new Promise<PythonEnvironment | undefined>((resolve) => {
+                        resolveDiscovery = resolve;
+                    }),
+            );
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironments(listener);
+
+            const refresh = manager.refresh(undefined);
+            await waitForStubCall(resolveVenvStub);
+            manager.dispose();
+            resolveDiscovery!(environment);
+            await refresh;
+
+            assert.deepStrictEqual(await manager.getEnvironments('all'), []);
+            assert.strictEqual(listener.callCount, 0);
+        });
+
+        test('dispose cancels a pending discovery retry', async () => {
+            const sidecar = await makeSidecar();
+            await createOwnedEnvironment();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            resolveVenvStub.resolves(undefined);
+            const retryManager = manager as unknown as {
+                getDiscoveryRetryDelayMs(attempt: number): number | undefined;
+            };
+            sinon.stub(retryManager, 'getDiscoveryRetryDelayMs').returns(25);
+
+            manager.startActivationDiscovery();
+            await waitForStubCall(resolveVenvStub);
+            manager.dispose();
+            await new Promise((resolve) => setTimeout(resolve, 40));
+
+            assert.strictEqual(resolveVenvStub.callCount, 1);
         });
     });
 

--- a/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
+++ b/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import assert from 'assert';
+import fsExtra from 'fs-extra';
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
@@ -1574,6 +1575,19 @@ suite('InlineScriptEnvManager', () => {
             );
         });
 
+        test('explicit refresh takes a single cache-root snapshot', async () => {
+            const environment = await createOwnedEnvironment();
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            setResolvedVenvs([environment]);
+            const readdirStub = sinon.stub(fsExtra, 'readdir').resolves([CACHE_KEY]);
+
+            await manager.refresh(undefined);
+
+            assert.strictEqual(readdirStub.callCount, 1);
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [environment]);
+        });
+
         test('refresh skips missing, invalid, unavailable, and non-directory cache entries', async () => {
             const valid = await createOwnedEnvironment();
             const cacheRoot = cacheLayout.getScriptEnvCacheRoot(globalStorageUri).fsPath;
@@ -1609,6 +1623,73 @@ suite('InlineScriptEnvManager', () => {
             manager.onDidChangeEnvironments(listener);
             await fs.remove(environment.sysPrefix);
             await fs.ensureDir(`${path.resolve(environment.sysPrefix)}.lock`);
+
+            await manager.refresh(undefined);
+
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [environment]);
+            assert.strictEqual(resolveVenvStub.callCount, 0);
+            assert.strictEqual(listener.callCount, 0);
+        });
+
+        test('refresh preserves a discovered environment when its lock probe reports EIO', async () => {
+            const environment = await createOwnedEnvironment();
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            setResolvedVenvs([environment]);
+            await manager.refresh(undefined);
+            resolveVenvStub.resetHistory();
+            baseInterpreterStatusStub.resetHistory();
+            baseInterpreterStatusStub.resolves('missing');
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironments(listener);
+            const lockPath = `${path.resolve(environment.sysPrefix)}.lock`;
+            sinon
+                .stub(fsExtra, 'lstat')
+                .callThrough()
+                .withArgs(lockPath)
+                .rejects(Object.assign(new Error('I/O error'), { code: 'EIO' }));
+
+            await manager.refresh(undefined);
+
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [environment]);
+            assert.strictEqual(resolveVenvStub.callCount, 0);
+            assert.strictEqual(baseInterpreterStatusStub.callCount, 0);
+            assert.strictEqual(listener.callCount, 0);
+        });
+
+        test('uses the cache entry name to preserve a canonical sysPrefix through a cache-root link', async function () {
+            const cacheRoot = cacheLayout.getScriptEnvCacheRoot(globalStorageUri).fsPath;
+            const physicalCacheRoot = path.join(tempRoot, 'physical-cache-root');
+            const physicalEnvDir = path.join(physicalCacheRoot, CACHE_KEY);
+            const physicalExecutable = getVenvPythonPath(physicalEnvDir);
+            await fs.ensureDir(path.dirname(cacheRoot));
+            await fs.ensureDir(physicalCacheRoot);
+            try {
+                await fs.symlink(physicalCacheRoot, cacheRoot, isWindows() ? 'junction' : 'dir');
+            } catch (error) {
+                const code = (error as NodeJS.ErrnoException).code;
+                if (code === 'EPERM' || code === 'EACCES') {
+                    this.skip();
+                    return;
+                }
+                throw error;
+            }
+            await fs.outputFile(physicalExecutable, '');
+            const environment = makeEnvironment(
+                'ms-python.python:inline-script',
+                '3.12.4',
+                physicalExecutable,
+                physicalEnvDir,
+            );
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            resolveVenvStub.resolves(environment);
+            await manager.refresh(undefined);
+            resolveVenvStub.resetHistory();
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironments(listener);
+            await fs.remove(physicalEnvDir);
+            await fs.ensureDir(`${physicalEnvDir}.lock`);
 
             await manager.refresh(undefined);
 
@@ -1660,6 +1741,127 @@ suite('InlineScriptEnvManager', () => {
 
             assert.deepStrictEqual(await manager.getEnvironments('all'), [environment]);
             assert.strictEqual(listener.callCount, 1);
+        });
+
+        test('runs a snapshot-aware follow-up when activation joins an explicit refresh', async () => {
+            const first = await createOwnedEnvironment();
+            const secondKey = 'fedcba9876543210';
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            let second: PythonEnvironment | undefined;
+            let releaseFirstResolution: (() => void) | undefined;
+            let signalFirstResolution: (() => void) | undefined;
+            const firstResolution = new Promise<void>((resolve) => {
+                signalFirstResolution = resolve;
+            });
+            const resolutionGate = new Promise<void>((resolve) => {
+                releaseFirstResolution = resolve;
+            });
+            let firstResolutionPending = true;
+            resolveVenvStub.callsFake(async (candidatePath: string) => {
+                if (
+                    firstResolutionPending &&
+                    normalizePath(candidatePath) === normalizePath(first.environmentPath.fsPath)
+                ) {
+                    firstResolutionPending = false;
+                    signalFirstResolution!();
+                    await resolutionGate;
+                }
+                return normalizePath(candidatePath) === normalizePath(first.environmentPath.fsPath) ? first : second;
+            });
+
+            const refresh = manager.refresh(undefined);
+            await firstResolution;
+            manager.startActivationDiscovery();
+            second = await createOwnedEnvironment(secondKey);
+            setSidecarResults({
+                [CACHE_KEY]: { kind: 'valid', metadata: sidecar },
+                [secondKey]: { kind: 'valid', metadata: sidecar },
+            });
+            releaseFirstResolution!();
+            await refresh;
+
+            await waitForStubCallCount(resolveVenvStub, 3);
+            await waitForCondition(
+                async () => (await manager.getEnvironments('all')).length === 2,
+                'Expected activation discovery to scan the entry added after the explicit refresh snapshot',
+            );
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [first, second]);
+        });
+
+        test('retries when a cache entry appears during a discovery scan', async () => {
+            const first = await createOwnedEnvironment();
+            const secondKey = 'fedcba9876543210';
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            let second: PythonEnvironment | undefined;
+            let releaseFirstResolution: (() => void) | undefined;
+            let signalFirstResolution: (() => void) | undefined;
+            const firstResolution = new Promise<void>((resolve) => {
+                signalFirstResolution = resolve;
+            });
+            const resolutionGate = new Promise<void>((resolve) => {
+                releaseFirstResolution = resolve;
+            });
+            let firstResolutionPending = true;
+            resolveVenvStub.callsFake(async (candidatePath: string) => {
+                if (
+                    firstResolutionPending &&
+                    normalizePath(candidatePath) === normalizePath(first.environmentPath.fsPath)
+                ) {
+                    firstResolutionPending = false;
+                    signalFirstResolution!();
+                    await resolutionGate;
+                }
+                return normalizePath(candidatePath) === normalizePath(first.environmentPath.fsPath) ? first : second;
+            });
+            const retryManager = manager as unknown as {
+                getDiscoveryRetryDelayMs(attempt: number): number | undefined;
+            };
+            sinon.stub(retryManager, 'getDiscoveryRetryDelayMs').callsFake((attempt) => (attempt === 0 ? 0 : undefined));
+
+            manager.startActivationDiscovery();
+            await firstResolution;
+            second = await createOwnedEnvironment(secondKey);
+            setSidecarResults({
+                [CACHE_KEY]: { kind: 'valid', metadata: sidecar },
+                [secondKey]: { kind: 'valid', metadata: sidecar },
+            });
+            releaseFirstResolution!();
+
+            await waitForStubCallCount(resolveVenvStub, 3);
+            await waitForCondition(
+                async () => (await manager.getEnvironments('all')).length === 2,
+                'Expected the scan after the changed snapshot to publish both environments',
+            );
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [first, second]);
+        });
+
+        test('discovers a build that completes after the short retry window', async () => {
+            const sidecar = await makeSidecar();
+            setSidecarResults({ [CACHE_KEY]: { kind: 'valid', metadata: sidecar } });
+            const retryManager = manager as unknown as {
+                getDiscoveryRetryDelayMs(attempt: number): number | undefined;
+            };
+            assert.strictEqual(retryManager.getDiscoveryRetryDelayMs(2), 30_000);
+            const retryDelayStub = sinon
+                .stub(retryManager, 'getDiscoveryRetryDelayMs')
+                .callsFake((attempt) => (attempt < 2 ? 0 : attempt === 2 ? 25 : undefined));
+            const lockPath = `${path.resolve(envDir().fsPath)}.lock`;
+            await fs.ensureDir(lockPath);
+
+            manager.startActivationDiscovery();
+            await waitForStubCallCount(retryDelayStub, 3);
+            const environment = await createOwnedEnvironment();
+            resolveVenvStub.resolves(environment);
+            await fs.remove(lockPath);
+
+            await waitForStubCall(resolveVenvStub);
+            await waitForCondition(
+                async () => (await manager.getEnvironments('all')).length === 1,
+                'Expected the extended retry to publish the completed build',
+            );
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [environment]);
         });
 
         test('explicit refresh does not schedule a delayed follow-up after an uncertain pass', async () => {
@@ -2431,6 +2633,28 @@ suite('InlineScriptEnvManager', () => {
             manager.onDidChangeEnvironment(listener);
             await fs.remove(environment.environmentPath.fsPath);
             await fs.ensureDir(`${path.resolve(environment.sysPrefix)}.lock`);
+            clock.tick(5_000);
+
+            assert.strictEqual(await manager.get(uri), undefined);
+            assert.deepStrictEqual(persistedAssociations, {
+                [normalizePath(uri.fsPath)]: environment.environmentPath.fsPath,
+            });
+            assert.strictEqual(listener.callCount, 0);
+        });
+
+        test('preserves a warm association when its lock probe reports EIO', async () => {
+            const uri = scriptUri();
+            const environment = await createOwnedEnvironment();
+            await manager.set(uri, environment);
+            const listener = sinon.spy();
+            manager.onDidChangeEnvironment(listener);
+            await fs.remove(environment.environmentPath.fsPath);
+            const lockPath = `${path.resolve(environment.sysPrefix)}.lock`;
+            sinon
+                .stub(fsExtra, 'lstat')
+                .callThrough()
+                .withArgs(lockPath)
+                .rejects(Object.assign(new Error('I/O error'), { code: 'EIO' }));
             clock.tick(5_000);
 
             assert.strictEqual(await manager.get(uri), undefined);

--- a/src/test/managers/builtin/inlineScript/main.unit.test.ts
+++ b/src/test/managers/builtin/inlineScript/main.unit.test.ts
@@ -7,6 +7,7 @@ import { Disposable, LogOutputChannel, Uri } from 'vscode';
 import { EnvironmentManager, PythonEnvironmentApi } from '../../../../api';
 import * as pythonApi from '../../../../features/pythonApi';
 import * as helpers from '../../../../helpers';
+import { InlineScriptEnvManager } from '../../../../managers/builtin/inlineScript/envManager';
 import { registerInlineScriptFeatures } from '../../../../managers/builtin/inlineScript/main';
 import { NativePythonFinder } from '../../../../managers/common/nativePythonFinder';
 
@@ -27,10 +28,15 @@ function makeFakeLog(): LogOutputChannel {
     } as unknown as LogOutputChannel;
 }
 
+function nextTurn(): Promise<void> {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
 suite('registerInlineScriptFeatures (feature-flag gate)', () => {
     let isEnabledStub: sinon.SinonStub;
     let getPythonApiStub: sinon.SinonStub;
     let registerEnvironmentManagerStub: sinon.SinonStub;
+    let startActivationDiscoveryStub: sinon.SinonStub;
     const nativeFinder = {} as NativePythonFinder;
     const baseManager = {} as EnvironmentManager;
     const globalStorageUri = Uri.file('inline-script-global-storage');
@@ -38,6 +44,7 @@ suite('registerInlineScriptFeatures (feature-flag gate)', () => {
     setup(() => {
         isEnabledStub = sinon.stub(helpers, 'isInlineScriptsFeatureEnabled');
         registerEnvironmentManagerStub = sinon.stub<[unknown], Disposable>().returns({ dispose: () => undefined });
+        startActivationDiscoveryStub = sinon.stub(InlineScriptEnvManager.prototype, 'startActivationDiscovery');
         getPythonApiStub = sinon.stub(pythonApi, 'getPythonApi').resolves({
             registerEnvironmentManager: registerEnvironmentManagerStub,
         } as unknown as PythonEnvironmentApi);
@@ -74,5 +81,25 @@ suite('registerInlineScriptFeatures (feature-flag gate)', () => {
             'registration disposable should be disposed',
         );
         assert.strictEqual(typeof manager.create, 'function');
+        await nextTurn();
+        disposables.forEach((disposable) => disposable.dispose());
+    });
+
+    test('when the feature flag is TRUE: defers activation-time discovery to the next turn', async () => {
+        isEnabledStub.returns(true);
+        const disposables: Disposable[] = [];
+
+        await registerInlineScriptFeatures(nativeFinder, disposables, makeFakeLog(), baseManager, globalStorageUri);
+
+        assert.strictEqual(
+            startActivationDiscoveryStub.callCount,
+            0,
+            'activation should not synchronously start bootstrap discovery',
+        );
+
+        await nextTurn();
+
+        sinon.assert.calledOnceWithExactly(startActivationDiscoveryStub);
+        disposables.forEach((disposable) => disposable.dispose());
     });
 });


### PR DESCRIPTION
> Part of #1602 (PEP 723 inline script env support). Design doc: #1601.
>
> Builds on the merged persistence work in #1697 and is rebased on current `main`.

### Roadmap context

This is **PR 8 of 16** in the PEP 723 inline-script roadmap. It makes extension-owned cached environments discoverable after activation; automatic script routing remains a separate follow-up.

| Phase 2: Manager | PR | Status |
|---|---|---|
| | PR 4: `InlineScriptEnvManager` skeleton | merged (#1610) |
| | PR 5a: generic env-creation utilities | merged (#1651) |
| | PR 5b: inline-script cache + interpreter utilities | merged (#1655) |
| | PR 5c: `create()` happy path | merged (#1656) |
| | PR 6: `create()` uv-install fallback | merged (#1696) |
| | PR 7: persistence (`get` / `set` + Memento) | merged (#1697) |
| | **PR 8: activation-time discovery** | **this PR** |
| | PR 9: route PEP 723 scripts to the inline manager | follow-up |

### Why this PR

PR 7 persists and lazily rehydrates a specific script's selected inline environment when the manager is asked for that script. The manager still has no global inventory, however: `getEnvironments()` returns `[]`, and cached environments are not published after an extension-host restart unless a script-specific lookup happens to reconstruct one.

This PR implements the activation-discovery portion of Q4 in the design:

- walk the versioned global cache without blocking extension activation;
- validate each cache entry before exposing it as a `PythonEnvironment`;
- publish add/remove events as valid entries appear or become definitively invalid;
- preserve previously known entries through locks and transient filesystem failures;
- retry bounded transient work without creating a permanent watcher or polling loop.

### What this PR does

**Defers discovery until after manager registration**

- Starts activation discovery with `setImmediate()` after the manager is registered.
- Leaves the feature-gate-off path unchanged: no manager registration, cache scan, timer, or filesystem work.
- Keeps extension activation non-blocking.

**Publishes a global discovered collection**

- `getEnvironments('all')` returns a copy of the validated cache collection.
- Other scopes remain empty because inline cache entries live in extension global storage rather than belonging to one workspace.
- Results are sorted deterministically.
- Collection reconciliation emits precise `EnvironmentChangeKind.add` and `remove` events only when manager identity, executable path, or Python version materially changes.

**Validates every cache entry before publication**

A candidate must:

1. be a normal directory rather than a symlink;
2. be unlocked and physically contained beneath the expected cache root;
3. have a valid `.meta.json` sidecar;
4. have an available cached launcher and base interpreter;
5. resolve into a real `PythonEnvironment`;
6. prove direct-child cache ownership through `sysPrefix`; and
7. match the Python release recorded in the sidecar.

Discovery is read-only. It does not delete, rebuild, or rewrite invalid entries.

**Distinguishes definitive invalidity from uncertainty**

- Missing, malformed, unowned, or version-mismatched entries are omitted.
- Locked entries and transient I/O/resolver/ownership failures preserve the previously published environment and request another activation pass.
- A missing cache root is treated as an empty cache.
- An unavailable cache root preserves the current collection and remains retryable.

**Handles concurrent cache changes**

- Activation scans compare an initial and final directory snapshot so an entry created during the scan triggers a follow-up pass.
- Final cache-root absence publishes an empty collection immediately; transient final-read failures preserve the prior collection until a retry.
- Per-entry filesystem fingerprints detect a cache directory rebuilt under the same key even when its name is unchanged.
- Locks use the cache entry name/hash as their identity.
- Published entries use that same cache-key identity rather than mixing lexical cache paths with canonical `sysPrefix` paths, avoiding false removal through symlink/junction path differences.
- Lock probing uses `lstat`; only `ENOENT` means unlocked. `EIO`, access failures, and other uncertain states fail closed.

**Coalesces refresh work without weakening activation discovery**

- Concurrent compatible refreshes share one scan.
- Activation joining an in-flight explicit refresh receives one snapshot-aware follow-up rather than accepting the explicit pass's weaker single-snapshot semantics.
- Explicit `refresh()` cancels activation retries, performs one settled pass, and schedules no delayed work afterward.

**Retries activation discovery only while useful**

- Follow-up delays are bounded at 1 second, 5 seconds, and 30 seconds.
- Retries are requested for locks, transient failures, or a changed cache snapshot.
- No permanent filesystem watcher or unbounded polling loop is introduced.
- Disposal cancels pending timers and prevents in-flight scans from publishing late results.

**Strengthens the Windows usability guard**

- Windows cache validation now checks both the cached environment launcher and the base interpreter referenced by `pyvenv.cfg`.
- A surviving base interpreter no longer makes an environment with a missing `Scripts\python.exe` appear usable.

### Discovery semantics

| Cache state | Behavior |
|---|---|
| Valid sidecar, launcher, interpreter, ownership, and version | Publish environment |
| Entry is locked or being built | Preserve previous publication; retry |
| Filesystem/resolver state is temporarily unavailable | Preserve previous publication; retry |
| Entry appears during the scan | Schedule snapshot-aware follow-up |
| Missing or malformed sidecar | Omit/remove from collection |
| Missing launcher/base interpreter | Omit/remove from collection |
| Ownership or recorded-version mismatch | Omit/remove from collection |
| Cache root is absent | Publish empty collection |

### Example

```text
extension activation
→ register InlineScriptEnvManager
→ defer one event-loop turn
→ scan <globalStorage>/script-envs-v1
→ validate sidecar + launcher + ownership + version
→ publish valid cached environments through getEnvironments('all')
→ retry only if the scan observed a lock, transient state, or snapshot change
```

This inventory does not associate an environment with a script. PR 7 owns persisted script associations, and PR 9 will use those associations for automatic per-file routing.

### Tests

Coverage includes:

- deferred feature-gated activation startup;
- valid cache discovery and `all`-scope publication;
- missing, malformed, unavailable, non-directory, and symlinked entries;
- missing and non-regular Windows launchers;
- lock preservation, including unavailable (`EIO`) lock probes;
- canonical `sysPrefix` versus lexical cache-root identities;
- add/remove event reconciliation;
- concurrent refresh coalescing;
- activation joining an explicit refresh;
- cache entries created during a scan;
- builds completing after the short retry window;
- bounded retry exhaustion;
- explicit single-pass refresh behavior; and
- disposal during in-flight scans and pending retries.

Validation on the rebased branch:

- `npm run compile-tests`
- `npm run compile`
- `npm run lint`
- focused activation-discovery/cache-launcher/registration suites

The full Windows unit run reaches 1613 passing and 5 pending; the existing concurrent `writeMetaJson` rename test can still intermittently fail with `EPERM` on Windows. That writer is unchanged by this PR and the same failure is reproducible on `main`.

### Performance

- Activation is deferred and never waits for discovery.
- Cache scans are coalesced.
- Retries are bounded and stop after a stable pass.
- Explicit refresh remains single-pass.
- There is no persistent watcher, unbounded polling, or per-document work.

### User impact

**No default-path user impact.** The manager and discovery remain behind the undeclared, default-off `python-envs.inlineScripts.enabled` flag.

With the internal flag manually enabled, valid cached inline environments become available through the manager after restart. This PR does not automatically select one for a script and introduces no public command, setting, picker item, project registration, cache deletion, TTL cleanup, or telemetry.

### Scope and follow-up

This PR intentionally does **not** implement:

- automatic PEP 723 script routing (PR 9);
- exact script project registration (PR 10);
- CodeLens or bulk setup UX (PRs 11-12);
- cache clearing or TTL eviction (PRs 13-14); or
- lifecycle telemetry (PR 15).

PR 7 (#1697) is merged, and this branch is rebased on current `main`. Automatic routing can follow independently after this manager-discovery layer lands.


