### PR TITLE
Fix inline-script env creation for CPython sys.version_info versions (PEP 723)

### DIFF
--- a/src/common/utils/pep440Release.ts
+++ b/src/common/utils/pep440Release.ts
@@ -4,15 +4,49 @@
 import { clean as cleanPep440Version, explain as explainPep440Version } from '@renovatebot/pep440';
 
 /**
+ * Convert a CPython `sys.version_info`-style version string to PEP 440.
+ *
+ * The native locator (`pet`) reports interpreter versions as
+ * `major.minor.micro.releaselevel.serial` — for example `"3.14.3.final.0"` or
+ * `"3.14.0.candidate.2"`. That shape is **not** valid PEP 440, so the
+ * `@renovatebot/pep440` helpers (`clean`, `satisfies`, …) reject it. This maps
+ * it to the PEP 440 equivalent (`"3.14.3"`, `"3.14.0rc2"`).
+ *
+ * The numeric release segments are preserved verbatim (no zero-padding, so
+ * `"3.14"` is never rewritten to `"3.14.0"`), and any string that does not
+ * match the `sys.version_info` shape is returned unchanged.
+ */
+export function normalizeCpythonVersionInfo(version: string): string {
+    const match = /^(\d+(?:\.\d+)*)\.(alpha|beta|candidate|final)\.(\d+)$/i.exec(version.trim());
+    if (!match) {
+        return version;
+    }
+    const [, release, level, serial] = match;
+    switch (level.toLowerCase()) {
+        case 'alpha':
+            return `${release}a${serial}`;
+        case 'beta':
+            return `${release}b${serial}`;
+        case 'candidate':
+            return `${release}rc${serial}`;
+        case 'final':
+        default:
+            return release;
+    }
+}
+
+/**
  * Parse the release segments from a PEP 440 version string.
  *
  * Release segments are the dotted numeric components of a version, such as
  * `[3, 12, 4]` for `3.12.4`. Leading/trailing whitespace, a leading `v`, and
  * an epoch prefix are ignored. Pre-release, post-release, development, and
- * local-version suffixes are intentionally omitted.
+ * local-version suffixes are intentionally omitted. CPython `sys.version_info`
+ * strings (e.g. `"3.14.3.final.0"`) are normalized via
+ * {@link normalizeCpythonVersionInfo} before parsing.
  */
 export function parseReleaseSegments(version: string): number[] | undefined {
-    const normalized = cleanPep440Version(version);
+    const normalized = cleanPep440Version(normalizeCpythonVersionInfo(version));
     return normalized ? (explainPep440Version(normalized)?.release ?? undefined) : undefined;
 }
 

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -69,7 +69,11 @@ import { sendTelemetryEvent } from '../../../common/telemetry/sender';
 import { createDeferred, Deferred } from '../../../common/utils/deferred';
 import { isFileNotFoundError } from '../../../common/utils/filesystem';
 import { normalizePath } from '../../../common/utils/pathUtils';
-import { compareReleaseSegments, parseReleaseSegments } from '../../../common/utils/pep440Release';
+import {
+    compareReleaseSegments,
+    normalizeCpythonVersionInfo,
+    parseReleaseSegments,
+} from '../../../common/utils/pep440Release';
 import { getVenvPythonPath } from '../../../common/utils/virtualEnvironment';
 import { getOpenTextDocuments, onDidDeleteFiles, onDidRenameFiles } from '../../../common/workspace.apis';
 import { NativePythonFinder } from '../../common/nativePythonFinder';
@@ -2503,7 +2507,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
 
     private matchesInstallConstraint(requiresPython: string, version: string): boolean {
         try {
-            return satisfiesPep440(version, requiresPython, {
+            return satisfiesPep440(normalizeCpythonVersionInfo(version), requiresPython, {
                 prereleases: /(?:(?:a|alpha|b|beta|c|rc|pre|preview)[._-]?\d+|dev[._-]?\d+)/i.test(
                     requiresPython,
                 ),

--- a/src/test/common/utils/pep440Release.unit.test.ts
+++ b/src/test/common/utils/pep440Release.unit.test.ts
@@ -2,12 +2,53 @@
 // Licensed under the MIT License.
 
 import assert from 'assert';
-import { compareReleaseSegments, parseReleaseSegments } from '../../../common/utils/pep440Release';
+import {
+    compareReleaseSegments,
+    normalizeCpythonVersionInfo,
+    parseReleaseSegments,
+} from '../../../common/utils/pep440Release';
 
 suite('pep440Release', () => {
+    suite('normalizeCpythonVersionInfo', () => {
+        test('rewrites a final sys.version_info string to its release', () => {
+            assert.strictEqual(normalizeCpythonVersionInfo('3.14.3.final.0'), '3.14.3');
+        });
+
+        test('rewrites prerelease sys.version_info strings to PEP 440 prereleases', () => {
+            assert.strictEqual(normalizeCpythonVersionInfo('3.14.0.alpha.1'), '3.14.0a1');
+            assert.strictEqual(normalizeCpythonVersionInfo('3.14.0.beta.2'), '3.14.0b2');
+            assert.strictEqual(normalizeCpythonVersionInfo('3.14.0.candidate.3'), '3.14.0rc3');
+        });
+
+        test('trims surrounding whitespace before matching', () => {
+            assert.strictEqual(normalizeCpythonVersionInfo('  3.14.3.final.0  '), '3.14.3');
+        });
+
+        test('does not zero-pad the release segments', () => {
+            assert.strictEqual(normalizeCpythonVersionInfo('3.14.final.0'), '3.14');
+        });
+
+        test('returns non-version_info strings unchanged', () => {
+            assert.strictEqual(normalizeCpythonVersionInfo('3.14.3'), '3.14.3');
+            assert.strictEqual(normalizeCpythonVersionInfo('3.13'), '3.13');
+            assert.strictEqual(normalizeCpythonVersionInfo('3.14.0rc2'), '3.14.0rc2');
+            assert.strictEqual(normalizeCpythonVersionInfo('>=3.11'), '>=3.11');
+            assert.strictEqual(normalizeCpythonVersionInfo('3.12.not-a-version'), '3.12.not-a-version');
+        });
+    });
+
     suite('parseReleaseSegments', () => {
         test('parses dotted numeric release segments', () => {
             assert.deepStrictEqual(parseReleaseSegments('3.12.4'), [3, 12, 4]);
+        });
+
+        test('parses CPython sys.version_info release strings', () => {
+            assert.deepStrictEqual(parseReleaseSegments('3.14.3.final.0'), [3, 14, 3]);
+            assert.deepStrictEqual(parseReleaseSegments('3.14.0.candidate.2'), [3, 14, 0]);
+        });
+
+        test('does not zero-pad release segments (keeps uv install targets intact)', () => {
+            assert.deepStrictEqual(parseReleaseSegments('3.13'), [3, 13]);
         });
 
         test('ignores syntax outside the release segments', () => {

--- a/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
+++ b/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
@@ -553,6 +553,29 @@ suite('InlineScriptEnvManager', () => {
             assert.strictEqual(promptInstallPythonViaUvStub.callCount, 0);
         });
 
+        test('creates an environment when the resolved base reports a CPython sys.version_info version', async () => {
+            // `pet` reports interpreter versions as `major.minor.micro.releaselevel.serial`
+            // (e.g. "3.14.3.final.0"), which is not valid PEP 440. This must still satisfy
+            // requires-python (matchesInstallConstraint) and pass the post-create
+            // release-equality check (areEqualPythonReleases) instead of being discarded.
+            const versionInfoBase = makeEnvironment('ms-python.python:system', '3.14.3.final.0', baseExecutable);
+            apiGetEnvironmentsStub.resolves([versionInfoBase]);
+
+            assert.ok(await manager.create(scriptUri()));
+
+            assert.strictEqual(createWithProgressStub.firstCall.args[4], versionInfoBase);
+        });
+
+        test('creates an environment with a sys.version_info version when requires-python is absent', async () => {
+            readMetadataStub.resolves({ ...VALID_METADATA, requiresPython: undefined });
+            const versionInfoBase = makeEnvironment('ms-python.python:system', '3.14.3.final.0', baseExecutable);
+            apiGetEnvironmentsStub.resolves([versionInfoBase]);
+
+            assert.ok(await manager.create(scriptUri()));
+
+            assert.strictEqual(createWithProgressStub.firstCall.args[4], versionInfoBase);
+        });
+
         test('excludes named conda environments even when they are newer than conda base', async () => {
             const condaNamed = makeEnvironment(
                 'ms-python.python:conda',


### PR DESCRIPTION
## Summary

Fixes PEP 723 inline-script environment **creation**, which currently fails for every interpreter whose version the native locator (`pet`) reports in CPython's `sys.version_info` form (e.g. `3.14.3.final.0`). The venv is provisioned correctly (base interpreter selected, `uv venv --seed` + dependencies installed), but is then **rejected by a post-creation self-check and deleted**, surfacing:

> Created inline-script environment does not match the requested cache entry.

## Root cause

`pet resolve` returns interpreter versions as `major.minor.micro.releaselevel.serial` — e.g. `"3.14.3.final.0"` (verified against the bundled `pet` in **both server mode and CLI**, for Python 3.12 / 3.13 / 3.14). That string is **not valid PEP 440**, and the `@renovatebot/pep440` helpers reject it:

- `parseReleaseSegments("3.14.3.final.0")` → `undefined` (because `clean()` returns `null`). `areEqualPythonReleases()` guards on `undefined` and returns **`false` even when both versions are identical**, so `buildCacheEntry()` treats the freshly-created environment as a version mismatch and deletes it. This blocks creation for scripts **without** `requires-python`.
- `satisfies("3.14.3.final.0", ">=3.11")` **throws** (`Cannot destructure property 'epoch' of 'input' as it is null`). `matchesInstallConstraint()` catches it and returns `false`, so scripts **with** `requires-python` find no compatible base interpreter during `selectBaseInterpreter()`.

The repo's existing `PythonVersion` class already parses the `sys.version_info` form (so `matchesPythonVersion` was unaffected); only the two `@renovatebot/pep440`-based helpers were not.

## Fix

Add `normalizeCpythonVersionInfo()` in `common/utils/pep440Release.ts`, converting the `sys.version_info` form to PEP 440:

- `3.14.3.final.0` → `3.14.3`
- `3.14.0.candidate.2` → `3.14.0rc2` (and `.alpha.N` / `.beta.N` → `aN` / `bN`)
- release segments are preserved verbatim — **no zero-padding**, so `3.13` stays `3.13` and `extractLowerBoundVersion()`'s `uv python install` targets are unchanged
- any non-`sys.version_info` string is returned unchanged

Apply it in:

- `parseReleaseSegments()` → fixes `areEqualPythonReleases()` (create + reuse cache validation) and the interpreter/candidate version sorting that also depends on it
- `matchesInstallConstraint()` (before `satisfiesPep440`) → fixes the `requires-python` base-selection and reuse paths

Scope is limited to the inline-script feature: `parseReleaseSegments` is used only by inline-script code, and `matchesInstallConstraint` is private to the inline-script manager. No change to venv / system / conda / other environment resolution.

## Testing

- New unit tests for `normalizeCpythonVersionInfo` and `parseReleaseSegments` (final + prerelease forms, whitespace, no zero-padding, non-matching passthrough).
- New create-flow regression tests in the inline-script manager suite: creation succeeds when the resolved base reports `3.14.3.final.0`, both **with** and **without** `requires-python` (both previously returned `undefined`).
- Full unit suite: **1978 passing / 6 pending**. `tsc` (`npm run compile-tests`) and `eslint` clean.

## Impact / benefit

Restores end-to-end PEP 723 inline-script environment creation on setups where the bundled `pet` reports `sys.version_info`-style versions (observed with `pet 0.1.0-dev.428887` on Windows for Python 3.12–3.14). Without this fix the "Set up environment" / CodeLens flow provisions the venv and then silently discards it, so users cannot create an inline-script environment at all.

## Out of scope

The same non-PEP-440 version string also makes `shortenVersionString()` return `"3.14.3.final.0"` verbatim (a **cosmetic** display artifact that affects all pet-resolved environments, not just inline scripts). That is a separate, non-blocking issue and is intentionally left for a follow-up to keep this fix's blast radius minimal.
