### PR TITLE
fix(terminal): wait for shell integration before running Python commands

### DIFF
--- a/src/features/terminal/runInTerminal.ts
+++ b/src/features/terminal/runInTerminal.ts
@@ -7,6 +7,7 @@ import { identifyTerminalShell } from '../common/shellDetector';
 import { quoteArgs } from '../execution/execUtils';
 import { normalizeShellPath } from './shells/common/shellUtils';
 import { traceLog } from '../../common/logging';
+import { waitForShellIntegration } from './utils';
 
 export async function runInTerminal(
     environment: PythonEnvironment,
@@ -25,6 +26,9 @@ export async function runInTerminal(
     // Normalize executable path for Git Bash on Windows
     if (shellType === ShellConstants.GITBASH) {
         executable = normalizeShellPath(executable, shellType);
+    }
+    if (!terminal.shellIntegration) {
+        await waitForShellIntegration(terminal);
     }
     if (terminal.shellIntegration) {
         let execution: TerminalShellExecution | undefined;

--- a/src/test/features/terminal/runInTerminal.unit.test.ts
+++ b/src/test/features/terminal/runInTerminal.unit.test.ts
@@ -1,0 +1,76 @@
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { Disposable, Terminal, TerminalShellExecution, TerminalShellExecutionEndEvent } from 'vscode';
+import * as windowApis from '../../../common/window.apis';
+import * as shellDetector from '../../../features/common/shellDetector';
+import { runInTerminal } from '../../../features/terminal/runInTerminal';
+import * as terminalUtils from '../../../features/terminal/utils';
+import { createMockPythonEnvironment } from '../../mocks/pythonEnvironment';
+
+suite('runInTerminal', () => {
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('waits for shell integration before executing a command', async () => {
+        sinon.stub(shellDetector, 'identifyTerminalShell').returns('fish');
+        const waitForShellIntegrationStub = sinon.stub(terminalUtils, 'waitForShellIntegration');
+        let resolveWaitForShellIntegration!: (result: boolean) => void;
+        const waitForShellIntegrationPromise = new Promise<boolean>((resolve) => {
+            resolveWaitForShellIntegration = resolve;
+        });
+
+        const execution = {} as TerminalShellExecution;
+        const shellIntegration = {
+            executeCommand: sinon.stub().returns(execution),
+        };
+        const terminal = {
+            name: 'Python',
+            shellIntegration: undefined,
+            sendText: sinon.stub(),
+        } as unknown as Terminal;
+        waitForShellIntegrationStub.returns(waitForShellIntegrationPromise);
+
+        let endListener: ((event: TerminalShellExecutionEndEvent) => void) | undefined;
+        sinon.stub(windowApis, 'onDidEndTerminalShellExecution').callsFake((listener) => {
+            endListener = listener;
+            return new Disposable(() => undefined);
+        });
+
+        const environment = createMockPythonEnvironment({ envPath: '/env/bin/python' });
+        const runPromise = runInTerminal(environment, terminal, { cwd: '/workspace', args: ['main.py'] });
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        sinon.assert.calledOnce(waitForShellIntegrationStub);
+        sinon.assert.notCalled(terminal.sendText as sinon.SinonStub);
+        sinon.assert.notCalled(shellIntegration.executeCommand);
+
+        (terminal as { shellIntegration?: typeof shellIntegration }).shellIntegration = shellIntegration;
+        resolveWaitForShellIntegration(true);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        sinon.assert.notCalled(terminal.sendText as sinon.SinonStub);
+        sinon.assert.calledOnce(shellIntegration.executeCommand);
+        assert.ok(endListener, 'shell execution end listener should be registered');
+
+        endListener!({ terminal, execution } as unknown as TerminalShellExecutionEndEvent);
+        await runPromise;
+    });
+
+    test('uses sendText when shell integration is unavailable after waiting', async () => {
+        sinon.stub(shellDetector, 'identifyTerminalShell').returns('fish');
+        const waitForShellIntegrationStub = sinon.stub(terminalUtils, 'waitForShellIntegration').resolves(false);
+        const sendText = sinon.stub();
+        const terminal = {
+            name: 'Python',
+            shellIntegration: undefined,
+            sendText,
+        } as unknown as Terminal;
+
+        const environment = createMockPythonEnvironment({ envPath: '/env/bin/python' });
+        await runInTerminal(environment, terminal, { cwd: '/workspace', args: ['main.py'] });
+
+        sinon.assert.calledOnceWithExactly(waitForShellIntegrationStub, terminal);
+        sinon.assert.calledOnceWithExactly(sendText, 'python main.py\n');
+    });
+});


### PR DESCRIPTION
## Summary

- Wait for shell integration before selecting the `sendText` fallback in `runInTerminal`.
- Re-check `terminal.shellIntegration` after the wait so a terminal that becomes ready uses `executeCommand`.
- Add unit-test coverage for the ordering.

## Background

On a newly created terminal, `terminal.shellIntegration` can be undefined while the shell is still initializing. `runInTerminal` previously selected the `sendText` fallback immediately in that state. With Fish, the command can then be written before the shell prompt and shell-integration sequences are ready, which can produce duplicate command or prompt echo.

The existing `waitForShellIntegration` helper already filters shell-integration events to the target terminal. This change waits for that helper before selecting the execution path and preserves the existing `sendText` fallback when shell integration remains unavailable.

Related to #1312

## Scope

This PR addresses the early `sendText` race in the Python Environments extension. A separate approximately five-second delay can occur inside VS Code Core after `executeCommand` is called; that Core behavior is not changed here.

## Testing

- `npm run compile-tests`
- `npm run lint`
- `npm run compile`
- Unit suite via Mocha with Node 22: 1871 passing, 8 pending
