### PR TITLE
Register PEP 723 scripts as exact projects (PEP 723 PR 10/16)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -407,7 +407,7 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
         ...(isInlineScriptsFeatureEnabled()
             ? [
                   commands.registerCommand('python-envs.clearScriptEnvCache', async () => {
-                      await clearScriptEnvironmentCacheCommand(envManagers, projectManager);
+                      await clearScriptEnvironmentCacheCommand(envManagers);
                   }),
               ]
             : []),

--- a/src/features/envCommands.ts
+++ b/src/features/envCommands.ts
@@ -31,7 +31,6 @@ import {
     PythonProjectManager,
 } from '../internal.api';
 import {
-    removeInlineScriptPythonProjectSettings,
     removePythonProjectSetting,
     setEnvironmentManager,
     setPackageManager,
@@ -704,7 +703,6 @@ export async function clearEnvironmentCachesCommand(
 
 export async function clearScriptEnvironmentCacheCommand(
     em: EnvironmentManagers,
-    wm: PythonProjectManager,
 ): Promise<void> {
     const manager = em.getEnvironmentManager(INLINE_SCRIPT_MANAGER_ID);
     if (!manager || !manager.supportsClearCache()) {
@@ -725,11 +723,7 @@ export async function clearScriptEnvironmentCacheCommand(
         return;
     }
 
-    await manager.clearCache();
-    const loadedProjectsToRemove = await removeInlineScriptPythonProjectSettings(wm.getProjects());
-    if (loadedProjectsToRemove.length > 0) {
-        wm.remove(loadedProjectsToRemove);
-    }
+    await em.clearInlineScriptCache();
 }
 
 export async function getPackageCommandOptions(

--- a/src/features/envManagers.ts
+++ b/src/features/envManagers.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { ConfigurationTarget, Disposable, Event, EventEmitter, Uri, workspace } from 'vscode';
 import {
     DidChangeEnvironmentEventArgs,
@@ -43,7 +44,14 @@ import {
     EditAllManagerSettings,
     getDefaultEnvManagerSetting,
     getDefaultPkgManagerSetting,
+    getExactPythonProjectSetting,
+    getManagedInlineScriptProjectRegistration,
     getProjectEnvironmentManagerSetting,
+    InlineScriptPythonProjectRegistration,
+    registerInlineScriptPythonProjectSetting,
+    removeInlineScriptPythonProjectSettings,
+    removeManagedInlineScriptPythonProjectSetting,
+    rollbackInlineScriptPythonProjectSetting,
     setAllManagerSettings,
 } from './settings/settingHelpers';
 
@@ -73,6 +81,7 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
     private readonly _inlineRoutingOverrides = new Map<string, string>();
     private readonly _selectionRevisions = new Map<string, number>();
     private readonly _selectionOperationCounters = new Map<string, number>();
+    private inlineScriptProjectSelectionQueue: Promise<void> = Promise.resolve();
 
     private _onDidChangeEnvironmentManager = new EventEmitter<DidChangeEnvironmentManagerEventArgs>();
     private _onDidChangePackageManager = new EventEmitter<DidChangePackageManagerEventArgs>();
@@ -98,6 +107,15 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
     /** Fires only when the *selected* manager's environment for a scope actually changes. */
     public onDidChangeActiveEnvironment: Event<DidChangeEnvironmentEventArgs> =
         this._onDidChangeActiveEnvironment.event;
+
+    private enqueueInlineScriptProjectSelection<T>(operation: () => Promise<T>): Promise<T> {
+        const run = this.inlineScriptProjectSelectionQueue.then(operation);
+        this.inlineScriptProjectSelectionQueue = run.then(
+            () => undefined,
+            () => undefined,
+        );
+        return run;
+    }
 
     constructor(
         private readonly pm: PythonProjectManager,
@@ -343,6 +361,20 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
         }
     }
 
+    public clearInlineScriptCache(): Promise<void> {
+        return this.enqueueInlineScriptProjectSelection(async () => {
+            const manager = this._environmentManagers.get(INLINE_SCRIPT_MANAGER_ID);
+            if (!manager || !manager.supportsClearCache()) {
+                throw new Error('Inline-script environment manager is unavailable.');
+            }
+            await manager.clearCache();
+            const projectsToRemove = await removeInlineScriptPythonProjectSettings(this.pm.getProjects());
+            if (projectsToRemove.length > 0) {
+                this.pm.remove(projectsToRemove);
+            }
+        });
+    }
+
     /**
      * Sets the environment for a single scope, scope of undefined checks 'global'.
      * If given an array of scopes, delegates to setEnvironments for batch setting.
@@ -353,7 +385,7 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
      *   Pass `false` when setting environments during initial selection/auto-discovery
      *   to avoid writing to settings.json.
      */
-    public async setEnvironment(
+    public setEnvironment(
         scope: SetEnvironmentScope,
         environment?: PythonEnvironment,
         shouldPersistSettings: boolean = true,
@@ -361,7 +393,19 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
         if (Array.isArray(scope)) {
             return this.setEnvironments(scope, environment, shouldPersistSettings);
         }
+        if (this.shouldSerializeInlineScriptProjectSelection(scope, environment, shouldPersistSettings)) {
+            return this.enqueueInlineScriptProjectSelection(() =>
+                this.setEnvironmentCore(scope, environment, shouldPersistSettings),
+            );
+        }
+        return this.setEnvironmentCore(scope, environment, shouldPersistSettings);
+    }
 
+    private async setEnvironmentCore(
+        scope: Uri | undefined,
+        environment: PythonEnvironment | undefined,
+        shouldPersistSettings: boolean,
+    ): Promise<void> {
         const customScope = environment ? environment : scope;
         const manager = this.getEnvironmentManager(customScope);
         if (!manager) {
@@ -374,6 +418,10 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
             traceError(this.managers.map((m) => m.id).join(', '));
             return;
         }
+        const inlineRegistration =
+            scope && environment && manager.id === INLINE_SCRIPT_MANAGER_ID && shouldPersistSettings
+                ? await this.prepareInlineScriptProjectRegistration(scope)
+                : undefined;
         const project = scope ? this.pm.get(scope) : undefined;
         const key = this.getActiveSelectionKey(scope, manager, project);
         const operation = this.beginSelectionOperation(key);
@@ -393,7 +441,21 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
             this.inlineScriptRouting?.shouldRoute(scope)
                 ? this.beginSelectionOperation(this.getInlineScriptSelectionKey(scope))
                 : undefined;
-        await manager.set(scope, environment);
+        try {
+            await manager.set(scope, environment);
+        } catch (error) {
+            if (inlineRegistration) {
+                await this.rollbackInlineScriptProjectRegistration(inlineRegistration);
+            }
+            throw error;
+        }
+
+        if (scope && !environment && manager.id === INLINE_SCRIPT_MANAGER_ID && shouldPersistSettings && project) {
+            const removeProject = await removeManagedInlineScriptPythonProjectSetting(project);
+            if (removeProject) {
+                this.pm.remove(project);
+            }
+        }
 
         // Only persist to settings when explicitly requested
         if (shouldPersistSettings && scope) {
@@ -482,10 +544,23 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
      *   Pass `false` when setting environments during initial selection/auto-discovery
      *   to avoid writing to settings.json.
      */
-    public async setEnvironments(
+    public setEnvironments(
         scope: Uri[] | string,
         environment?: PythonEnvironment,
         shouldPersistSettings: boolean = true,
+    ): Promise<void> {
+        if (this.shouldSerializeInlineScriptProjectSelection(scope, environment, shouldPersistSettings)) {
+            return this.enqueueInlineScriptProjectSelection(() =>
+                this.setEnvironmentsCore(scope, environment, shouldPersistSettings),
+            );
+        }
+        return this.setEnvironmentsCore(scope, environment, shouldPersistSettings);
+    }
+
+    private async setEnvironmentsCore(
+        scope: Uri[] | string,
+        environment: PythonEnvironment | undefined,
+        shouldPersistSettings: boolean,
     ): Promise<void> {
         if (environment) {
             const manager = this.managers.find((m) => m.id === environment.envId.managerId);
@@ -502,8 +577,17 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
             const settings: EditAllManagerSettings[] = [];
             const events: DidChangeEnvironmentEventArgs[] = [];
             if (Array.isArray(scope) && scope.every((s) => s instanceof Uri)) {
+                const inlineRegistrations =
+                    manager.id === INLINE_SCRIPT_MANAGER_ID && shouldPersistSettings
+                        ? await this.prepareInlineScriptProjectRegistrations(scope)
+                        : [];
                 const selections = scope.map((uri) => this.beginPendingSelection(uri, manager));
-                await manager.set(scope, environment);
+                try {
+                    await manager.set(scope, environment);
+                } catch (error) {
+                    await this.rollbackInlineScriptProjectRegistrations(inlineRegistrations);
+                    throw error;
+                }
                 selections.forEach((selection) => {
                     const m = this.getEnvironmentManager(selection.scope);
                     // Always add settings when persisting, OR when manager differs
@@ -518,7 +602,7 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
                         });
                     }
                 });
-                if (shouldPersistSettings) {
+                if (shouldPersistSettings && settings.length > 0) {
                     await setAllManagerSettings(settings);
                 }
                 selections.forEach((selection) => {
@@ -601,6 +685,19 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
                     const events: DidChangeEnvironmentEventArgs[] = [];
                     const selections = uris.map((uri) => this.beginPendingSelection(uri, manager));
                     await manager.set(uris);
+                    if (manager.id === INLINE_SCRIPT_MANAGER_ID && shouldPersistSettings) {
+                        for (const selection of selections) {
+                            if (!selection.project) {
+                                continue;
+                            }
+                            const removeProject = await removeManagedInlineScriptPythonProjectSetting(
+                                selection.project,
+                            );
+                            if (removeProject) {
+                                this.pm.remove(selection.project);
+                            }
+                        }
+                    }
                     await Promise.all(
                         selections.map(async (selection) => {
                             const newEnv = await manager.get(selection.scope);
@@ -765,6 +862,10 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
         project: PythonProject | undefined,
     ): InternalEnvironmentManager | undefined {
         if (!project || normalizePath(project.uri.fsPath) !== normalizePath(scope.fsPath)) {
+            return undefined;
+        }
+        const exactSetting = getExactPythonProjectSetting(this.pm, scope);
+        if (getManagedInlineScriptProjectRegistration(exactSetting)) {
             return undefined;
         }
         const exactManagerId = getProjectEnvironmentManagerSetting(this.pm, scope);
@@ -977,16 +1078,99 @@ export class PythonEnvironmentManagers implements EnvironmentManagers {
         );
     }
 
-    private canPersistManagerSettingForScope(
-        scope: Uri,
-        manager: InternalEnvironmentManager,
-        project: PythonProject | undefined,
+    private shouldSerializeInlineScriptProjectSelection(
+        scope: SetEnvironmentScope | string,
+        environment: PythonEnvironment | undefined,
+        shouldPersistSettings: boolean,
     ): boolean {
-        // Inline associations are per file; never promote one to its containing project's manager setting.
-        return (
-            manager.id !== INLINE_SCRIPT_MANAGER_ID ||
-            (!!project && normalizePath(project.uri.fsPath) === normalizePath(scope.fsPath))
+        if (!shouldPersistSettings) {
+            return false;
+        }
+        if (environment?.envId.managerId === INLINE_SCRIPT_MANAGER_ID) {
+            return true;
+        }
+        const scopes = scope instanceof Uri ? [scope] : Array.isArray(scope) ? scope : [];
+        return scopes.some((uri) =>
+            getManagedInlineScriptProjectRegistration(getExactPythonProjectSetting(this.pm, uri)),
         );
+    }
+
+    private async prepareInlineScriptProjectRegistration(
+        scope: Uri,
+    ): Promise<PreparedInlineScriptProjectRegistration | undefined> {
+        const existingProject = this.pm.get(scope);
+        const hasExactProject =
+            existingProject !== undefined &&
+            normalizePath(existingProject.uri.fsPath) === normalizePath(scope.fsPath);
+        const project = hasExactProject
+            ? existingProject
+            : this.pm.create(path.basename(scope.fsPath) || scope.fsPath, scope);
+        const registration = await registerInlineScriptPythonProjectSetting(this.pm, project);
+        if (!registration) {
+            return undefined;
+        }
+
+        const addedProject = !hasExactProject;
+        try {
+            if (addedProject) {
+                await this.pm.add(project, { persistSettings: false });
+            }
+        } catch (error) {
+            const removeProject = await rollbackInlineScriptPythonProjectSetting(project, registration);
+            if (removeProject && addedProject) {
+                this.pm.remove(project);
+            }
+            throw error;
+        }
+        return { project, registration, addedProject };
+    }
+
+    private async prepareInlineScriptProjectRegistrations(
+        scopes: readonly Uri[],
+    ): Promise<PreparedInlineScriptProjectRegistration[]> {
+        const registrations: PreparedInlineScriptProjectRegistration[] = [];
+        try {
+            for (const scope of scopes) {
+                const registration = await this.prepareInlineScriptProjectRegistration(scope);
+                if (registration) {
+                    registrations.push(registration);
+                }
+            }
+            return registrations;
+        } catch (error) {
+            await this.rollbackInlineScriptProjectRegistrations(registrations);
+            throw error;
+        }
+    }
+
+    private async rollbackInlineScriptProjectRegistrations(
+        registrations: readonly PreparedInlineScriptProjectRegistration[],
+    ): Promise<void> {
+        for (const registration of [...registrations].reverse()) {
+            await this.rollbackInlineScriptProjectRegistration(registration);
+        }
+    }
+
+    private async rollbackInlineScriptProjectRegistration(
+        prepared: PreparedInlineScriptProjectRegistration,
+    ): Promise<void> {
+        const removeProject = await rollbackInlineScriptPythonProjectSetting(
+            prepared.project,
+            prepared.registration,
+        );
+        if (removeProject && prepared.addedProject) {
+            this.pm.remove(prepared.project);
+        }
+    }
+
+    private canPersistManagerSettingForScope(
+        _scope: Uri,
+        manager: InternalEnvironmentManager,
+        _project: PythonProject | undefined,
+    ): boolean {
+        // Inline associations are persisted by the inline manager. The managed exact-project entry
+        // stores the ordinary fallback manager rather than replacing it with the inline manager.
+        return manager.id !== INLINE_SCRIPT_MANAGER_ID;
     }
 
     private beginSelectionOperation(key: string): number {
@@ -1054,4 +1238,10 @@ interface PendingEnvironmentSelection {
     readonly operation: number;
     readonly publishInlineSelection: boolean;
     readonly inlineClearOperation: number | undefined;
+}
+
+interface PreparedInlineScriptProjectRegistration {
+    readonly project: PythonProject;
+    readonly registration: InlineScriptPythonProjectRegistration;
+    readonly addedProject: boolean;
 }

--- a/src/features/projectManager.ts
+++ b/src/features/projectManager.ts
@@ -197,7 +197,10 @@ export class PythonProjectManagerImpl implements PythonProjectManager {
         return new PythonProjectsImpl(name, uri, options);
     }
 
-    async add(projects: PythonProject | ProjectArray): Promise<void> {
+    async add(
+        projects: PythonProject | ProjectArray,
+        options?: { persistSettings?: boolean },
+    ): Promise<void> {
         const _projects = Array.isArray(projects) ? projects : [projects];
         if (_projects.length === 0) {
             return;
@@ -228,7 +231,7 @@ export class PythonProjectManagerImpl implements PythonProjectManager {
         });
         this._onDidChangeProjects.fire(Array.from(this._projects.values()));
 
-        if (edits.length > 0) {
+        if (options?.persistSettings !== false && edits.length > 0) {
             await addPythonProjectSetting(edits);
         }
     }

--- a/src/features/settings/settingHelpers.ts
+++ b/src/features/settings/settingHelpers.ts
@@ -13,43 +13,22 @@ import { normalizePath } from '../../common/utils/pathUtils';
 import { EventNames } from '../../common/telemetry/constants';
 import { sendTelemetryEvent } from '../../common/telemetry/sender';
 import * as workspaceApis from '../../common/workspace.apis';
-import { PythonProjectManager, PythonProjectSettings } from '../../internal.api';
+import {
+    InlineScriptProjectRegistrationKind,
+    InlineScriptProjectRegistrationMarker,
+    PythonProjectManager,
+    PythonProjectSettings,
+} from '../../internal.api';
 
-interface ResolvedPythonProjectSettingSource {
-    readonly setting: PythonProjectSettings;
-    readonly uri: Uri;
-    readonly workspaceFolder: WorkspaceFolder;
-    readonly source: 'global' | 'workspace' | 'workspaceFolder';
-    readonly target: ConfigurationTarget.Global | ConfigurationTarget.Workspace | ConfigurationTarget.WorkspaceFolder;
-}
+let inlineScriptProjectSettingsQueue: Promise<void> = Promise.resolve();
 
-interface ResolvedPythonProjectSetting {
-    readonly uri: Uri;
-    readonly workspaceFolder: WorkspaceFolder;
-    readonly effective: ResolvedPythonProjectSettingSource;
-    readonly sources: readonly ResolvedPythonProjectSettingSource[];
-}
-
-function resolvePythonProjectSettingSource(
-    setting: PythonProjectSettings,
-    workspaceFolder: WorkspaceFolder,
-    allWorkspaceFolders: readonly WorkspaceFolder[],
-    source: 'global' | 'workspace' | 'workspaceFolder',
-    target: ConfigurationTarget.Global | ConfigurationTarget.Workspace | ConfigurationTarget.WorkspaceFolder,
-): ResolvedPythonProjectSettingSource | undefined {
-    const resolvedWorkspaceFolder = setting.workspace
-        ? allWorkspaceFolders.find((candidate) => candidate.name === setting.workspace)
-        : workspaceFolder;
-    if (!resolvedWorkspaceFolder || resolvedWorkspaceFolder.uri.toString() !== workspaceFolder.uri.toString()) {
-        return undefined;
-    }
-    return {
-        setting,
-        uri: Uri.file(path.resolve(resolvedWorkspaceFolder.uri.fsPath, setting.path)),
-        workspaceFolder,
-        source,
-        target,
-    };
+function enqueueInlineScriptProjectSettingsMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const run = inlineScriptProjectSettingsQueue.then(operation);
+    inlineScriptProjectSettingsQueue = run.then(
+        () => undefined,
+        () => undefined,
+    );
+    return run;
 }
 
 function resolveProjectSettingUri(
@@ -65,73 +44,6 @@ function resolveProjectSettingUri(
         : undefined;
 }
 
-function getResolvedPythonProjectSettings(
-    workspaceFolder: WorkspaceFolder,
-    config: WorkspaceConfiguration = workspaceApis.getConfiguration('python-envs', workspaceFolder.uri),
-): ResolvedPythonProjectSetting[] {
-    const allWorkspaceFolders = workspaceApis.getWorkspaceFolders() ?? [workspaceFolder];
-    const projectsInspect =
-        typeof config.inspect === 'function' ? config.inspect<PythonProjectSettings[]>('pythonProjects') : undefined;
-    const fallbackSettings =
-        projectsInspect === undefined ? config.get<PythonProjectSettings[]>('pythonProjects', []) : undefined;
-    const orderedSources: ResolvedPythonProjectSettingSource[] = [
-        ...(projectsInspect?.globalValue ?? [])
-            .map((setting) =>
-                resolvePythonProjectSettingSource(
-                    setting,
-                    workspaceFolder,
-                    allWorkspaceFolders,
-                    'global',
-                    ConfigurationTarget.Global,
-                ),
-            )
-            .filter((setting): setting is ResolvedPythonProjectSettingSource => setting !== undefined),
-        ...(projectsInspect?.workspaceValue ?? fallbackSettings ?? [])
-            .map((setting) =>
-                resolvePythonProjectSettingSource(
-                    setting,
-                    workspaceFolder,
-                    allWorkspaceFolders,
-                    'workspace',
-                    ConfigurationTarget.Workspace,
-                ),
-            )
-            .filter((setting): setting is ResolvedPythonProjectSettingSource => setting !== undefined),
-        ...(projectsInspect?.workspaceFolderValue ?? [])
-            .map((setting) =>
-                resolvePythonProjectSettingSource(
-                    setting,
-                    workspaceFolder,
-                    allWorkspaceFolders,
-                    'workspaceFolder',
-                    ConfigurationTarget.WorkspaceFolder,
-                ),
-            )
-            .filter((setting): setting is ResolvedPythonProjectSettingSource => setting !== undefined),
-    ];
-
-    const grouped = new Map<string, ResolvedPythonProjectSetting>();
-    for (const source of orderedSources) {
-        const key = source.uri.toString();
-        const existing = grouped.get(key);
-        if (existing) {
-            grouped.set(key, {
-                ...existing,
-                effective: source,
-                sources: [...existing.sources, source],
-            });
-        } else {
-            grouped.set(key, {
-                uri: source.uri,
-                workspaceFolder,
-                effective: source,
-                sources: [source],
-            });
-        }
-    }
-    return Array.from(grouped.values());
-}
-
 function getSettings(
     wm: PythonProjectManager,
     config: WorkspaceConfiguration,
@@ -144,18 +56,33 @@ function getSettings(
         const w = workspaceApis.getWorkspaceFolder(scope);
         if (pw && w) {
             const pwPath = normalizePath(pw.uri.fsPath);
-            return overrides.find((s) => normalizePath(path.resolve(w.uri.fsPath, s.path)) === pwPath);
+            return overrides.find(
+                (s) =>
+                    (!s.workspace || s.workspace === w.name) &&
+                    normalizePath(path.resolve(w.uri.fsPath, s.path)) === pwPath,
+            );
         }
     }
     return undefined;
+}
+
+export function getExactPythonProjectSetting(
+    wm: PythonProjectManager,
+    scope: Uri,
+): PythonProjectSettings | undefined {
+    const project = wm.get(scope);
+    if (!project || normalizePath(project.uri.fsPath) !== normalizePath(scope.fsPath)) {
+        return undefined;
+    }
+    const config = workspaceApis.getConfiguration('python-envs', scope);
+    return config && typeof config.get === 'function' ? getSettings(wm, config, scope) : undefined;
 }
 
 export function getProjectEnvironmentManagerSetting(
     wm: PythonProjectManager,
     scope: Uri,
 ): string | undefined {
-    const config = workspaceApis.getConfiguration('python-envs', scope);
-    const setting = getSettings(wm, config, scope)?.envManager;
+    const setting = getExactPythonProjectSetting(wm, scope)?.envManager;
     return setting ? setting : undefined;
 }
 
@@ -240,7 +167,20 @@ export async function setAllManagerSettings(edits: EditAllManagerSettings[]): Pr
     const workspaces = new Map<WorkspaceFolder, EditAllManagerSettingsInternal[]>();
     const projectEdits = edits.filter((e): e is EditAllManagerSettingsInternal => !!e.project);
     traceIgnoredGlobalManagerEdits('setAllManagerSettings', edits.length - projectEdits.length);
-    projectEdits.forEach((e) => {
+    const handledManagedEdits = await Promise.all(
+        projectEdits.map((edit) =>
+            edit.envManager === INLINE_SCRIPT_MANAGER_ID
+                ? Promise.resolve(false)
+                : updateManagedInlineScriptProjectSetting(edit.project, {
+                      envManager: edit.envManager,
+                      packageManager: edit.packageManager,
+                  }),
+        ),
+    );
+    projectEdits.forEach((e, index) => {
+        if (handledManagedEdits[index]) {
+            return;
+        }
         const w = workspaceApis.getWorkspaceFolder(e.project.uri);
         if (w) {
             workspaces.set(w, [
@@ -274,7 +214,11 @@ export async function setAllManagerSettings(edits: EditAllManagerSettings[]): Pr
         es.forEach((e) => {
             const pwPath = normalizePath(e.project.uri.fsPath);
             const isRoot = normalizePath(w.uri.fsPath) === pwPath;
-            const index = overrides.findIndex((s) => normalizePath(path.resolve(w.uri.fsPath, s.path)) === pwPath);
+            const index = overrides.findIndex(
+                (s) =>
+                    (!s.workspace || s.workspace === w.name) &&
+                    normalizePath(path.resolve(w.uri.fsPath, s.path)) === pwPath,
+            );
 
             // For workspace root in single-folder workspaces (no workspaceFile),
             // use default settings instead of pythonProjects entries
@@ -294,6 +238,9 @@ export async function setAllManagerSettings(edits: EditAllManagerSettings[]): Pr
             } else if (index >= 0) {
                 overrides[index].envManager = e.envManager;
                 overrides[index].packageManager = e.packageManager;
+                if (e.envManager !== INLINE_SCRIPT_MANAGER_ID) {
+                    delete overrides[index]._inlineScriptRegistration;
+                }
                 // Fix empty path to "." for workspace root (migration from buggy entries)
                 if (overrides[index].path === '') {
                     overrides[index].path = '.';
@@ -356,7 +303,19 @@ export async function setEnvironmentManager(edits: EditEnvManagerSettings[]): Pr
     const workspaces = new Map<WorkspaceFolder, EditEnvManagerSettingsInternal[]>();
     const projectEdits = edits.filter((e): e is EditEnvManagerSettingsInternal => !!e.project);
     traceIgnoredGlobalManagerEdits('setEnvironmentManager', edits.length - projectEdits.length);
-    projectEdits.forEach((e) => {
+    const handledManagedEdits = await Promise.all(
+        projectEdits.map((edit) =>
+            edit.envManager === INLINE_SCRIPT_MANAGER_ID
+                ? Promise.resolve(false)
+                : updateManagedInlineScriptProjectSetting(edit.project, {
+                      envManager: edit.envManager,
+                  }),
+        ),
+    );
+    projectEdits.forEach((e, index) => {
+        if (handledManagedEdits[index]) {
+            return;
+        }
         const w = workspaceApis.getWorkspaceFolder(e.project.uri);
         if (w) {
             workspaces.set(w, [...(workspaces.get(w) || []), { project: e.project, envManager: e.envManager }]);
@@ -383,9 +342,16 @@ export async function setEnvironmentManager(edits: EditEnvManagerSettings[]): Pr
 
         es.forEach((e) => {
             const pwPath = normalizePath(e.project.uri.fsPath);
-            const index = overrides.findIndex((s) => normalizePath(path.resolve(w.uri.fsPath, s.path)) === pwPath);
+            const index = overrides.findIndex(
+                (s) =>
+                    (!s.workspace || s.workspace === w.name) &&
+                    normalizePath(path.resolve(w.uri.fsPath, s.path)) === pwPath,
+            );
             if (index >= 0) {
                 overrides[index].envManager = e.envManager;
+                if (e.envManager !== INLINE_SCRIPT_MANAGER_ID) {
+                    delete overrides[index]._inlineScriptRegistration;
+                }
                 projectsModified = true;
             } else if (config.get('defaultEnvManager') !== e.envManager) {
                 promises.push(config.update('defaultEnvManager', e.envManager, ConfigurationTarget.Workspace));
@@ -493,151 +459,309 @@ function matchesProjectSettingEdit(
     return true;
 }
 
-function hasProjectSetting(
-    settings: readonly PythonProjectSettings[],
-    project: PythonProject,
-    workspaceFolder: WorkspaceFolder,
-): boolean {
-    const projectPath = normalizePath(project.uri.fsPath);
-    return settings.some((setting) => {
-        const settingUri = resolveProjectSettingUri(setting, workspaceFolder);
-        return settingUri ? normalizePath(settingUri.fsPath) === projectPath : false;
-    });
-}
-
 function cloneProjectSettings(
     settings: readonly PythonProjectSettings[] | undefined,
 ): PythonProjectSettings[] | undefined {
     return settings?.map((setting) => ({ ...setting }));
 }
 
-export async function removeInlineScriptPythonProjectSettings(
+type InlineScriptProjectSettingsTarget =
+    | ConfigurationTarget.Global
+    | ConfigurationTarget.Workspace
+    | ConfigurationTarget.WorkspaceFolder;
+
+export interface InlineScriptPythonProjectRegistration {
+    readonly kind: InlineScriptProjectRegistrationKind;
+    readonly changed: boolean;
+    readonly workspaceFolder: WorkspaceFolder;
+    readonly target: InlineScriptProjectSettingsTarget;
+}
+
+export function getManagedInlineScriptProjectRegistration(
+    setting: PythonProjectSettings | undefined,
+): InlineScriptProjectRegistrationMarker | undefined {
+    const marker = setting?._inlineScriptRegistration;
+    return marker?.kind === 'created' || marker?.kind === 'adopted' ? marker : undefined;
+}
+
+function getInlineScriptProjectSettingsTarget(config: WorkspaceConfiguration): InlineScriptProjectSettingsTarget {
+    const inspect = config.inspect<PythonProjectSettings[]>('pythonProjects');
+    if (inspect?.workspaceFolderValue !== undefined) {
+        return ConfigurationTarget.WorkspaceFolder;
+    }
+    if (inspect?.workspaceValue !== undefined) {
+        return ConfigurationTarget.Workspace;
+    }
+    if (inspect?.globalValue !== undefined) {
+        return ConfigurationTarget.Global;
+    }
+    return workspaceApis.getWorkspaceFile()
+        ? ConfigurationTarget.WorkspaceFolder
+        : ConfigurationTarget.Workspace;
+}
+
+function getExplicitProjectSettings(
+    config: WorkspaceConfiguration,
+    target: InlineScriptProjectSettingsTarget,
+): PythonProjectSettings[] | undefined {
+    const inspect = config.inspect<PythonProjectSettings[]>('pythonProjects');
+    if (!inspect) {
+        return target === ConfigurationTarget.Workspace
+            ? cloneProjectSettings(config.get<PythonProjectSettings[]>('pythonProjects', []))
+            : undefined;
+    }
+    if (target === ConfigurationTarget.Global) {
+        return cloneProjectSettings(inspect.globalValue);
+    }
+    if (target === ConfigurationTarget.Workspace) {
+        return cloneProjectSettings(inspect.workspaceValue);
+    }
+    return cloneProjectSettings(inspect.workspaceFolderValue);
+}
+
+function getDefinedProjectSettingsTargets(config: WorkspaceConfiguration): InlineScriptProjectSettingsTarget[] {
+    const inspect = config.inspect<PythonProjectSettings[]>('pythonProjects');
+    if (!inspect) {
+        return [ConfigurationTarget.Workspace];
+    }
+    return [
+        inspect.workspaceFolderValue !== undefined ? ConfigurationTarget.WorkspaceFolder : undefined,
+        inspect.workspaceValue !== undefined ? ConfigurationTarget.Workspace : undefined,
+        inspect.globalValue !== undefined ? ConfigurationTarget.Global : undefined,
+    ].filter((target): target is InlineScriptProjectSettingsTarget => target !== undefined);
+}
+
+function getInlineScriptProjectSettingPath(
+    project: PythonProject,
+    workspaceFolder: WorkspaceFolder,
+    target: InlineScriptProjectSettingsTarget,
+): string {
+    return target === ConfigurationTarget.Global
+        ? project.uri.fsPath
+        : path.relative(workspaceFolder.uri.fsPath, project.uri.fsPath).replace(/\\/g, '/') || '.';
+}
+
+async function writeProjectSettings(
+    config: WorkspaceConfiguration,
+    target: InlineScriptProjectSettingsTarget,
+    settings: readonly PythonProjectSettings[],
+): Promise<void> {
+    await config.update('pythonProjects', settings.length > 0 ? settings : undefined, target);
+}
+
+function updateManagedInlineScriptProjectSetting(
+    project: PythonProject,
+    updates: Partial<Pick<PythonProjectSettings, 'envManager' | 'packageManager'>>,
+): Promise<boolean> {
+    return enqueueInlineScriptProjectSettingsMutation(async () => {
+        const workspaceFolder = workspaceApis.getWorkspaceFolder(project.uri);
+        if (!workspaceFolder) {
+            return false;
+        }
+        const config = workspaceApis.getConfiguration('python-envs', workspaceFolder.uri);
+        for (const target of getDefinedProjectSettingsTargets(config)) {
+            const settings = getExplicitProjectSettings(config, target);
+            if (!settings) {
+                continue;
+            }
+            const index = settings.findIndex((setting) =>
+                matchesProjectSettingEdit(setting, { project }, workspaceFolder),
+            );
+            if (index < 0 || !getManagedInlineScriptProjectRegistration(settings[index])) {
+                continue;
+            }
+            settings[index] = { ...settings[index], ...updates };
+            delete settings[index]._inlineScriptRegistration;
+            await writeProjectSettings(config, target, settings);
+            return true;
+        }
+        return false;
+    });
+}
+
+export function registerInlineScriptPythonProjectSetting(
+    wm: PythonProjectManager,
+    project: PythonProject,
+): Promise<InlineScriptPythonProjectRegistration | undefined> {
+    return enqueueInlineScriptProjectSettingsMutation(async () => {
+        const workspaceFolder = workspaceApis.getWorkspaceFolder(project.uri);
+        if (!workspaceFolder) {
+            traceInfo(
+                `Unable to register inline-script project ${project.uri.fsPath} because it is outside an open workspace.`,
+            );
+            return undefined;
+        }
+
+        const config = workspaceApis.getConfiguration('python-envs', workspaceFolder.uri);
+        const target = getInlineScriptProjectSettingsTarget(config);
+        const settings = getExplicitProjectSettings(config, target) ?? [];
+        const index = settings.findIndex((setting) =>
+            matchesProjectSettingEdit(setting, { project }, workspaceFolder),
+        );
+        if (index >= 0) {
+            const marker = getManagedInlineScriptProjectRegistration(settings[index]);
+            if (marker) {
+                return { kind: marker.kind, changed: false, workspaceFolder, target };
+            }
+            settings[index]._inlineScriptRegistration = { kind: 'adopted' };
+            await writeProjectSettings(config, target, settings);
+            return { kind: 'adopted', changed: true, workspaceFolder, target };
+        }
+
+        settings.push({
+            path: getInlineScriptProjectSettingPath(project, workspaceFolder, target),
+            envManager: getDefaultEnvManagerSetting(wm, project.uri),
+            packageManager: getDefaultPkgManagerSetting(wm, project.uri),
+            workspace:
+                target === ConfigurationTarget.Workspace &&
+                (workspaceApis.getWorkspaceFolders()?.length ?? 0) > 1
+                    ? workspaceFolder.name
+                    : undefined,
+            _inlineScriptRegistration: { kind: 'created' },
+        });
+        await writeProjectSettings(config, target, settings);
+        return { kind: 'created', changed: true, workspaceFolder, target };
+    });
+}
+
+async function cleanupInlineScriptPythonProjectSetting(
+    project: PythonProject,
+    workspaceFolder: WorkspaceFolder,
+    target: InlineScriptProjectSettingsTarget,
+    expectedKind?: InlineScriptProjectRegistrationKind,
+): Promise<{ changed: boolean; removeProject: boolean }> {
+    const config = workspaceApis.getConfiguration('python-envs', workspaceFolder.uri);
+    const settings = getExplicitProjectSettings(config, target);
+    if (!settings) {
+        return { changed: false, removeProject: false };
+    }
+    const index = settings.findIndex((setting) =>
+        matchesProjectSettingEdit(setting, { project }, workspaceFolder),
+    );
+    const marker = index >= 0 ? getManagedInlineScriptProjectRegistration(settings[index]) : undefined;
+    if (!marker || (expectedKind && marker.kind !== expectedKind)) {
+        return { changed: false, removeProject: false };
+    }
+    if (marker.kind === 'created') {
+        settings.splice(index, 1);
+    } else {
+        delete settings[index]._inlineScriptRegistration;
+    }
+    await writeProjectSettings(config, target, settings);
+    return { changed: true, removeProject: marker.kind === 'created' };
+}
+
+export function rollbackInlineScriptPythonProjectSetting(
+    project: PythonProject,
+    registration: InlineScriptPythonProjectRegistration,
+): Promise<boolean> {
+    if (!registration.changed) {
+        return Promise.resolve(false);
+    }
+    return enqueueInlineScriptProjectSettingsMutation(async () =>
+        (
+            await cleanupInlineScriptPythonProjectSetting(
+            project,
+            registration.workspaceFolder,
+            registration.target,
+            registration.kind,
+            )
+        ).removeProject,
+    );
+}
+
+export function removeManagedInlineScriptPythonProjectSetting(project: PythonProject): Promise<boolean> {
+    return enqueueInlineScriptProjectSettingsMutation(async () => {
+        const workspaceFolder = workspaceApis.getWorkspaceFolder(project.uri);
+        if (!workspaceFolder) {
+            return false;
+        }
+        const config = workspaceApis.getConfiguration('python-envs', workspaceFolder.uri);
+        for (const target of getDefinedProjectSettingsTargets(config)) {
+            const result = await cleanupInlineScriptPythonProjectSetting(project, workspaceFolder, target);
+            if (result.changed) {
+                return result.removeProject;
+            }
+        }
+        return false;
+    });
+}
+
+export function removeInlineScriptPythonProjectSettings(
     currentProjects: readonly PythonProject[],
 ): Promise<PythonProject[]> {
-    const currentProjectsByUri = new Map(currentProjects.map((project) => [project.uri.toString(), project] as const));
-    const workspaceFolders = workspaceApis.getWorkspaceFolders() ?? [];
-    const globalConfig = workspaceApis.getConfiguration('python-envs', workspaceFolders[0]?.uri);
-    const globalValueOriginal = cloneProjectSettings(
-        globalConfig.inspect<PythonProjectSettings[]>('pythonProjects')?.globalValue,
-    );
-    const globalValueRemaining =
-        globalValueOriginal?.filter((projectSetting) => projectSetting.envManager !== INLINE_SCRIPT_MANAGER_ID) ?? [];
-    const promises: Thenable<void>[] = [];
-    if (globalValueOriginal !== undefined && globalValueRemaining.length !== globalValueOriginal.length) {
-        promises.push(
-            globalConfig.update(
-                'pythonProjects',
-                globalValueRemaining.length > 0 ? globalValueRemaining : undefined,
-                ConfigurationTarget.Global,
-            ),
+    return enqueueInlineScriptProjectSettingsMutation(async () => {
+        const workspaceFolders = workspaceApis.getWorkspaceFolders() ?? [];
+        const currentProjectsByPath = new Map(
+            currentProjects.map((project) => [normalizePath(project.uri.fsPath), project] as const),
         );
-    }
+        const createdProjectPaths = new Set<string>();
+        const remainingProjectPaths = new Set<string>();
 
-    const workspaceEntries: Array<readonly [WorkspaceFolder, EditProjectSettings[]]> = [];
-    for (const workspaceFolder of workspaceFolders) {
-        const edits: EditProjectSettings[] = getResolvedPythonProjectSettings(workspaceFolder)
-            .filter((resolvedSetting) =>
-                resolvedSetting.sources.some((source) => source.setting.envManager === INLINE_SCRIPT_MANAGER_ID),
-            )
-            .map((resolvedSetting) => ({
-                project:
-                    currentProjectsByUri.get(resolvedSetting.uri.toString()) ?? {
-                        name: path.basename(resolvedSetting.uri.fsPath) || resolvedSetting.effective.setting.path,
-                        uri: resolvedSetting.uri,
-                    },
-                envManager: INLINE_SCRIPT_MANAGER_ID,
-            }));
+        const cleanupTarget = async (
+            config: WorkspaceConfiguration,
+            target: InlineScriptProjectSettingsTarget,
+            workspaceFolder: WorkspaceFolder | undefined,
+        ) => {
+            const settings = getExplicitProjectSettings(config, target);
+            if (!settings) {
+                return;
+            }
+            let changed = false;
+            const remaining: PythonProjectSettings[] = [];
+            for (const setting of settings) {
+                const marker = getManagedInlineScriptProjectRegistration(setting);
+                if (!marker) {
+                    remaining.push(setting);
+                    const uri = workspaceFolder
+                        ? resolveProjectSettingUri(setting, workspaceFolder, workspaceFolders)
+                        : undefined;
+                    if (uri) {
+                        remainingProjectPaths.add(normalizePath(uri.fsPath));
+                    }
+                    continue;
+                }
+                changed = true;
+                if (marker.kind === 'adopted') {
+                    const restored = { ...setting };
+                    delete restored._inlineScriptRegistration;
+                    remaining.push(restored);
+                    const uri = workspaceFolder
+                        ? resolveProjectSettingUri(restored, workspaceFolder, workspaceFolders)
+                        : undefined;
+                    if (uri) {
+                        remainingProjectPaths.add(normalizePath(uri.fsPath));
+                    }
+                    continue;
+                }
+                const uri = workspaceFolder
+                    ? resolveProjectSettingUri(setting, workspaceFolder, workspaceFolders)
+                    : undefined;
+                if (uri) {
+                    createdProjectPaths.add(normalizePath(uri.fsPath));
+                }
+            }
+            if (changed) {
+                await writeProjectSettings(config, target, remaining);
+            }
+        };
 
-        if (edits.length > 0) {
-            workspaceEntries.push([workspaceFolder, edits]);
+        const firstWorkspace = workspaceFolders[0];
+        const sharedConfig = workspaceApis.getConfiguration('python-envs', firstWorkspace?.uri);
+        await cleanupTarget(sharedConfig, ConfigurationTarget.Global, firstWorkspace);
+        if (firstWorkspace) {
+            await cleanupTarget(sharedConfig, ConfigurationTarget.Workspace, firstWorkspace);
         }
-    }
-
-    if (workspaceEntries.length === 0) {
-        await Promise.all(promises);
-        return [];
-    }
-
-    const removedProjects = new Map<string, PythonProject>();
-    const folderRemainingSettings = new Map<string, PythonProjectSettings[]>();
-    const folderExistingSettings = new Map<string, PythonProjectSettings[]>();
-    let workspaceConfig: WorkspaceConfiguration | undefined;
-    let workspaceValueOriginal: PythonProjectSettings[] | undefined;
-
-    workspaceEntries.forEach(([workspaceFolder, edits]) => {
-        const config = workspaceApis.getConfiguration('python-envs', workspaceFolder.uri);
-        const projectsInspect = config.inspect<PythonProjectSettings[]>('pythonProjects');
-        workspaceConfig ??= config;
-        workspaceValueOriginal ??= cloneProjectSettings(projectsInspect?.workspaceValue);
-
-        const workspaceFolderOriginal = cloneProjectSettings(projectsInspect?.workspaceFolderValue) ?? [];
-        folderExistingSettings.set(workspaceFolder.uri.toString(), workspaceFolderOriginal);
-        const workspaceFolderRemaining = workspaceFolderOriginal.filter(
-            (projectSetting) => !edits.some((edit) => matchesProjectSettingEdit(projectSetting, edit, workspaceFolder)),
-        );
-        folderRemainingSettings.set(workspaceFolder.uri.toString(), workspaceFolderRemaining);
-
-        if (workspaceFolderRemaining.length !== workspaceFolderOriginal.length) {
-            promises.push(
-                config.update(
-                    'pythonProjects',
-                    workspaceFolderRemaining.length > 0 ? workspaceFolderRemaining : undefined,
-                    ConfigurationTarget.WorkspaceFolder,
-                ),
-            );
+        for (const workspaceFolder of workspaceFolders) {
+            const config = workspaceApis.getConfiguration('python-envs', workspaceFolder.uri);
+            await cleanupTarget(config, ConfigurationTarget.WorkspaceFolder, workspaceFolder);
         }
+
+        return Array.from(createdProjectPaths)
+            .filter((projectPath) => !remainingProjectPaths.has(projectPath))
+            .map((projectPath) => currentProjectsByPath.get(projectPath))
+            .filter((project): project is PythonProject => project !== undefined);
     });
-
-    const aggregatedEdits = workspaceEntries.flatMap(([workspaceFolder, edits]) =>
-        edits.map((edit) => ({ workspaceFolder, edit })),
-    );
-    const workspaceValueRemaining =
-        workspaceValueOriginal?.filter(
-            (projectSetting) =>
-                !aggregatedEdits.some(({ workspaceFolder, edit }) =>
-                    matchesProjectSettingEdit(projectSetting, edit, workspaceFolder),
-                ),
-        ) ?? [];
-
-    if (
-        workspaceConfig &&
-        workspaceValueOriginal !== undefined &&
-        workspaceValueRemaining.length !== workspaceValueOriginal.length
-    ) {
-        promises.push(
-            workspaceConfig.update(
-                'pythonProjects',
-                workspaceValueRemaining.length > 0 ? workspaceValueRemaining : undefined,
-                ConfigurationTarget.Workspace,
-            ),
-        );
-    }
-
-    workspaceEntries.forEach(([workspaceFolder, edits]) => {
-        const existingSettings = [
-            ...(globalValueOriginal ?? []),
-            ...(workspaceValueOriginal ?? []),
-            ...((folderExistingSettings.get(workspaceFolder.uri.toString()) ?? [])),
-        ];
-        const remainingSettings = [
-            ...globalValueRemaining,
-            ...workspaceValueRemaining,
-            ...((folderRemainingSettings.get(workspaceFolder.uri.toString()) ?? [])),
-        ];
-        edits.filter(
-            (edit) =>
-                existingSettings.some((projectSetting) => matchesProjectSettingEdit(projectSetting, edit, workspaceFolder)) &&
-                !hasProjectSetting(remainingSettings, edit.project, workspaceFolder),
-        ).forEach((edit) => {
-            removedProjects.set(edit.project.uri.toString(), edit.project);
-        });
-    });
-
-    await Promise.all(promises);
-
-    return Array.from(removedProjects.values())
-        .map((project) => currentProjectsByUri.get(project.uri.toString()))
-        .filter((project): project is PythonProject => project !== undefined);
 }
 
 export async function addPythonProjectSetting(edits: EditProjectSettings[]): Promise<void> {

--- a/src/internal.api.ts
+++ b/src/internal.api.ts
@@ -116,6 +116,7 @@ export interface EnvironmentManagers extends Disposable {
     packageManagers: InternalPackageManager[];
 
     clearCache(scope: EnvironmentManagerScope): Promise<void>;
+    clearInlineScriptCache(): Promise<void>;
 
     /**
      * Sets the environment for a scope.
@@ -460,11 +461,20 @@ export interface PythonProjectManager extends Disposable {
         uri: Uri,
         options?: { description?: string; tooltip?: string | MarkdownString; iconPath?: IconPath },
     ): PythonProject;
-    add(pyWorkspace: PythonProject | PythonProject[]): Promise<void>;
+    add(
+        pyWorkspace: PythonProject | PythonProject[],
+        options?: { persistSettings?: boolean },
+    ): Promise<void>;
     remove(pyWorkspace: PythonProject | PythonProject[]): void;
     getProjects(uris?: Uri[]): ReadonlyArray<PythonProject>;
     get(uri: Uri): PythonProject | undefined;
     onDidChangeProjects: Event<PythonProject[] | undefined>;
+}
+
+export type InlineScriptProjectRegistrationKind = 'created' | 'adopted';
+
+export interface InlineScriptProjectRegistrationMarker {
+    readonly kind: InlineScriptProjectRegistrationKind;
 }
 
 export interface PythonProjectSettings {
@@ -472,6 +482,7 @@ export interface PythonProjectSettings {
     envManager: string;
     packageManager: string;
     workspace?: string;
+    _inlineScriptRegistration?: InlineScriptProjectRegistrationMarker;
 }
 
 export class PythonEnvironmentImpl implements PythonEnvironment {

--- a/src/test/features/envCommands.unit.test.ts
+++ b/src/test/features/envCommands.unit.test.ts
@@ -238,120 +238,48 @@ suite('Clear Script Environment Cache Command Tests', () => {
     });
 
     test('cancels without clearing the cache or touching project settings', async () => {
-        const clearCache = sinon.stub().resolves();
+        const clearInlineScriptCache = sinon.stub().resolves();
         const envManagers = {
             getEnvironmentManager: sinon.stub().withArgs(INLINE_SCRIPT_MANAGER_ID).returns({
                 supportsClearCache: () => true,
-                clearCache,
             }),
+            clearInlineScriptCache,
         } as unknown as EnvironmentManagers;
-        const projectManager = {
-            getProjects: sinon.stub().returns([]),
-            remove: sinon.stub(),
-        } as unknown as PythonProjectManager;
         sinon.stub(windowApis, 'showWarningMessage').resolves(undefined);
-        const removeInlineSettings = sinon.stub(settingHelpers, 'removeInlineScriptPythonProjectSettings').resolves([]);
 
-        await clearScriptEnvironmentCacheCommand(envManagers, projectManager);
+        await clearScriptEnvironmentCacheCommand(envManagers);
 
-        sinon.assert.notCalled(clearCache);
-        sinon.assert.notCalled(removeInlineSettings);
-        sinon.assert.notCalled(projectManager.remove as sinon.SinonStub);
+        sinon.assert.notCalled(clearInlineScriptCache);
     });
 
-    test('clears cache before inline settings cleanup and unloads removed projects', async () => {
-        const calls: string[] = [];
-        const selectionEvents: string[] = [];
-        let associationPresent = true;
-        const inlineProject: PythonProject = {
-            uri: Uri.file('/workspace/script.py'),
-            name: 'script.py',
-        };
-        const clearCache = sinon.stub().callsFake(async () => {
-            calls.push('clearCache');
-            associationPresent = false;
-            selectionEvents.push('cleared');
-        });
+    test('delegates coordinated inline cache and project cleanup', async () => {
+        const clearInlineScriptCache = sinon.stub().resolves();
         const envManagers = {
             getEnvironmentManager: sinon.stub().withArgs(INLINE_SCRIPT_MANAGER_ID).returns({
                 supportsClearCache: () => true,
-                clearCache,
             }),
+            clearInlineScriptCache,
         } as unknown as EnvironmentManagers;
-        const projectManager = {
-            getProjects: sinon.stub().callsFake(() => {
-                calls.push('getProjects');
-                return [inlineProject];
-            }),
-            remove: sinon.stub().callsFake(() => {
-                calls.push('removeProjects');
-            }),
-        } as unknown as PythonProjectManager;
         sinon.stub(windowApis, 'showWarningMessage').resolves('Clear Cache' as never);
-        const removeInlineSettings = sinon
-            .stub(settingHelpers, 'removeInlineScriptPythonProjectSettings')
-            .callsFake(async (projects) => {
-                calls.push('removeInlineSettings');
-                assert.deepStrictEqual(projects, [inlineProject]);
-                assert.strictEqual(associationPresent, false);
-                assert.deepStrictEqual(selectionEvents, ['cleared']);
-                return [inlineProject];
-            });
 
-        await clearScriptEnvironmentCacheCommand(envManagers, projectManager);
+        await clearScriptEnvironmentCacheCommand(envManagers);
 
-        sinon.assert.calledOnce(clearCache);
-        sinon.assert.calledOnce(removeInlineSettings);
-        sinon.assert.calledOnceWithExactly(projectManager.remove as sinon.SinonStub, [inlineProject]);
-        assert.deepStrictEqual(calls, ['clearCache', 'getProjects', 'removeInlineSettings', 'removeProjects']);
+        sinon.assert.calledOnce(clearInlineScriptCache);
     });
 
-    test('keeps loaded projects when inline settings cleanup leaves them configured', async () => {
-        const inlineProject: PythonProject = {
-            uri: Uri.file('/workspace/runner'),
-            name: 'runner',
-        };
-        const clearCache = sinon.stub().resolves();
+    test('propagates coordinated cleanup failures', async () => {
+        const clearInlineScriptCache = sinon.stub().rejects(new Error('one cache entry could not be deleted'));
         const envManagers = {
             getEnvironmentManager: sinon.stub().withArgs(INLINE_SCRIPT_MANAGER_ID).returns({
                 supportsClearCache: () => true,
-                clearCache,
             }),
+            clearInlineScriptCache,
         } as unknown as EnvironmentManagers;
-        const projectManager = {
-            getProjects: sinon.stub().returns([inlineProject]),
-            remove: sinon.stub(),
-        } as unknown as PythonProjectManager;
         sinon.stub(windowApis, 'showWarningMessage').resolves('Clear Cache' as never);
-        const removeInlineSettings = sinon.stub(settingHelpers, 'removeInlineScriptPythonProjectSettings').resolves([]);
 
-        await clearScriptEnvironmentCacheCommand(envManagers, projectManager);
+        await assert.rejects(clearScriptEnvironmentCacheCommand(envManagers), /could not be deleted/);
 
-        sinon.assert.calledOnce(clearCache);
-        sinon.assert.calledOnceWithExactly(removeInlineSettings, [inlineProject]);
-        sinon.assert.notCalled(projectManager.remove as sinon.SinonStub);
-    });
-
-    test('preserves project settings when cache cleanup reports a partial failure', async () => {
-        const clearCache = sinon.stub().rejects(new Error('one cache entry could not be deleted'));
-        const envManagers = {
-            getEnvironmentManager: sinon.stub().withArgs(INLINE_SCRIPT_MANAGER_ID).returns({
-                supportsClearCache: () => true,
-                clearCache,
-            }),
-        } as unknown as EnvironmentManagers;
-        const projectManager = {
-            getProjects: sinon.stub().returns([]),
-            remove: sinon.stub(),
-        } as unknown as PythonProjectManager;
-        sinon.stub(windowApis, 'showWarningMessage').resolves('Clear Cache' as never);
-        const removeInlineSettings = sinon.stub(settingHelpers, 'removeInlineScriptPythonProjectSettings').resolves([]);
-
-        await assert.rejects(clearScriptEnvironmentCacheCommand(envManagers, projectManager), /could not be deleted/);
-
-        sinon.assert.calledOnce(clearCache);
-        sinon.assert.notCalled(removeInlineSettings);
-        sinon.assert.notCalled(projectManager.remove as sinon.SinonStub);
+        sinon.assert.calledOnce(clearInlineScriptCache);
     });
 });
 

--- a/src/test/features/envManagers.lastKnown.unit.test.ts
+++ b/src/test/features/envManagers.lastKnown.unit.test.ts
@@ -12,7 +12,7 @@ import { Extension } from 'vscode';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as typeMoq from 'typemoq';
-import { EventEmitter, Uri } from 'vscode';
+import { ConfigurationTarget, EventEmitter, Uri, WorkspaceFolder } from 'vscode';
 import {
     DidChangeEnvironmentEventArgs,
     DidChangeEnvironmentsEventArgs,
@@ -94,6 +94,7 @@ suite('PythonEnvironmentManagers getLastKnownEnvironment', () => {
         getImpl: (scope: GetEnvironmentScope) => Promise<PythonEnvironment | undefined>,
         setImpl: EnvironmentManager['set'] = async () => undefined,
         name = 'test-env-mgr',
+        clearCache?: () => Promise<void>,
     ): string {
         const onDidChangeEnvironment = new EventEmitter<DidChangeEnvironmentEventArgs>();
         const onDidChangeEnvironments = new EventEmitter<DidChangeEnvironmentsEventArgs>();
@@ -108,6 +109,7 @@ suite('PythonEnvironmentManagers getLastKnownEnvironment', () => {
             set: setImpl,
             resolve: async () => undefined,
             refresh: async () => undefined,
+            clearCache,
         } as unknown as EnvironmentManager;
 
         const managerIndex = envManagers.managers.length;
@@ -267,7 +269,7 @@ suite('PythonEnvironmentManagers getLastKnownEnvironment', () => {
         const scope = Uri.file('/workspace/script.py');
         const project = { name: 'script.py', uri: scope };
         projectsByUri.set(scope.toString(), project);
-        const managerId = registerManager(async () => undefined, async () => undefined, 'inline-script');
+        const managerId = registerManager(async () => undefined, async () => undefined, 'venv');
         const first = { ...makeEnv('first'), envId: { id: 'first', managerId } };
         const second = { ...makeEnv('second'), envId: { id: 'second', managerId } };
         stubPackageManager();
@@ -287,8 +289,6 @@ suite('PythonEnvironmentManagers getLastKnownEnvironment', () => {
         settings.onSecondCall().resolves();
         const events: DidChangeEnvironmentEventArgs[] = [];
         envManagers.onDidChangeActiveEnvironment((event) => events.push(event));
-        markInlineScript(scope);
-
         const olderSelection = envManagers.setEnvironment(scope, first);
         await firstWriteStarted;
         await envManagers.setEnvironment(scope, second);
@@ -629,6 +629,30 @@ suite('PythonEnvironmentManagers getLastKnownEnvironment', () => {
         assert.strictEqual(envManagers.getEnvironmentManager(script)?.id, selectedId);
     });
 
+    test('uses a managed exact project as fallback without blocking validated inline routing', async () => {
+        const script = Uri.file('/workspace/script.py');
+        projectsByUri.set(script.toString(), { name: 'script.py', uri: script });
+        const selectedId = registerManager(async () => makeEnv('selected'), async () => undefined, 'venv');
+        let inlineEnvironment: PythonEnvironment;
+        const inlineId = registerManager(async () => inlineEnvironment, async () => undefined, 'inline-script');
+        inlineEnvironment = { ...makeEnv('inline'), envId: { id: 'inline', managerId: inlineId } };
+        defaultManagerId = selectedId;
+        exactManagerSettings.set(script.toString(), selectedId);
+        sinon.stub(settingHelpers, 'getExactPythonProjectSetting').returns({
+            path: 'script.py',
+            envManager: selectedId,
+            packageManager: 'ms-python.python:pip',
+            _inlineScriptRegistration: { kind: 'created' },
+        });
+        markInlineScript(script);
+
+        await envManagers.setEnvironment(script, inlineEnvironment, false);
+        assert.strictEqual(envManagers.getEnvironmentManager(script)?.id, inlineId);
+
+        routingRegistry.clearMetadata(script);
+        assert.strictEqual(envManagers.getEnvironmentManager(script)?.id, selectedId);
+    });
+
     test('clears active inline routing after selecting a different manager', async () => {
         const script = Uri.file('/workspace/project/script.py');
         projectsByUri.set(script.toString(), { name: 'project', uri: Uri.file('/workspace/project') });
@@ -958,63 +982,180 @@ suite('PythonEnvironmentManagers getLastKnownEnvironment', () => {
         assert.strictEqual(envManagers.getEnvironmentManager(script)?.id, defaultId);
     });
 
-    test('does not persist an inline-script manager for the containing project', async () => {
+    test('registers an exact script project before binding an inline environment', async () => {
         const script = Uri.file('/workspace/project/script.py');
         const containingProject = { name: 'project', uri: Uri.file('/workspace/project') };
-        projectsByUri.set(script.toString(), containingProject);
-        const managerId = registerManager(async () => undefined, async () => undefined, 'inline-script');
-        const environment = { ...makeEnv('inline'), envId: { id: 'inline', managerId } };
-        stubPackageManager();
-        const settings = sinon.stub(settingHelpers, 'setAllManagerSettings').resolves();
-
-        await envManagers.setEnvironment(script, environment);
-
-        assert.strictEqual(settings.callCount, 0);
-    });
-
-    test('persists an inline-script manager when the script is its own project', async () => {
-        const script = Uri.file('/workspace/script.py');
         const scriptProject = { name: 'script.py', uri: script };
-        projectsByUri.set(script.toString(), scriptProject);
-        const managerId = registerManager(async () => undefined, async () => undefined, 'inline-script');
+        projectsByUri.set(script.toString(), containingProject);
+        const calls: string[] = [];
+        const managerId = registerManager(
+            async () => undefined,
+            async () => {
+                calls.push('set');
+                assert.strictEqual(projectsByUri.get(script.toString())?.uri.toString(), script.toString());
+            },
+            'inline-script',
+        );
         const environment = { ...makeEnv('inline'), envId: { id: 'inline', managerId } };
-        stubPackageManager();
+        const workspaceFolder: WorkspaceFolder = {
+            uri: Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        projectManager
+            .setup((pm) => pm.create(typeMoq.It.isAny(), typeMoq.It.isAny()))
+            .returns(() => scriptProject);
+        projectManager
+            .setup((pm) => pm.add(typeMoq.It.isAny(), typeMoq.It.isAny()))
+            .returns(async (project) => {
+                calls.push('add');
+                const added = Array.isArray(project) ? project : [project];
+                added.forEach((entry) => projectsByUri.set(entry.uri.toString(), entry));
+            });
+        const registerProject = sinon
+            .stub(settingHelpers, 'registerInlineScriptPythonProjectSetting')
+            .callsFake(async () => {
+                calls.push('register');
+                return {
+                    kind: 'created',
+                    changed: true,
+                    workspaceFolder,
+                    target: ConfigurationTarget.Workspace,
+                };
+            });
         const settings = sinon.stub(settingHelpers, 'setAllManagerSettings').resolves();
 
         await envManagers.setEnvironment(script, environment);
 
-        sinon.assert.calledOnce(settings);
-        assert.deepStrictEqual(settings.firstCall.args[0], [
-            {
-                project: scriptProject,
-                envManager: managerId,
-                packageManager: 'ms-python.python:pip',
-            },
-        ]);
+        sinon.assert.calledOnceWithExactly(registerProject, projectManager.object, scriptProject);
+        projectManager.verify(
+            (pm) => pm.add(scriptProject, { persistSettings: false }),
+            typeMoq.Times.once(),
+        );
+        assert.strictEqual(settings.callCount, 0);
+        assert.deepStrictEqual(calls, ['register', 'add', 'set']);
     });
 
-    test('persists batch inline settings only for scripts registered as exact projects', async () => {
-        const exactScript = Uri.file('/workspace/exact.py');
-        const nestedScript = Uri.file('/workspace/project/nested.py');
-        const looseScript = Uri.file('/outside/loose.py');
-        const exactProject = { name: 'exact.py', uri: exactScript };
+    test('rolls back a newly registered script project when inline binding fails', async () => {
+        const script = Uri.file('/workspace/project/script.py');
         const containingProject = { name: 'project', uri: Uri.file('/workspace/project') };
-        projectsByUri.set(exactScript.toString(), exactProject);
-        projectsByUri.set(nestedScript.toString(), containingProject);
-        const managerId = registerManager(async () => undefined, async () => undefined, 'inline-script');
+        const scriptProject = { name: 'script.py', uri: script };
+        projectsByUri.set(script.toString(), containingProject);
+        const managerId = registerManager(
+            async () => undefined,
+            async () => {
+                throw new Error('binding failed');
+            },
+            'inline-script',
+        );
         const environment = { ...makeEnv('inline'), envId: { id: 'inline', managerId } };
+        const workspaceFolder: WorkspaceFolder = {
+            uri: Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        projectManager
+            .setup((pm) => pm.create(typeMoq.It.isAny(), typeMoq.It.isAny()))
+            .returns(() => scriptProject);
+        projectManager
+            .setup((pm) => pm.add(typeMoq.It.isAny(), typeMoq.It.isAny()))
+            .returns(async (project) => {
+                const added = Array.isArray(project) ? project : [project];
+                added.forEach((entry) => projectsByUri.set(entry.uri.toString(), entry));
+            });
+        projectManager
+            .setup((pm) => pm.remove(typeMoq.It.isAny()))
+            .callback((project) => {
+                const removed = Array.isArray(project) ? project : [project];
+                removed.forEach((entry) => projectsByUri.delete(entry.uri.toString()));
+            });
+        const registration = {
+            kind: 'created' as const,
+            changed: true,
+            workspaceFolder,
+            target: ConfigurationTarget.Workspace,
+        };
+        sinon.stub(settingHelpers, 'registerInlineScriptPythonProjectSetting').resolves(registration);
+        const rollback = sinon.stub(settingHelpers, 'rollbackInlineScriptPythonProjectSetting').resolves(true);
+
+        await assert.rejects(envManagers.setEnvironment(script, environment), /binding failed/);
+
+        sinon.assert.calledOnceWithExactly(rollback, scriptProject, registration);
+        projectManager.verify((pm) => pm.remove(scriptProject), typeMoq.Times.once());
+        assert.strictEqual(projectsByUri.has(script.toString()), false);
+    });
+
+    test('registers every batch script before binding the inline environment', async () => {
+        const firstScript = Uri.file('/workspace/project/first.py');
+        const secondScript = Uri.file('/workspace/project/second.py');
+        const containingProject = { name: 'project', uri: Uri.file('/workspace/project') };
+        projectsByUri.set(firstScript.toString(), containingProject);
+        projectsByUri.set(secondScript.toString(), containingProject);
+        const managerId = registerManager(
+            async () => undefined,
+            async () => {
+                assert.strictEqual(projectsByUri.get(firstScript.toString())?.uri.toString(), firstScript.toString());
+                assert.strictEqual(projectsByUri.get(secondScript.toString())?.uri.toString(), secondScript.toString());
+            },
+            'inline-script',
+        );
+        const environment = { ...makeEnv('inline'), envId: { id: 'inline', managerId } };
+        const workspaceFolder: WorkspaceFolder = {
+            uri: Uri.file('/workspace'),
+            name: 'workspace',
+            index: 0,
+        };
+        projectManager
+            .setup((pm) => pm.create(typeMoq.It.isAny(), typeMoq.It.isAny()))
+            .returns((name, uri) => ({ name, uri }));
+        projectManager
+            .setup((pm) => pm.add(typeMoq.It.isAny(), typeMoq.It.isAny()))
+            .returns(async (project) => {
+                const added = Array.isArray(project) ? project : [project];
+                added.forEach((entry) => projectsByUri.set(entry.uri.toString(), entry));
+            });
+        const registerProject = sinon
+            .stub(settingHelpers, 'registerInlineScriptPythonProjectSetting')
+            .callsFake(async () => ({
+                kind: 'created',
+                changed: true,
+                workspaceFolder,
+                target: ConfigurationTarget.Workspace,
+            }));
         const settings = sinon.stub(settingHelpers, 'setAllManagerSettings').resolves();
 
-        await envManagers.setEnvironments([exactScript, nestedScript, looseScript], environment);
+        await envManagers.setEnvironments([firstScript, secondScript], environment);
 
-        sinon.assert.calledOnce(settings);
-        assert.deepStrictEqual(settings.firstCall.args[0], [
-            {
-                project: exactProject,
-                envManager: managerId,
-                packageManager: 'ms-python.python:pip',
+        sinon.assert.callCount(registerProject, 2);
+        sinon.assert.notCalled(settings);
+    });
+
+    test('serializes inline cache clearing with managed project cleanup', async () => {
+        const project = { name: 'script.py', uri: Uri.file('/workspace/script.py') };
+        const calls: string[] = [];
+        registerManager(
+            async () => undefined,
+            async () => undefined,
+            'inline-script',
+            async () => {
+                calls.push('clearCache');
             },
-        ]);
+        );
+        projectManager.setup((pm) => pm.getProjects()).returns(() => [project]);
+        projectManager
+            .setup((pm) => pm.remove(typeMoq.It.isAny()))
+            .callback(() => calls.push('removeProject'));
+        sinon
+            .stub(settingHelpers, 'removeInlineScriptPythonProjectSettings')
+            .callsFake(async (projects) => {
+                calls.push('cleanupSettings');
+                assert.deepStrictEqual(projects, [project]);
+                return [project];
+            });
+
+        await envManagers.clearInlineScriptCache();
+
+        assert.deepStrictEqual(calls, ['clearCache', 'cleanupSettings', 'removeProject']);
     });
 
     test('retains an earlier successful refresh when a later refresh fails', async () => {

--- a/src/test/features/settings/settingHelpers.unit.test.ts
+++ b/src/test/features/settings/settingHelpers.unit.test.ts
@@ -9,14 +9,18 @@ import * as sender from '../../../common/telemetry/sender';
 import * as workspaceApis from '../../../common/workspace.apis';
 import {
     addPythonProjectSetting,
+    getExactPythonProjectSetting,
     migrateGlobalDefaultEnvManagerSetting,
+    registerInlineScriptPythonProjectSetting,
     removeInlineScriptPythonProjectSettings,
+    removeManagedInlineScriptPythonProjectSetting,
     removePythonProjectSetting,
+    rollbackInlineScriptPythonProjectSetting,
     setAllManagerSettings,
     setEnvironmentManager,
     setPackageManager,
 } from '../../../features/settings/settingHelpers';
-import { PythonProjectSettings, PythonProjectsImpl } from '../../../internal.api';
+import { PythonProjectManager, PythonProjectSettings, PythonProjectsImpl } from '../../../internal.api';
 import { MockWorkspaceConfiguration } from '../../mocks/mockWorkspaceConfig';
 
 /**
@@ -694,6 +698,16 @@ suite('Setting Helpers - Project Removal', () => {
         return (settings ?? []).map((setting) => ({ ...setting }));
     }
 
+    function createdInlineSetting(pathValue: string, workspace?: string): PythonProjectSettings {
+        return {
+            path: pathValue,
+            envManager: INLINE_MANAGER_ID,
+            packageManager: PIP_MANAGER_ID,
+            workspace,
+            _inlineScriptRegistration: { kind: 'created' },
+        };
+    }
+
     function createSharedWorkspaceConfigs(options: {
         workspaceValue: PythonProjectSettings[];
         firstWorkspaceFolderValue?: PythonProjectSettings[];
@@ -747,6 +761,35 @@ suite('Setting Helpers - Project Removal', () => {
         };
     }
 
+    test('exact project lookup respects the workspace discriminator in multi-root settings', () => {
+        const project = new PythonProjectsImpl(
+            'script.py',
+            Uri.file(path.join(secondWorkspaceUri.fsPath, 'script.py')),
+        );
+        const config = createProjectConfig({
+            workspaceName: secondWorkspace.name,
+            workspaceValue: [
+                createdInlineSetting('script.py', firstWorkspace.name),
+                {
+                    path: 'script.py',
+                    envManager: VENV_MANAGER_ID,
+                    packageManager: PIP_MANAGER_ID,
+                    workspace: secondWorkspace.name,
+                },
+            ],
+        });
+        sinon.stub(workspaceApis, 'getWorkspaceFolder').returns(secondWorkspace);
+        sinon.stub(workspaceApis, 'getConfiguration').returns(config);
+        const projectManager = {
+            get: () => project,
+        } as unknown as PythonProjectManager;
+
+        assert.strictEqual(
+            getExactPythonProjectSetting(projectManager, project.uri)?.workspace,
+            secondWorkspace.name,
+        );
+    });
+
     suite('removePythonProjectSetting (bde7cf8-equivalent generic behavior)', () => {
         test('rewrites the merged effective array back to workspace scope', async () => {
             const project = new PythonProjectsImpl('script.py', Uri.file(path.join(firstWorkspacePath, 'script.py')));
@@ -799,12 +842,187 @@ suite('Setting Helpers - Project Removal', () => {
         });
     });
 
+    suite('inline-script project registration', () => {
+        function createStatefulWorkspaceConfig(
+            initial: PythonProjectSettings[],
+            expectedTarget: ConfigurationTarget.Workspace | ConfigurationTarget.WorkspaceFolder =
+                ConfigurationTarget.Workspace,
+        ) {
+            let workspaceValue = cloneSettings(initial);
+            const config = new MockWorkspaceConfiguration();
+            (config as any).get = <T>(key: string, defaultValue?: T): T | undefined =>
+                key === 'pythonProjects' ? (cloneSettings(workspaceValue) as unknown as T) : defaultValue;
+            (config as any).inspect = (key: string) =>
+                key === 'pythonProjects'
+                    ? {
+                          globalValue: undefined,
+                          workspaceValue:
+                              expectedTarget === ConfigurationTarget.Workspace
+                                  ? cloneSettings(workspaceValue)
+                                  : undefined,
+                          workspaceFolderValue:
+                              expectedTarget === ConfigurationTarget.WorkspaceFolder
+                                  ? cloneSettings(workspaceValue)
+                                  : undefined,
+                      }
+                    : undefined;
+            config.update = (
+                _section: string,
+                value: unknown,
+                configurationTarget?: boolean | ConfigurationTarget,
+            ): Promise<void> => {
+                assert.strictEqual(configurationTarget, expectedTarget);
+                workspaceValue = cloneSettings(value as PythonProjectSettings[] | undefined);
+                return Promise.resolve();
+            };
+            return { config, getWorkspaceValue: () => cloneSettings(workspaceValue) };
+        }
+
+        function createProjectManager(project: PythonProjectsImpl): PythonProjectManager {
+            const containingProject = new PythonProjectsImpl(firstWorkspace.name, firstWorkspace.uri);
+            return {
+                get: () => containingProject,
+                getProjects: () => [containingProject, project],
+            } as unknown as PythonProjectManager;
+        }
+
+        test('creates a marked exact project setting and rolls it back on setup failure', async () => {
+            const project = new PythonProjectsImpl(
+                'script.py',
+                Uri.file(path.join(firstWorkspacePath, 'script.py')),
+            );
+            const { config, getWorkspaceValue } = createStatefulWorkspaceConfig([]);
+            sinon.stub(workspaceApis, 'getWorkspaceFolders').returns([firstWorkspace]);
+            sinon.stub(workspaceApis, 'getWorkspaceFolder').returns(firstWorkspace);
+            sinon.stub(workspaceApis, 'getWorkspaceFile').returns(undefined);
+            sinon.stub(workspaceApis, 'getConfiguration').returns(config);
+
+            const registration = await registerInlineScriptPythonProjectSetting(
+                createProjectManager(project),
+                project,
+            );
+
+            assert.deepStrictEqual(registration, {
+                kind: 'created',
+                changed: true,
+                workspaceFolder: firstWorkspace,
+                target: ConfigurationTarget.Workspace,
+            });
+            assert.deepStrictEqual(getWorkspaceValue(), [
+                {
+                    path: 'script.py',
+                    envManager: VENV_MANAGER_ID,
+                    packageManager: PIP_MANAGER_ID,
+                    workspace: undefined,
+                    _inlineScriptRegistration: { kind: 'created' },
+                },
+            ]);
+
+            assert.strictEqual(
+                await rollbackInlineScriptPythonProjectSetting(project, registration!),
+                true,
+            );
+            assert.deepStrictEqual(getWorkspaceValue(), []);
+        });
+
+        test('temporarily marks an existing exact project and restores it without removing the project', async () => {
+            const project = new PythonProjectsImpl(
+                'script.py',
+                Uri.file(path.join(firstWorkspacePath, 'script.py')),
+            );
+            const existing = {
+                path: 'script.py',
+                envManager: VENV_MANAGER_ID,
+                packageManager: PIP_MANAGER_ID,
+            };
+            const { config, getWorkspaceValue } = createStatefulWorkspaceConfig([existing]);
+            sinon.stub(workspaceApis, 'getWorkspaceFolders').returns([firstWorkspace]);
+            sinon.stub(workspaceApis, 'getWorkspaceFolder').returns(firstWorkspace);
+            sinon.stub(workspaceApis, 'getConfiguration').returns(config);
+
+            const registration = await registerInlineScriptPythonProjectSetting(
+                createProjectManager(project),
+                project,
+            );
+
+            assert.strictEqual(registration?.kind, 'adopted');
+            assert.deepStrictEqual(getWorkspaceValue(), [
+                { ...existing, _inlineScriptRegistration: { kind: 'adopted' } },
+            ]);
+            assert.strictEqual(await removeManagedInlineScriptPythonProjectSetting(project), false);
+            assert.deepStrictEqual(getWorkspaceValue(), [existing]);
+        });
+
+        test('updates only the matching managed script when roots share the same relative path', async () => {
+            const project = new PythonProjectsImpl(
+                'script.py',
+                Uri.file(path.join(secondWorkspaceUri.fsPath, 'script.py')),
+            );
+            const firstSetting = createdInlineSetting('script.py', firstWorkspace.name);
+            const secondSetting = createdInlineSetting('script.py', secondWorkspace.name);
+            const { config, getWorkspaceValue } = createStatefulWorkspaceConfig([
+                firstSetting,
+                secondSetting,
+            ]);
+            sinon.stub(workspaceApis, 'getWorkspaceFolders').returns([firstWorkspace, secondWorkspace]);
+            sinon.stub(workspaceApis, 'getWorkspaceFolder').returns(secondWorkspace);
+            sinon.stub(workspaceApis, 'getConfiguration').returns(config);
+
+            await setAllManagerSettings([
+                {
+                    project,
+                    envManager: 'ms-python.python:conda',
+                    packageManager: PIP_MANAGER_ID,
+                },
+            ]);
+
+            assert.deepStrictEqual(getWorkspaceValue(), [
+                firstSetting,
+                {
+                    path: 'script.py',
+                    envManager: 'ms-python.python:conda',
+                    packageManager: PIP_MANAGER_ID,
+                    workspace: secondWorkspace.name,
+                },
+            ]);
+        });
+
+        test('updates a workspace-folder-owned managed script at its owning target', async () => {
+            const project = new PythonProjectsImpl(
+                'script.py',
+                Uri.file(path.join(firstWorkspacePath, 'script.py')),
+            );
+            const { config, getWorkspaceValue } = createStatefulWorkspaceConfig(
+                [createdInlineSetting('script.py')],
+                ConfigurationTarget.WorkspaceFolder,
+            );
+            sinon.stub(workspaceApis, 'getWorkspaceFolder').returns(firstWorkspace);
+            sinon.stub(workspaceApis, 'getConfiguration').returns(config);
+
+            await setEnvironmentManager([
+                {
+                    project,
+                    envManager: 'ms-python.python:conda',
+                },
+            ]);
+
+            assert.deepStrictEqual(getWorkspaceValue(), [
+                {
+                    path: 'script.py',
+                    envManager: 'ms-python.python:conda',
+                    packageManager: PIP_MANAGER_ID,
+                    workspace: undefined,
+                },
+            ]);
+        });
+    });
+
     suite('removeInlineScriptPythonProjectSettings', () => {
         test('removes global inline entries when no workspace folders are open', async () => {
             const config = createProjectConfig({
                 workspaceName: 'global',
                 globalValue: [
-                    { path: 'script.py', envManager: INLINE_MANAGER_ID, packageManager: PIP_MANAGER_ID },
+                    createdInlineSetting('script.py'),
                     { path: 'keep.py', envManager: VENV_MANAGER_ID, packageManager: PIP_MANAGER_ID },
                 ],
             });
@@ -833,9 +1051,9 @@ suite('Setting Helpers - Project Removal', () => {
             const config = createProjectConfig({
                 workspaceName: firstWorkspace.name,
                 workspaceValue: [
-                    { path: 'script.py', envManager: INLINE_MANAGER_ID, packageManager: PIP_MANAGER_ID },
+                    createdInlineSetting('script.py'),
                     { path: 'script.py', envManager: VENV_MANAGER_ID, packageManager: PIP_MANAGER_ID },
-                    { path: 'other.py', envManager: INLINE_MANAGER_ID, packageManager: PIP_MANAGER_ID },
+                    createdInlineSetting('other.py'),
                 ],
             });
             sinon.stub(workspaceApis, 'getWorkspaceFolders').returns([firstWorkspace]);
@@ -862,7 +1080,7 @@ suite('Setting Helpers - Project Removal', () => {
             const config = createProjectConfig({
                 workspaceName: firstWorkspace.name,
                 workspaceValue: [
-                    { path: 'runner', envManager: INLINE_MANAGER_ID, packageManager: PIP_MANAGER_ID },
+                    createdInlineSetting('runner'),
                     { path: 'keep', envManager: VENV_MANAGER_ID, packageManager: PIP_MANAGER_ID },
                 ],
             });
@@ -887,7 +1105,7 @@ suite('Setting Helpers - Project Removal', () => {
             const firstConfig = createProjectConfig({
                 workspaceName: firstWorkspace.name,
                 workspaceFolderValue: [
-                    { path: 'script.py', envManager: INLINE_MANAGER_ID, packageManager: PIP_MANAGER_ID },
+                    createdInlineSetting('script.py'),
                 ],
             });
             const secondConfig = createProjectConfig({
@@ -920,12 +1138,7 @@ suite('Setting Helpers - Project Removal', () => {
             const config = createProjectConfig({
                 workspaceName: firstWorkspace.name,
                 workspaceValue: [
-                    {
-                        path: 'script.py',
-                        envManager: INLINE_MANAGER_ID,
-                        packageManager: PIP_MANAGER_ID,
-                        workspace: firstWorkspace.name,
-                    },
+                    createdInlineSetting('script.py', firstWorkspace.name),
                 ],
                 workspaceFolderValue: [
                     { path: 'script.py', envManager: VENV_MANAGER_ID, packageManager: PIP_MANAGER_ID },
@@ -950,18 +1163,8 @@ suite('Setting Helpers - Project Removal', () => {
             const secondProject = new PythonProjectsImpl('second', Uri.file(path.join(secondWorkspaceUri.fsPath, 'second')));
             const { firstConfig, secondConfig, getWorkspaceValue } = createSharedWorkspaceConfigs({
                 workspaceValue: [
-                    {
-                        path: 'first',
-                        envManager: INLINE_MANAGER_ID,
-                        packageManager: PIP_MANAGER_ID,
-                        workspace: firstWorkspace.name,
-                    },
-                    {
-                        path: 'second',
-                        envManager: INLINE_MANAGER_ID,
-                        packageManager: PIP_MANAGER_ID,
-                        workspace: secondWorkspace.name,
-                    },
+                    createdInlineSetting('first', firstWorkspace.name),
+                    createdInlineSetting('second', secondWorkspace.name),
                 ],
             });
             sinon.stub(workspaceApis, 'getWorkspaceFolders').returns([firstWorkspace, secondWorkspace]);
@@ -995,18 +1198,8 @@ suite('Setting Helpers - Project Removal', () => {
             );
             const { firstConfig, secondConfig, getWorkspaceValue } = createSharedWorkspaceConfigs({
                 workspaceValue: [
-                    {
-                        path: 'first',
-                        envManager: INLINE_MANAGER_ID,
-                        packageManager: PIP_MANAGER_ID,
-                        workspace: firstWorkspace.name,
-                    },
-                    {
-                        path: 'second',
-                        envManager: INLINE_MANAGER_ID,
-                        packageManager: PIP_MANAGER_ID,
-                        workspace: secondWorkspace.name,
-                    },
+                    createdInlineSetting('first', firstWorkspace.name),
+                    createdInlineSetting('second', secondWorkspace.name),
                     {
                         path: 'keep',
                         envManager: VENV_MANAGER_ID,
@@ -1055,7 +1248,7 @@ suite('Setting Helpers - Project Removal', () => {
             const firstConfig = createProjectConfig({
                 workspaceName: firstWorkspace.name,
                 workspaceValue: [
-                    { path: 'script.py', envManager: INLINE_MANAGER_ID, packageManager: PIP_MANAGER_ID },
+                    createdInlineSetting('script.py'),
                 ],
                 workspaceFolderValue: [
                     { path: 'keep-folder.py', envManager: VENV_MANAGER_ID, packageManager: PIP_MANAGER_ID },
@@ -1064,7 +1257,7 @@ suite('Setting Helpers - Project Removal', () => {
             const secondConfig = createProjectConfig({
                 workspaceName: secondWorkspace.name,
                 workspaceFolderValue: [
-                    { path: 'script.py', envManager: INLINE_MANAGER_ID, packageManager: PIP_MANAGER_ID },
+                    createdInlineSetting('script.py'),
                     { path: 'keep.py', envManager: VENV_MANAGER_ID, packageManager: PIP_MANAGER_ID },
                 ],
             });
@@ -1119,11 +1312,11 @@ suite('Setting Helpers - Project Removal', () => {
             const firstConfig = createProjectConfig({
                 workspaceName: firstWorkspace.name,
                 globalValue: [
-                    { path: 'global.py', envManager: INLINE_MANAGER_ID, packageManager: PIP_MANAGER_ID },
+                    createdInlineSetting('global.py'),
                     { path: 'keep.py', envManager: VENV_MANAGER_ID, packageManager: PIP_MANAGER_ID },
                 ],
                 workspaceValue: [
-                    { path: 'workspace.py', envManager: INLINE_MANAGER_ID, packageManager: PIP_MANAGER_ID },
+                    createdInlineSetting('workspace.py'),
                 ],
                 workspaceFolderValue: [
                     { path: 'global.py', envManager: VENV_MANAGER_ID, packageManager: PIP_MANAGER_ID },
@@ -1132,11 +1325,11 @@ suite('Setting Helpers - Project Removal', () => {
             const secondConfig = createProjectConfig({
                 workspaceName: secondWorkspace.name,
                 globalValue: [
-                    { path: 'global.py', envManager: INLINE_MANAGER_ID, packageManager: PIP_MANAGER_ID },
+                    createdInlineSetting('global.py'),
                     { path: 'keep.py', envManager: VENV_MANAGER_ID, packageManager: PIP_MANAGER_ID },
                 ],
                 workspaceFolderValue: [
-                    { path: 'folder.py', envManager: INLINE_MANAGER_ID, packageManager: PIP_MANAGER_ID },
+                    createdInlineSetting('folder.py'),
                 ],
             });
             sinon.stub(workspaceApis, 'getWorkspaceFolders').returns([firstWorkspace, secondWorkspace]);


### PR DESCRIPTION
> Part of #1602 (PEP 723 inline script env support). Design doc: #1601.

### Roadmap context

This is **PR 10 of 16** in the PEP 723 inline-script roadmap. PRs 7-9 persist, discover, validate, and route per-script environments; this PR gives each configured script an exact project identity that survives restart and can be consumed by per-file integrations.

| Phase 3 / integration | PR | Status |
|---|---|---|
| | PR 7: per-script persistence | merged (#1697) |
| | PR 8: activation-time discovery | merged (#1722) |
| | PR 9: automatic per-script routing | merged (#1729) |
| | **PR 10: exact script project registration** | **this PR** |
| | PRs 11-12: CodeLens and bulk setup UX | follow-up |
| | PR 17: Pylance per-file Python path | [microsoft/pyrx#9265](https://github.com/microsoft/pyrx/pull/9265) |
| | PR 19: Python extension per-file lookup | [microsoft/vscode-python#26129](https://github.com/microsoft/vscode-python/pull/26129) |

### Why this PR

PR 9 can route a saved script to a validated inline environment, but the project manager still identifies the script through its containing workspace project. That prevents the per-file identity from surviving restart consistently and leaves downstream configuration and environment-change consumers without an exact script scope.

The registration also needs an ownership boundary: clearing inline environments must remove entries created by the extension without deleting user-authored project settings.

### What this PR does

- Registers an exact `pythonProjects` entry before binding an inline environment.
- Stores the normal environment and package manager as the script's fallback rather than replacing them with the inline manager.
- Marks extension-managed entries as either:
  - `created`: remove the entry during inline cleanup;
  - `adopted`: remove only the marker and preserve the user's entry.
- Ignores the managed fallback entry while a validated inline association is routeable.
- Uses that entry normally when the feature is disabled or the association becomes stale.
- Rolls back a newly prepared registration if inline association binding fails.
- Supports single and batch script selection.
- Converts a managed entry into an ordinary user-owned entry when the user explicitly selects a non-inline manager.
- Coordinates explicit managed selections with the dedicated clear-cache operation.
- Resolves and updates same-named scripts correctly in multi-root workspaces.

### Registration and cleanup semantics

| Condition | Behavior |
|---|---|
| No exact project entry exists | Create a marked entry containing the ordinary fallback managers |
| An exact user entry exists | Temporarily mark it without changing its manager choices |
| Inline binding fails | Roll back the marker/created entry and any newly added in-memory project |
| Validated association exists | Route through the inline manager |
| Association is stale or unavailable | Use the stored fallback manager |
| User selects a non-inline manager | Update the owning setting and remove the managed marker |
| Clear Script Environment Cache | Remove created entries; restore adopted entries |
| Two roots contain the same relative script path | Match using the `workspace` discriminator |

### Performance and safety

- No workspace scan is introduced.
- Configuration writes occur only during explicit persisted selection, rollback, manager changes, or dedicated cache cleanup.
- Serialization is limited to managed inline-script project mutations; unrelated environment routing and refresh operations are not queued.
- User-owned project settings are never deleted by inline cleanup.

### User impact

The feature remains behind `python-envs.inlineScripts.enabled`. Existing users and projects without a managed inline-script entry retain their current manager-selection behavior. After setup, a script has a stable exact project scope across reloads; when inline routing is unavailable, its previous project/workspace environment remains the fallback.

### Tests

- `npm run compile-tests`
- `npm run compile`
- `npm run lint`
- Focused command, environment-manager, and settings tests: **92 passing**
- The full unit suite was also run. Six unchanged timing-sensitive inline-manager tests failed only under full-suite load and passed together in an isolated rerun.

### Scope and follow-up

This PR does not add the setup CodeLens, bulk setup command, TTL eviction, or public feature enablement. Those remain in PRs 11, 12, and 14. Per-file language-service and debugger integration are handled by the companion cross-repository PRs above.
