### PR TITLE
Add opportunistic inline-script TTL eviction (PEP 723 PR 14/16)

### DIFF
--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -25,6 +25,7 @@ import {
 import { getErrorMessage } from '../../../common/errors/utils';
 import { computeCacheKey, normalizeDependency } from '../../../common/inlineScript/cacheKey';
 import {
+    CacheEntrySummary,
     CacheEnvironmentInspection,
     INLINE_SCRIPT_CACHE_DIR_NAME,
     InlineScriptEnvMeta,
@@ -38,6 +39,7 @@ import {
     inspectMetaJson,
     restoreMetaJsonBackupUnderLock,
     resolveCacheEntryPath,
+    selectStaleEntries,
     writeMetaJson,
 } from '../../../common/inlineScript/cacheLayout';
 import { extractLowerBoundVersion, pickCompatibleInterpreter } from '../../../common/inlineScript/interpreter';
@@ -89,6 +91,7 @@ const BASE_INTERPRETER_MANAGER_IDS = new Set([
 
 const CACHE_LOCK_TIMEOUT_MS = 5 * 60 * 1000;
 const CACHE_LOCK_RETRY_MS = 500;
+const CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000;
 const CACHED_ASSOCIATION_VALIDATION_INTERVAL_MS = 5_000;
 const DISCOVERY_RETRY_DELAYS_MS = [1_000, 5_000, 30_000] as const;
 const PERSISTED_ASSOCIATION_SCHEMA_VERSION = 1 as const;
@@ -142,6 +145,12 @@ interface PendingCreationContext {
 interface MergeCacheEntrySourceMetadataIdentityHashResult {
     readonly success: boolean;
     readonly sourceMetadataIdentityHashes?: readonly string[];
+}
+
+interface CacheEntryRemovalOptions {
+    readonly shouldRemove?: (entryPath: string) => Promise<boolean>;
+    readonly afterRemove?: () => void;
+    readonly reclaimRetainedLock?: boolean;
 }
 
 type CacheEntryInspection =
@@ -200,6 +209,8 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
     private cacheMaintenanceBarrier: Deferred<void> | undefined;
     private pendingCacheMaintenances = 0;
     private activeCreateOperations = 0;
+    private ttlEviction: Promise<void> | undefined;
+    private cacheMutationRevision = 0;
     private disposed = false;
 
     private readonly _onDidChangeEnvironments = new EventEmitter<DidChangeEnvironmentsEventArgs>();
@@ -260,6 +271,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
     ): Promise<PythonEnvironment | undefined> {
         this.activeCreateOperations += 1;
         try {
+            await this.runTtlEvictionOnce();
             return await this.waitForCacheMaintenance(async () => {
                 try {
                     const scriptUri = this.getScriptUri(scope);
@@ -583,6 +595,11 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
     }
 
     private async refreshDiscoveredEnvironments(checkForSnapshotChanges: boolean): Promise<boolean> {
+        const cacheMaintenance = this.cacheMaintenanceBarrier;
+        if (cacheMaintenance) {
+            await cacheMaintenance.promise;
+        }
+        const cacheMutationRevision = this.cacheMutationRevision;
         const cacheRoot = getScriptEnvCacheRoot(this.globalStorageUri);
         const previousByKey = new Map(
             this.collection.map((environment) => [this.getDiscoveredEnvironmentKey(environment), environment]),
@@ -698,6 +715,9 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
 
         if (this.disposed) {
             return false;
+        }
+        if (cacheMutationRevision !== this.cacheMutationRevision) {
+            return true;
         }
 
         // Preserve previously known entries when a refresh cannot safely classify
@@ -2139,6 +2159,17 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         return this.associationStore.clear();
     }
 
+    private runTtlEvictionOnce(): Promise<void> {
+        if (!this.ttlEviction) {
+            this.ttlEviction = this.enqueueCacheMaintenance(() =>
+                this.enqueueSelection(() => this.evictStaleCacheEntries()),
+            ).catch((error) => {
+                this.log.warn(`Unable to evict stale inline-script environments: ${getErrorMessage(error)}`);
+            });
+        }
+        return this.ttlEviction;
+    }
+
     private async waitForCacheMaintenance<T>(operation: () => Promise<T>): Promise<T> {
         const barrier = this.cacheMaintenanceBarrier;
         if (barrier) {
@@ -2849,6 +2880,142 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         return { environment: result.environment };
     }
 
+    private async evictStaleCacheEntries(): Promise<void> {
+        const cacheRoot = getScriptEnvCacheRoot(this.globalStorageUri);
+        const physicalCacheRootPath = await this.getPhysicalOwnedCacheRootPath(cacheRoot);
+        if (!physicalCacheRootPath) {
+            return;
+        }
+
+        let entryNames: string[];
+        try {
+            entryNames = await fs.readdir(physicalCacheRootPath);
+        } catch (error) {
+            if (isFileNotFoundError(error)) {
+                return;
+            }
+            throw error;
+        }
+
+        const now = new Date();
+        const entries: CacheEntrySummary[] = [];
+        for (const entryName of entryNames.sort()) {
+            if (entryName.endsWith(FILE_LOCK_DIR_SUFFIX)) {
+                continue;
+            }
+            const entryPath = path.join(physicalCacheRootPath, entryName);
+            try {
+                const stat = await fs.lstat(entryPath);
+                if (!stat.isDirectory() || stat.isSymbolicLink()) {
+                    continue;
+                }
+                const sidecar = await inspectMetaJson(Uri.file(entryPath));
+                if (sidecar.kind === 'valid') {
+                    entries.push({
+                        envDirPath: entryPath,
+                        lastUsedAt: new Date(sidecar.metadata.lastUsedAt),
+                    });
+                }
+            } catch (error) {
+                if (!isFileNotFoundError(error)) {
+                    this.log.warn(
+                        `Unable to inspect inline-script cache entry for TTL eviction ${entryPath}: ${getErrorMessage(error)}`,
+                    );
+                }
+            }
+        }
+
+        const staleEntries = selectStaleEntries(entries, now, CACHE_TTL_MS);
+        if (staleEntries.length === 0) {
+            return;
+        }
+
+        const persistedAssociations = await this.getPersistedAssociationSnapshot();
+        const scriptPaths = this.getTrackedScriptPaths(persistedAssociations);
+        const priorSelections = this.getPriorSelections(scriptPaths);
+        const removedCacheEntries = new Set<string>();
+        for (const staleEntry of staleEntries) {
+            try {
+                const removed = await this.removeCacheEntryForClear(
+                    cacheRoot,
+                    physicalCacheRootPath,
+                    path.basename(staleEntry),
+                    {
+                        reclaimRetainedLock: false,
+                        afterRemove: () => {
+                            this.cacheMutationRevision += 1;
+                        },
+                        shouldRemove: async (entryPath) => {
+                            const sidecar = await inspectMetaJson(Uri.file(entryPath));
+                            return (
+                                sidecar.kind === 'valid' &&
+                                selectStaleEntries(
+                                    [
+                                        {
+                                            envDirPath: entryPath,
+                                            lastUsedAt: new Date(sidecar.metadata.lastUsedAt),
+                                        },
+                                    ],
+                                    now,
+                                    CACHE_TTL_MS,
+                                ).length === 1
+                            );
+                        },
+                    },
+                );
+                if (removed) {
+                    removedCacheEntries.add(normalizePath(removed));
+                } else if (await this.isCacheEntryDefinitelyMissing(staleEntry)) {
+                    this.cacheMutationRevision += 1;
+                    removedCacheEntries.add(normalizePath(staleEntry));
+                }
+            } catch (error) {
+                this.log.warn(
+                    `Unable to evict stale inline-script cache entry ${staleEntry}: ${getErrorMessage(error)}`,
+                );
+                if (await this.isCacheEntryDefinitelyMissing(staleEntry)) {
+                    this.cacheMutationRevision += 1;
+                    removedCacheEntries.add(normalizePath(staleEntry));
+                }
+            }
+        }
+
+        if (removedCacheEntries.size === 0) {
+            return;
+        }
+
+        this.replaceDiscoveredEnvironments(
+            this.collection.filter(
+                (environment) => !removedCacheEntries.has(normalizePath(environment.sysPrefix)),
+            ),
+        );
+        const invalidatedScriptPaths = await this.getInvalidatedAssociationPaths(
+            scriptPaths,
+            persistedAssociations,
+            removedCacheEntries,
+        );
+        await this.clearInvalidatedAssociations(
+            invalidatedScriptPaths,
+            persistedAssociations,
+            priorSelections,
+        );
+    }
+
+    private async isCacheEntryDefinitelyMissing(entryPath: string): Promise<boolean> {
+        try {
+            await fs.lstat(entryPath);
+            return false;
+        } catch (error) {
+            if (isFileNotFoundError(error)) {
+                return true;
+            }
+            this.log.warn(
+                `Unable to verify stale inline-script cache entry ${entryPath}: ${getErrorMessage(error)}`,
+            );
+            return false;
+        }
+    }
+
     private async clearCacheInternal(activeCreatesAtStart: number): Promise<void> {
         if (activeCreatesAtStart > 0) {
             const message = l10n.t(
@@ -2861,21 +3028,8 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         const cacheRoot = getScriptEnvCacheRoot(this.globalStorageUri);
         const physicalCacheRootPath = await this.getPhysicalOwnedCacheRootPath(cacheRoot);
         const persistedAssociations = await this.getPersistedAssociationSnapshot();
-        const scriptPaths = new Set<string>([
-            ...Object.keys(persistedAssociations),
-            ...this.associationRevisions.keys(),
-            ...this.cachedAssociationValidatedAt.keys(),
-            ...this.lastValidatedMetadataIdentities.keys(),
-            ...this.lastValidatedMetadataIdentityProofs.keys(),
-            ...this.fsPathToEnv.keys(),
-            ...this.fsPathToPersistedAssociation.keys(),
-            ...this.pendingRehydrations.keys(),
-            ...this.pendingMetadataRefreshes.keys(),
-        ]);
-        const priorSelections = new Map<string, PythonEnvironment | undefined>();
-        scriptPaths.forEach((scriptPath) => {
-            priorSelections.set(scriptPath, this.fsPathToEnv.get(scriptPath));
-        });
+        const scriptPaths = this.getTrackedScriptPaths(persistedAssociations);
+        const priorSelections = this.getPriorSelections(scriptPaths);
 
         const removedCacheEntries = new Set<string>();
         const deletionErrors: unknown[] = [];
@@ -2953,11 +3107,15 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         cacheRoot: Uri,
         originalPhysicalCacheRootPath: string,
         entryName: string,
+        options: CacheEntryRemovalOptions = {},
     ): Promise<string | undefined> {
         const envDirPath = path.join(originalPhysicalCacheRootPath, entryName);
         let lock: AcquiredFileLock | undefined;
         try {
-            lock = await this.acquireCacheEntryLockForClear(envDirPath);
+            lock = await this.acquireCacheEntryLockForClear(
+                envDirPath,
+                options.reclaimRetainedLock !== false,
+            );
             const currentPhysicalCacheRootPath = await this.getPhysicalOwnedCacheRootPath(cacheRoot);
             if (!currentPhysicalCacheRootPath) {
                 return undefined;
@@ -2981,7 +3139,11 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             if (!entryPath) {
                 return undefined;
             }
+            if (options.shouldRemove && !(await options.shouldRemove(entryPath))) {
+                return undefined;
+            }
             await this.deleteCacheEntryForClear(entryPath);
+            options.afterRemove?.();
             return entryPath;
         } finally {
             if (lock) {
@@ -2990,7 +3152,10 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         }
     }
 
-    private async acquireCacheEntryLockForClear(envDirPath: string): Promise<AcquiredFileLock> {
+    private async acquireCacheEntryLockForClear(
+        envDirPath: string,
+        reclaimRetainedLock: boolean = true,
+    ): Promise<AcquiredFileLock> {
         for (let attempt = 0; attempt < 3; attempt += 1) {
             try {
                 return await acquireFileLock(envDirPath, { timeoutMs: 0, retryIntervalMs: CACHE_LOCK_RETRY_MS });
@@ -2999,9 +3164,12 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                     throw error;
                 }
                 const lockState = await inspectFileLock(envDirPath);
-                if (lockState === 'stale' || lockState === 'retained') {
+                if (lockState === 'stale' || (lockState === 'retained' && reclaimRetainedLock)) {
                     await reclaimFileLock(envDirPath);
                     continue;
+                }
+                if (lockState === 'retained') {
+                    throw error;
                 }
                 if (lockState === 'missing') {
                     continue;
@@ -3258,6 +3426,30 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
 
     private async getPersistedAssociationSnapshot(): Promise<PersistedInlineScriptEnvironments> {
         return this.parsePersistedAssociations(await this.associationStore.read<unknown>())?.records ?? {};
+    }
+
+    private getTrackedScriptPaths(
+        persistedAssociations: PersistedInlineScriptEnvironments,
+    ): Set<string> {
+        return new Set([
+            ...Object.keys(persistedAssociations),
+            ...this.associationRevisions.keys(),
+            ...this.cachedAssociationValidatedAt.keys(),
+            ...this.lastValidatedMetadataIdentities.keys(),
+            ...this.lastValidatedMetadataIdentityProofs.keys(),
+            ...this.fsPathToEnv.keys(),
+            ...this.fsPathToPersistedAssociation.keys(),
+            ...this.pendingRehydrations.keys(),
+            ...this.pendingMetadataRefreshes.keys(),
+        ]);
+    }
+
+    private getPriorSelections(
+        scriptPaths: ReadonlySet<string>,
+    ): Map<string, PythonEnvironment | undefined> {
+        return new Map(
+            Array.from(scriptPaths, (scriptPath) => [scriptPath, this.fsPathToEnv.get(scriptPath)]),
+        );
     }
 
     private async removeCacheEntry(envDir: Uri): Promise<boolean> {

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -2933,8 +2933,19 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         const persistedAssociations = await this.getPersistedAssociationSnapshot();
         const scriptPaths = this.getTrackedScriptPaths(persistedAssociations);
         const priorSelections = this.getPriorSelections(scriptPaths);
+        // Never evict an environment that a script association still points to. `lastUsedAt` is only
+        // refreshed when an environment is created or reused (never when it is resolved for run, debug,
+        // or Pylance), so an actively-used environment can look stale here. Reclaim only orphaned entries
+        // (e.g. superseded by a dependency change, or left behind by a deleted or deselected script).
+        const referencedEnvDirs = this.getReferencedCacheEntryDirs(persistedAssociations, scriptPaths);
+        const evictableStaleEntries = staleEntries.filter(
+            (staleEntry) => !referencedEnvDirs.has(normalizePath(staleEntry)),
+        );
+        if (evictableStaleEntries.length === 0) {
+            return;
+        }
         const removedCacheEntries = new Set<string>();
-        for (const staleEntry of staleEntries) {
+        for (const staleEntry of evictableStaleEntries) {
             try {
                 const removed = await this.removeCacheEntryForClear(
                     cacheRoot,
@@ -3321,6 +3332,26 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
 
     private deleteCacheEntryForClear(entryPath: string): Promise<void> {
         return fs.remove(entryPath);
+    }
+
+    private getReferencedCacheEntryDirs(
+        persistedAssociations: PersistedInlineScriptEnvironments,
+        scriptPaths: ReadonlySet<string>,
+    ): Set<string> {
+        const referenced = new Set<string>();
+        for (const scriptPath of scriptPaths) {
+            const environmentPaths = [
+                persistedAssociations[scriptPath]?.environmentPath,
+                this.fsPathToPersistedAssociation.get(scriptPath)?.environmentPath,
+                this.fsPathToEnv.get(scriptPath)?.environmentPath.fsPath,
+            ].filter((value): value is string => value !== undefined);
+            for (const environmentPath of environmentPaths) {
+                // Mirror isRemovedOrMissingCacheAssociation: the cache-entry dir is two levels above the
+                // interpreter executable (e.g. <envDir>/bin/python -> <envDir>).
+                referenced.add(normalizePath(path.dirname(path.dirname(environmentPath))));
+            }
+        }
+        return referenced;
     }
 
     private async getInvalidatedAssociationPaths(

--- a/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
+++ b/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
@@ -5803,35 +5803,41 @@ suite('InlineScriptEnvManager', () => {
             assert.strictEqual(await fs.pathExists(stale.sysPrefix), true);
         });
 
-        test('invalidates associations and discovered environments for deleted entries', async () => {
+        test('removes discovered environments for evicted orphaned entries', async () => {
+            const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
+            await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
+            (manager as unknown as { collection: PythonEnvironment[] }).collection = [stale];
+            const collectionListener = sinon.spy();
+            manager.onDidChangeEnvironments(collectionListener);
+
+            assert.ok(await manager.create(scriptUri('trigger.py')));
+
+            assert.strictEqual(await fs.pathExists(stale.sysPrefix), false);
+            assert.deepStrictEqual(await manager.getEnvironments('all'), []);
+            sinon.assert.calledOnceWithExactly(collectionListener, [
+                { kind: EnvironmentChangeKind.remove, environment: stale },
+            ]);
+        });
+
+        test('preserves a stale entry and its association while a script still references it', async () => {
             const uri = scriptUri('associated.py');
             const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
             await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
             await manager.set(uri, stale);
             (manager as unknown as { collection: PythonEnvironment[] }).collection = [stale];
             const selectionListener = sinon.spy();
-            const collectionListener = sinon.spy();
             manager.onDidChangeEnvironment(selectionListener);
-            manager.onDidChangeEnvironments(collectionListener);
 
             assert.ok(await manager.create(scriptUri('trigger.py')));
 
-            assert.strictEqual(await manager.get(uri), undefined);
-            assert.strictEqual(persistedAssociations, undefined);
-            assert.deepStrictEqual(await manager.getEnvironments('all'), []);
-            sinon.assert.calledOnce(selectionListener);
-            assert.strictEqual(
-                normalizePath(selectionListener.firstCall.args[0].uri.fsPath),
-                normalizePath(uri.fsPath),
-            );
-            assert.strictEqual(selectionListener.firstCall.args[0].old, stale);
-            assert.strictEqual(selectionListener.firstCall.args[0].new, undefined);
-            sinon.assert.calledOnceWithExactly(collectionListener, [
-                { kind: EnvironmentChangeKind.remove, environment: stale },
-            ]);
+            assert.strictEqual(await fs.pathExists(stale.sysPrefix), true);
+            assert.strictEqual(await manager.get(uri), stale);
+            assert.notStrictEqual(persistedAssociations, undefined);
+            assert.ok((await manager.getEnvironments('all')).some((env) => env === stale));
+            sinon.assert.notCalled(selectionListener);
         });
 
-        test('invalidates an association when another host removes the stale entry first', async () => {
+        test('does not attempt to remove a stale entry that a script still references', async () => {
             const uri = scriptUri('associated.py');
             const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
             await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
@@ -5847,15 +5853,14 @@ suite('InlineScriptEnvManager', () => {
                     },
                 ): Promise<string | undefined>;
             };
-            sinon.stub(internalManager, 'removeCacheEntryForClear').callsFake(async () => {
-                await fs.remove(stale.sysPrefix);
-                return undefined;
-            });
+            const removeSpy = sinon.spy(internalManager, 'removeCacheEntryForClear');
 
             assert.ok(await manager.create(scriptUri('trigger.py')));
 
-            assert.strictEqual(persistedAssociations, undefined);
-            assert.strictEqual(await manager.get(uri), undefined);
+            sinon.assert.notCalled(removeSpy);
+            assert.strictEqual(await fs.pathExists(stale.sysPrefix), true);
+            assert.strictEqual(await manager.get(uri), stale);
+            assert.notStrictEqual(persistedAssociations, undefined);
         });
 
         test('does not let an in-flight refresh re-add an evicted environment', async () => {
@@ -5913,14 +5918,19 @@ suite('InlineScriptEnvManager', () => {
         });
 
         test('does not fail creation when association cleanup cannot be persisted', async () => {
-            const uri = scriptUri('associated.py');
-            const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
-            await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
-            await manager.set(uri, stale);
+            const orphan = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
+            await setLastUsedAt(orphan, new Date(NOW.getTime() - TTL_MS - 1));
+            // A separate association whose environment was deleted out from under us. Evicting the
+            // orphaned entry above drives the association cleanup pass, and persisting that cleanup is
+            // what fails here.
+            const missingUri = scriptUri('missing.py');
+            const missing = await createOwnedEnvironment('bbbbbbbbbbbbbbbb');
+            await manager.set(missingUri, missing);
+            await fs.remove(missing.sysPrefix);
             workspaceState.update.onSecondCall().rejects(new Error('Memento unavailable'));
 
             assert.ok(await manager.create(scriptUri('trigger.py')));
-            assert.strictEqual(await fs.pathExists(stale.sysPrefix), false);
+            assert.strictEqual(await fs.pathExists(orphan.sysPrefix), false);
         });
     });
 

--- a/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
+++ b/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
@@ -1886,7 +1886,7 @@ suite('InlineScriptEnvManager', () => {
                 schemaVersion: cacheLayout.META_SCHEMA_VERSION,
                 baseInterpreterPath: baseExecutable,
                 baseInterpreterVersion: baseEnvironment.version,
-                lastUsedAt: '2026-07-01T00:00:00.000Z',
+                lastUsedAt: '2026-07-20T00:00:00.000Z',
             };
             const cached = makeEnvironment(
                 'ms-python.python:inline-script',
@@ -1922,7 +1922,7 @@ suite('InlineScriptEnvManager', () => {
                 schemaVersion: cacheLayout.META_SCHEMA_VERSION,
                 baseInterpreterPath: baseExecutable,
                 baseInterpreterVersion: baseEnvironment.version,
-                lastUsedAt: '2026-07-01T00:00:00.000Z',
+                lastUsedAt: '2026-07-20T00:00:00.000Z',
                 sourceMetadataIdentityHashes: [cacheLayout.hashSourceMetadataIdentity('{"requiresPython":">=3.12","dependencies":["rich"]}')],
             });
             const cached = makeEnvironment(
@@ -1961,7 +1961,7 @@ suite('InlineScriptEnvManager', () => {
                 schemaVersion: cacheLayout.META_SCHEMA_VERSION,
                 baseInterpreterPath: baseExecutable,
                 baseInterpreterVersion: baseEnvironment.version,
-                lastUsedAt: '2026-07-01T00:00:00.000Z',
+                lastUsedAt: '2026-07-20T00:00:00.000Z',
                 sourceMetadataIdentityHashes: hashes,
             });
             const cached = makeEnvironment(
@@ -1996,7 +1996,7 @@ suite('InlineScriptEnvManager', () => {
                 schemaVersion: cacheLayout.META_SCHEMA_VERSION,
                 baseInterpreterPath: baseExecutable,
                 baseInterpreterVersion: baseEnvironment.version,
-                lastUsedAt: '2026-07-01T00:00:00.000Z',
+                lastUsedAt: '2026-07-20T00:00:00.000Z',
             });
             const cached = makeEnvironment(
                 'ms-python.python:inline-script',
@@ -2237,7 +2237,12 @@ suite('InlineScriptEnvManager', () => {
             assert.strictEqual(await manager.create(scriptUri()), undefined);
             assert.strictEqual(await fs.readFile(markerPath, 'utf8'), 'keep');
             assert.strictEqual((await fs.lstat(envDir().fsPath)).isSymbolicLink(), true);
-            assert.strictEqual(inspectMetaStub.callCount, 0);
+            assert.strictEqual(
+                inspectMetaStub
+                    .getCalls()
+                    .some((call) => normalizePath(call.args[0].fsPath) === normalizePath(envDir().fsPath)),
+                false,
+            );
             assert.strictEqual(writeMetaStub.callCount, 0);
             assert.strictEqual(createWithProgressStub.callCount, 0);
         });
@@ -2261,7 +2266,12 @@ suite('InlineScriptEnvManager', () => {
             assert.strictEqual(await manager.create(scriptUri()), undefined);
             assert.strictEqual(await fs.readFile(markerPath, 'utf8'), 'keep');
             assert.strictEqual((await fs.lstat(envDir().fsPath)).isSymbolicLink(), true);
-            assert.strictEqual(inspectMetaStub.callCount, 0);
+            assert.strictEqual(
+                inspectMetaStub
+                    .getCalls()
+                    .some((call) => normalizePath(call.args[0].fsPath) === normalizePath(envDir().fsPath)),
+                false,
+            );
             assert.strictEqual(writeMetaStub.callCount, 0);
             assert.strictEqual(createWithProgressStub.callCount, 0);
         });
@@ -5683,6 +5693,234 @@ suite('InlineScriptEnvManager', () => {
             assert.strictEqual(await manager.get(valid), undefined);
             assert.strictEqual(await manager.get(undefined), undefined);
             assert.strictEqual(await manager.get(Uri.parse('untitled:script.py')), undefined);
+        });
+    });
+
+    suite('TTL eviction', () => {
+        const TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+        async function setLastUsedAt(environment: PythonEnvironment, lastUsedAt: Date): Promise<void> {
+            setSidecar(
+                await makeSidecar({ lastUsedAt: lastUsedAt.toISOString() }),
+                Uri.file(environment.sysPrefix),
+            );
+        }
+
+        test('evicts only entries older than 14 days before the first create', async () => {
+            const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
+            const recent = await createOwnedEnvironment('bbbbbbbbbbbbbbbb');
+            const exactCutoff = await createOwnedEnvironment('cccccccccccccccc');
+            await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
+            await setLastUsedAt(recent, new Date(NOW.getTime() - TTL_MS + 1));
+            await setLastUsedAt(exactCutoff, new Date(NOW.getTime() - TTL_MS));
+
+            const created = await manager.create(scriptUri());
+
+            assert.ok(created);
+            assert.strictEqual(await fs.pathExists(stale.sysPrefix), false);
+            assert.strictEqual(await fs.pathExists(recent.sysPrefix), true);
+            assert.strictEqual(await fs.pathExists(exactCutoff.sysPrefix), true);
+        });
+
+        test('attempts the eviction sweep once and does not block creation when it fails', async () => {
+            const internalManager = manager as unknown as {
+                evictStaleCacheEntries(): Promise<void>;
+            };
+            const eviction = sinon
+                .stub(internalManager, 'evictStaleCacheEntries')
+                .rejects(new Error('cache scan unavailable'));
+
+            assert.ok(await manager.create(scriptUri('first.py')));
+            assert.ok(await manager.create(scriptUri('second.py')));
+
+            sinon.assert.calledOnce(eviction);
+        });
+
+        test('rechecks lastUsedAt under the entry lock before deleting', async () => {
+            const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
+            await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
+            lockStub.callsFake(async (entryPath: string) => {
+                if (normalizePath(entryPath) === normalizePath(stale.sysPrefix)) {
+                    await setLastUsedAt(stale, NOW);
+                }
+                return { release: releaseLockStub, retain: retainLockStub };
+            });
+
+            assert.ok(await manager.create(scriptUri()));
+
+            assert.strictEqual(await fs.pathExists(stale.sysPrefix), true);
+        });
+
+        test('preserves a locked stale entry without failing the triggering create', async () => {
+            const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
+            await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
+            lockStub.callsFake(async (entryPath: string) => {
+                if (normalizePath(entryPath) === normalizePath(stale.sysPrefix)) {
+                    throw Object.assign(new Error('cache entry is locked'), { code: 'ELOCKED' });
+                }
+                return { release: releaseLockStub, retain: retainLockStub };
+            });
+
+            const created = await manager.create(scriptUri());
+
+            assert.ok(created);
+            assert.strictEqual(await fs.pathExists(stale.sysPrefix), true);
+        });
+
+        test('does not reclaim a retained lock during silent eviction', async () => {
+            lockStub.restore();
+            const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
+            await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
+            const lock = await lockfileApis.acquireFileLock(stale.sysPrefix, {
+                timeoutMs: 0,
+                retryIntervalMs: 1,
+            });
+            await lock.retain();
+
+            assert.ok(await manager.create(scriptUri()));
+
+            assert.strictEqual(await fs.pathExists(stale.sysPrefix), true);
+            assert.strictEqual(await fs.pathExists(lockfileApis.getFileLockPath(stale.sysPrefix)), true);
+        });
+
+        test('preserves a stale entry when deletion fails without failing creation', async () => {
+            const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
+            await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
+            const internalManager = manager as unknown as {
+                deleteCacheEntryForClear(entryPath: string): Promise<void>;
+            };
+            const originalDelete = internalManager.deleteCacheEntryForClear.bind(manager);
+            sinon.stub(internalManager, 'deleteCacheEntryForClear').callsFake(async (entryPath) => {
+                if (normalizePath(entryPath) === normalizePath(stale.sysPrefix)) {
+                    throw new Error('deletion unavailable');
+                }
+                return originalDelete(entryPath);
+            });
+
+            const created = await manager.create(scriptUri());
+
+            assert.ok(created);
+            assert.strictEqual(await fs.pathExists(stale.sysPrefix), true);
+        });
+
+        test('invalidates associations and discovered environments for deleted entries', async () => {
+            const uri = scriptUri('associated.py');
+            const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
+            await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
+            await manager.set(uri, stale);
+            (manager as unknown as { collection: PythonEnvironment[] }).collection = [stale];
+            const selectionListener = sinon.spy();
+            const collectionListener = sinon.spy();
+            manager.onDidChangeEnvironment(selectionListener);
+            manager.onDidChangeEnvironments(collectionListener);
+
+            assert.ok(await manager.create(scriptUri('trigger.py')));
+
+            assert.strictEqual(await manager.get(uri), undefined);
+            assert.strictEqual(persistedAssociations, undefined);
+            assert.deepStrictEqual(await manager.getEnvironments('all'), []);
+            sinon.assert.calledOnce(selectionListener);
+            assert.strictEqual(
+                normalizePath(selectionListener.firstCall.args[0].uri.fsPath),
+                normalizePath(uri.fsPath),
+            );
+            assert.strictEqual(selectionListener.firstCall.args[0].old, stale);
+            assert.strictEqual(selectionListener.firstCall.args[0].new, undefined);
+            sinon.assert.calledOnceWithExactly(collectionListener, [
+                { kind: EnvironmentChangeKind.remove, environment: stale },
+            ]);
+        });
+
+        test('invalidates an association when another host removes the stale entry first', async () => {
+            const uri = scriptUri('associated.py');
+            const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
+            await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
+            await manager.set(uri, stale);
+            const internalManager = manager as unknown as {
+                removeCacheEntryForClear(
+                    cacheRoot: Uri,
+                    physicalCacheRootPath: string,
+                    entryName: string,
+                    options?: {
+                        shouldRemove?: (entryPath: string) => Promise<boolean>;
+                        reclaimRetainedLock?: boolean;
+                    },
+                ): Promise<string | undefined>;
+            };
+            sinon.stub(internalManager, 'removeCacheEntryForClear').callsFake(async () => {
+                await fs.remove(stale.sysPrefix);
+                return undefined;
+            });
+
+            assert.ok(await manager.create(scriptUri('trigger.py')));
+
+            assert.strictEqual(persistedAssociations, undefined);
+            assert.strictEqual(await manager.get(uri), undefined);
+        });
+
+        test('does not let an in-flight refresh re-add an evicted environment', async () => {
+            const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
+            await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
+            let releaseRefresh: (() => void) | undefined;
+            let signalRefreshStarted: (() => void) | undefined;
+            const refreshStarted = new Promise<void>((resolve) => {
+                signalRefreshStarted = resolve;
+            });
+            const refreshGate = new Promise<void>((resolve) => {
+                releaseRefresh = resolve;
+            });
+            const internalManager = manager as unknown as {
+                inspectDiscoveredCacheEntry(
+                    cacheRoot: Uri,
+                    envDir: Uri,
+                ): Promise<{
+                    kind: 'resolved';
+                    environment: PythonEnvironment;
+                    fingerprint: string;
+                }>;
+            };
+            sinon.stub(internalManager, 'inspectDiscoveredCacheEntry').callsFake(async () => {
+                signalRefreshStarted!();
+                await refreshGate;
+                return { kind: 'resolved', environment: stale, fingerprint: 'stale-snapshot' };
+            });
+
+            const refresh = manager.refresh(undefined);
+            await refreshStarted;
+            const create = manager.create(scriptUri('trigger.py'));
+            await waitForCondition(
+                async () => !(await fs.pathExists(stale.sysPrefix)),
+                'Expected TTL eviction to delete the stale entry',
+            );
+            releaseRefresh!();
+            await Promise.all([refresh, create]);
+
+            assert.strictEqual(await fs.pathExists(stale.sysPrefix), false);
+            assert.deepStrictEqual(await manager.getEnvironments('all'), []);
+        });
+
+        test('does not treat transient access errors as confirmed cross-host deletion', async () => {
+            const entryPath = path.join(tempRoot, 'unavailable-entry');
+            const internalManager = manager as unknown as {
+                isCacheEntryDefinitelyMissing(candidate: string): Promise<boolean>;
+            };
+            sinon
+                .stub(fsExtra, 'lstat')
+                .withArgs(entryPath)
+                .rejects(Object.assign(new Error('access unavailable'), { code: 'EACCES' }));
+
+            assert.strictEqual(await internalManager.isCacheEntryDefinitelyMissing(entryPath), false);
+        });
+
+        test('does not fail creation when association cleanup cannot be persisted', async () => {
+            const uri = scriptUri('associated.py');
+            const stale = await createOwnedEnvironment('aaaaaaaaaaaaaaaa');
+            await setLastUsedAt(stale, new Date(NOW.getTime() - TTL_MS - 1));
+            await manager.set(uri, stale);
+            workspaceState.update.onSecondCall().rejects(new Error('Memento unavailable'));
+
+            assert.ok(await manager.create(scriptUri('trigger.py')));
+            assert.strictEqual(await fs.pathExists(stale.sysPrefix), false);
         });
     });
 


### PR DESCRIPTION
> Part of #1602 (PEP 723 inline script env support). Design doc: #1601.

### Roadmap context

This is **PR 14 of 16** in the PEP 723 inline-script roadmap. PR 13 added explicit, user-confirmed cache cleanup; this PR adds the separate best-effort TTL path.

| Phase 5: Lifecycle and polish | PR | Status |
|---|---|---|
| | PR 7: persistence (`get` / `set` + Memento) | merged (#1697) |
| | PR 13: Clear Script Environment Cache | merged (#1724) |
| | **PR 14: opportunistic 14-day TTL eviction** | **this PR** |
| | PR 15: lifecycle telemetry | merged (#1723) |
| | PR 16: status-bar decision | resolved; no code PR |

### Why this PR

Inline-script environments are dependency/interpreter-keyed and intentionally rebuilt instead of synchronized in place. Without lifecycle cleanup, old cache keys accumulate whenever dependencies or the selected Python change.

The design calls for a pipx-style 14-day TTL in addition to the explicit clear command. Because TTL cleanup is silent, it must be more conservative than user-confirmed cleanup and must never prevent the requested environment from being created.

### What this PR does

- Attempts one TTL sweep per `InlineScriptEnvManager` session.
- Runs the sweep before the first environment creation/reuse reaches the cache.
- Reads only valid `.meta.json` sidecars and selects entries whose `lastUsedAt` is strictly older than 14 days.
- Reuses PR 13's physical-root, normal-directory, direct-child, and entry-lock safety checks.
- Re-reads `lastUsedAt` under the entry lock before deletion.
- Preserves held, retained, malformed, redirected, unavailable, or failed-to-delete entries.
- Treats all TTL failures as best-effort warnings and continues the triggering creation.
- Invalidates persisted and warm script associations only for entries confirmed deleted or definitively removed by another host.
- Removes evicted environments from the discovered collection and emits the existing environment-change events.
- Prevents a concurrent discovery refresh from publishing a stale snapshot after eviction.

### Eviction semantics

| State | Behavior |
|---|---|
| `lastUsedAt` older than 14 days | Lock, revalidate, and delete |
| Age exactly 14 days | Keep |
| Recent or future timestamp | Keep |
| Missing, invalid, unsupported, or unreadable sidecar | Keep |
| Timestamp becomes fresh before lock acquisition | Keep |
| Entry is actively locked | Keep |
| Entry has a retained cancellation lock | Keep; only explicit cleanup may reclaim it |
| Entry deletion fails | Keep and continue creation |
| Another host already deleted the entry | Confirm with `lstat`, then invalidate local associations |
| Association persistence fails after deletion | Keep in-memory state consistent, log, and continue creation |
| Refresh started before deletion | Reject its stale collection snapshot |
| Refresh starts during maintenance | Wait, then scan the post-eviction cache |

### Concurrency and safety

- The once-per-session latch is set synchronously, so concurrent creates share one sweep.
- The sweep uses the existing cache-maintenance then selection-queue ordering.
- The active-create counter is incremented before the sweep, preserving PR 13's clear-vs-create behavior.
- Each deletion is protected by the existing cross-host cache-entry lock.
- Physical root and entry containment are revalidated after lock acquisition.
- A cache mutation revision prevents stale discovery publication without waiting on, or deadlocking with, a refresh already blocked by maintenance.
- Only `ENOENT` counts as confirmed cross-host deletion; permission and transient access errors preserve associations.

### Performance

- The cache is scanned once per extension-host session, not on every lookup.
- Entries are inspected and deleted sequentially to avoid I/O spikes.
- Activation remains unchanged and is not blocked by TTL work.
- Environments with missing or uncertain metadata are not repeatedly modified.

### User impact

The feature remains behind `python-envs.inlineScripts.enabled`. Users without inline-script environments see no behavior change. Existing environments are retained unless a valid sidecar proves they have not been successfully reused for more than 14 days.

### Tests

- `npm run compile-tests`
- `npm run compile`
- `npm run lint`
- Complete unit suite: **1,928 passing**, 6 pending

Focused coverage includes:

- strict 14-day cutoff;
- once-per-session and failed-sweep behavior;
- under-lock freshness revalidation;
- held and retained lock preservation;
- deletion and persistence failure isolation;
- cross-host deletion confirmation;
- association and discovered-collection invalidation;
- refresh-versus-eviction publication races;
- unchanged explicit clear-cache behavior.

### Scope and follow-up

This PR does not add telemetry, activation-time cleanup, a cache-root lock, project-setting cleanup, UX, or retry loops. Explicit clear-cache behavior remains unchanged.
