### PR TITLE
Fix inline-script routing for closed scripts, and surface its commands and names

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,6 +252,12 @@
                 "icon": "$(trash)"
             },
             {
+                "command": "python-envs.setupInlineScriptEnvs",
+                "title": "%python-envs.setupInlineScriptEnvs.title%",
+                "category": "Python Envs",
+                "icon": "$(tools)"
+            },
+            {
                 "command": "python-envs.runInTerminal",
                 "title": "%python-envs.runInTerminal.title%",
                 "category": "Python Envs",
@@ -422,6 +428,10 @@
                 },
                 {
                     "command": "python-envs.clearScriptEnvCache",
+                    "when": "pythonEnvsInlineScriptsEnabled"
+                },
+                {
+                    "command": "python-envs.setupInlineScriptEnvs",
                     "when": "pythonEnvsInlineScriptsEnabled"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -246,6 +246,12 @@
                 "icon": "$(trash)"
             },
             {
+                "command": "python-envs.clearScriptEnvCache",
+                "title": "%python-envs.clearScriptEnvCache.title%",
+                "category": "Python Envs",
+                "icon": "$(trash)"
+            },
+            {
                 "command": "python-envs.runInTerminal",
                 "title": "%python-envs.runInTerminal.title%",
                 "category": "Python Envs",
@@ -413,6 +419,10 @@
                 {
                     "command": "python-envs.runAsTask",
                     "when": "config.python.useEnvironmentsExtension != false"
+                },
+                {
+                    "command": "python-envs.clearScriptEnvCache",
+                    "when": "pythonEnvsInlineScriptsEnabled"
                 },
                 {
                     "command": "python-envs.terminal.activate",

--- a/package.nls.json
+++ b/package.nls.json
@@ -36,6 +36,7 @@
     "python-envs.packages.title": "Manage Packages",
     "python-envs.clearCache.title": "Clear Cache",
     "python-envs.clearScriptEnvCache.title": "Clear Inline Script Environment Cache",
+    "python-envs.setupInlineScriptEnvs.title": "Set Up Environments for Inline Script Files",
     "python-envs.runInTerminal.title": "Run in Terminal",
     "python-envs.createTerminal.title": "Create Python Terminal",
     "python-envs.runAsTask.title": "Run as Task",

--- a/package.nls.json
+++ b/package.nls.json
@@ -35,6 +35,7 @@
     "python-envs.refreshPackages.title": "Refresh Packages List",
     "python-envs.packages.title": "Manage Packages",
     "python-envs.clearCache.title": "Clear Cache",
+    "python-envs.clearScriptEnvCache.title": "Clear Inline Script Environment Cache",
     "python-envs.runInTerminal.title": "Run in Terminal",
     "python-envs.createTerminal.title": "Create Python Terminal",
     "python-envs.runAsTask.title": "Run as Task",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,9 +44,9 @@ import { NewScriptProject } from './features/creators/newScriptProject';
 import { ProjectCreatorsImpl } from './features/creators/projectCreators';
 import {
     addPythonProjectCommand,
-    copyPathToClipboard,
     clearEnvironmentCachesCommand,
     clearScriptEnvironmentCacheCommand,
+    copyPathToClipboard,
     createAnyEnvironmentCommand,
     createEnvironmentCommand,
     createTerminalCommand,
@@ -191,6 +191,8 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
     if (inlineScriptRouting) {
         context.subscriptions.push(inlineScriptRouting);
     }
+
+    void commands.executeCommand('setContext', 'pythonEnvsInlineScriptsEnabled', inlineScriptFeatureActivation.enabled);
 
     const envVarManager: EnvVarManager = new PythonEnvVariableManager(projectManager);
     context.subscriptions.push(envVarManager);

--- a/src/features/inlineScript/setupEnvironment.ts
+++ b/src/features/inlineScript/setupEnvironment.ts
@@ -4,11 +4,12 @@
 import { commands, Disposable, l10n, QuickPickItem, Uri, window } from 'vscode';
 import { PythonEnvironment } from '../../api';
 import { INLINE_SCRIPT_MANAGER_ID } from '../../common/constants';
-import { InlineScriptRoutingRegistry } from '../../common/inlineScript/routingRegistry';
 import { readInlineScriptMetadataFromFile } from '../../common/inlineScript/metadata';
+import { InlineScriptRoutingRegistry } from '../../common/inlineScript/routingRegistry';
 import { traceError, traceInfo } from '../../common/logging';
+import { normalizePath } from '../../common/utils/pathUtils';
 import { showErrorMessage, showInformationMessage, showQuickPickWithButtons } from '../../common/window.apis';
-import { asRelativePath, findFiles } from '../../common/workspace.apis';
+import { asRelativePath, findFiles, getOpenTextDocuments } from '../../common/workspace.apis';
 import { EnvironmentManagers } from '../../internal.api';
 import { registerInlineScriptCodeLens } from './codeLens';
 
@@ -54,6 +55,7 @@ export async function setUpInlineScriptEnvironment(
         traceError('Inline-script setup requested but the inline-script environment manager is not registered.');
         return undefined;
     }
+    await seedRoutingMetadataForClosedScript(scriptUri, routing);
     const metadataIdentityBeforeCreate = routing.getMetadataIdentity(scriptUri);
     const environment = await manager.create(scriptUri, undefined);
     if (!environment) {
@@ -68,6 +70,23 @@ export async function setUpInlineScriptEnvironment(
     }
     await em.setEnvironment(scriptUri, environment);
     return environment;
+}
+
+async function seedRoutingMetadataForClosedScript(scriptUri: Uri, routing: InlineScriptRoutingRegistry): Promise<void> {
+    if (routing.getMetadata(scriptUri)) {
+        return;
+    }
+    const scriptPath = normalizePath(scriptUri.fsPath);
+    const isOpen = getOpenTextDocuments().some(
+        (document) => document.uri.scheme === 'file' && normalizePath(document.uri.fsPath) === scriptPath,
+    );
+    if (isOpen) {
+        return;
+    }
+    const metadata = await readInlineScriptMetadataFromFile(scriptUri);
+    if (metadata && !routing.getMetadata(scriptUri)) {
+        routing.setMetadata(scriptUri, metadata);
+    }
 }
 
 function setupInlineScriptEnvironmentHandler(

--- a/src/features/inlineScript/setupEnvironment.ts
+++ b/src/features/inlineScript/setupEnvironment.ts
@@ -19,8 +19,9 @@ import { registerInlineScriptCodeLens } from './codeLens';
 export const SETUP_INLINE_SCRIPT_ENV_COMMAND = 'python-envs.setupInlineScriptEnv';
 
 /**
- * Hidden command that scans the workspace and sets up environments for the selected inline-script
- * files. Intentionally not contributed in `package.json` while the feature is behind the internal flag.
+ * Command that scans the workspace and sets up environments for the selected inline-script files.
+ * Contributed in `package.json` but only shown in the Command Palette while the inline-scripts
+ * feature flag is enabled (gated by the `pythonEnvsInlineScriptsEnabled` context key).
  */
 export const SETUP_INLINE_SCRIPT_ENVS_COMMAND = 'python-envs.setupInlineScriptEnvs';
 
@@ -182,8 +183,8 @@ async function filterInlineScriptFiles(files: readonly Uri[]): Promise<Uri[]> {
 
 /**
  * Register the inline-script user-facing surfaces (the CodeLens and its setup commands). Only called
- * when the PEP 723 inline-script feature flag is enabled; the commands are intentionally hidden from
- * `package.json` for now.
+ * when the PEP 723 inline-script feature flag is enabled. The single-file setup command is invoked by
+ * the CodeLens and stays out of `package.json`; the bulk command is palette-gated behind the flag.
  */
 export function registerInlineScriptUx(em: EnvironmentManagers, routing: InlineScriptRoutingRegistry): Disposable[] {
     return [

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -108,6 +108,7 @@ interface CreateOrReuseEnvironmentOptions {
     readonly metadata: InlineScriptMetadata;
     readonly selectedBase: SelectedBaseInterpreter;
     readonly pendingCreation: PendingCreationContext;
+    readonly scriptUri: Uri;
 }
 
 interface BuildCacheEntryResult {
@@ -374,6 +375,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             metadata,
             selectedBase,
             pendingCreation,
+            scriptUri,
         });
         pendingCreation.promise = creation;
         this.pendingCreations.set(cacheKey, pendingCreation);
@@ -780,6 +782,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                 this.api,
                 this,
                 this.baseManager,
+                'inlineScript',
             );
         } catch (error) {
             this.log.warn(`Unable to resolve inline-script cache entry ${envDir.fsPath}: ${getErrorMessage(error)}`);
@@ -1132,6 +1135,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                     this.api,
                     this,
                     this.baseManager,
+                    'inlineScript',
                 );
                 if (!this.isCurrentAssociationRevision(scriptPath, revision)) {
                     return this.fsPathToEnv.get(scriptPath);
@@ -1304,6 +1308,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                 this.api,
                 this,
                 this.baseManager,
+                'inlineScript',
             );
         } catch (error) {
             this.log.warn(
@@ -2622,6 +2627,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         metadata,
         selectedBase,
         pendingCreation,
+        scriptUri,
     }: CreateOrReuseEnvironmentOptions): Promise<PythonEnvironment | undefined> {
         const dependencyCount = this.getTelemetryDependencyCount(packages);
         const cacheRoot = getScriptEnvCacheRoot(this.globalStorageUri);
@@ -2650,7 +2656,14 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                 }
 
                 const buildStartAtMs = Date.now();
-                const build = await this.buildCacheEntry(envDir, cacheRoot, packages, selectedBase, pendingCreation);
+                const build = await this.buildCacheEntry(
+                    envDir,
+                    cacheRoot,
+                    packages,
+                    selectedBase,
+                    pendingCreation,
+                    scriptUri,
+                );
                 if (build.retainLock) {
                     try {
                         await lock.retain();
@@ -2738,6 +2751,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             this.api,
             this,
             this.baseManager,
+            'inlineScript',
         );
         if (!environment) {
             return { kind: 'uncertain' };
@@ -2784,6 +2798,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         packages: ReadonlyArray<string>,
         selectedBase: SelectedBaseInterpreter,
         pendingCreation: PendingCreationContext,
+        scriptUri: Uri,
     ): Promise<BuildCacheEntryResult> {
         let result;
         try {
@@ -2797,6 +2812,10 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                 envDir.fsPath,
                 { install: [...packages], uninstall: [] },
                 false, // trackUvEnvironment
+                {
+                    progressTitle: l10n.t('Setting up environment for {0}', path.basename(scriptUri.fsPath)),
+                    nameStyle: 'inlineScript',
+                },
             );
         } catch (error) {
             this.log.error(`Failed to build inline-script environment: ${getErrorMessage(error)}`);

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -223,7 +223,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
     public readonly onDidChangeEnvironment: Event<DidChangeEnvironmentEventArgs> = this._onDidChangeEnvironment.event;
 
     public readonly name = 'inline-script';
-    public readonly displayName = l10n.t('Inline script environments');
+    public readonly displayName = l10n.t('Inline scripts');
     public readonly preferredPackageManagerId = 'ms-python.python:pip';
     public readonly description: string | undefined = undefined;
     public readonly tooltip: string | MarkdownString = new MarkdownString(

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import type { Stats } from 'fs';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import type { Stats } from 'fs';
 import {
     Disposable,
     Event,
@@ -20,8 +20,8 @@ import {
     CreateEnvironmentScope,
     DidChangeEnvironmentEventArgs,
     DidChangeEnvironmentsEventArgs,
-    EnvironmentManager,
     EnvironmentChangeKind,
+    EnvironmentManager,
     GetEnvironmentScope,
     GetEnvironmentsScope,
     IconPath,
@@ -31,23 +31,29 @@ import {
     ResolveEnvironmentContext,
     SetEnvironmentScope,
 } from '../../../api';
+import {
+    CONDA_MANAGER_ID,
+    INLINE_SCRIPT_MANAGER_ID,
+    PYENV_MANAGER_ID,
+    SYSTEM_MANAGER_ID,
+} from '../../../common/constants';
 import { getErrorMessage } from '../../../common/errors/utils';
 import { computeCacheKey, normalizeDependency } from '../../../common/inlineScript/cacheKey';
 import {
     CacheEntrySummary,
     CacheEnvironmentInspection,
-    INLINE_SCRIPT_CACHE_DIR_NAME,
-    InlineScriptEnvMeta,
-    hashSourceMetadataIdentity,
-    mergeSourceMetadataIdentityHashes,
-    META_SCHEMA_VERSION,
     getBaseInterpreterStatus,
     getScriptEnvCacheRoot,
     getScriptEnvDir,
-    inspectOwnedCacheEntry,
+    hashSourceMetadataIdentity,
+    INLINE_SCRIPT_CACHE_DIR_NAME,
+    InlineScriptEnvMeta,
     inspectMetaJson,
-    restoreMetaJsonBackupUnderLock,
+    inspectOwnedCacheEntry,
+    mergeSourceMetadataIdentityHashes,
+    META_SCHEMA_VERSION,
     resolveCacheEntryPath,
+    restoreMetaJsonBackupUnderLock,
     selectStaleEntries,
     writeMetaJson,
 } from '../../../common/inlineScript/cacheLayout';
@@ -59,20 +65,13 @@ import {
     InlineScriptRoutingRegistry,
 } from '../../../common/inlineScript/routingRegistry';
 import {
-    CONDA_MANAGER_ID,
-    INLINE_SCRIPT_MANAGER_ID,
-    PYENV_MANAGER_ID,
-    SYSTEM_MANAGER_ID,
-} from '../../../common/constants';
-import {
-    acquireFileLock,
     AcquiredFileLock,
+    acquireFileLock,
     FILE_LOCK_DIR_SUFFIX,
     getFileLockPath,
     inspectFileLock,
     reclaimFileLock,
 } from '../../../common/lockfile.apis';
-import { InlineAssociationAccessor, InlineScriptAssociationStore } from './associationStore';
 import { EventNames, InlineScriptEnvErrorCategory } from '../../../common/telemetry/constants';
 import { sendTelemetryEvent } from '../../../common/telemetry/sender';
 import { createDeferred, Deferred } from '../../../common/utils/deferred';
@@ -87,6 +86,7 @@ import { sortEnvironments } from '../../common/utils';
 import { resolveSystemPythonEnvironmentPath } from '../utils';
 import * as uvPythonInstaller from '../uvPythonInstaller';
 import { createWithProgress, hasMinimumPathDepth, isDriveRoot, resolveVenvPythonEnvironmentPath } from '../venvUtils';
+import { InlineAssociationAccessor, InlineScriptAssociationStore } from './associationStore';
 
 const BASE_INTERPRETER_MANAGER_IDS = new Set([SYSTEM_MANAGER_ID, CONDA_MANAGER_ID, PYENV_MANAGER_ID]);
 
@@ -1835,10 +1835,27 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         });
     }
 
+    private async seedRoutingMetadataFromSavedFile(uri: Uri, scriptPath: string): Promise<void> {
+        if (this.routingRegistry.getMetadata(scriptPath) || this.isDocumentOpen(scriptPath)) {
+            return;
+        }
+        const metadata = await readInlineScriptMetadataFromFile(uri);
+        if (metadata && !this.routingRegistry.getMetadata(scriptPath)) {
+            this.routingRegistry.setMetadata(uri, metadata);
+        }
+    }
+
+    private isDocumentOpen(scriptPath: string): boolean {
+        return getOpenTextDocuments().some(
+            (document) => document.uri.scheme === 'file' && normalizePath(document.uri.fsPath) === scriptPath,
+        );
+    }
+
     private initializePersistedAssociations(): Promise<void> {
         return this.persistedAssociationsLoaded.then(async () => {
             await Promise.all(
                 [...this.fsPathToPersistedAssociation.keys()].map(async (scriptPath) => {
+                    await this.seedRoutingMetadataFromSavedFile(Uri.file(scriptPath), scriptPath);
                     const uri = this.routingRegistry.getUri(scriptPath);
                     const metadata = this.routingRegistry.getMetadata(scriptPath);
                     if (uri && metadata) {

--- a/src/managers/builtin/venvUtils.ts
+++ b/src/managers/builtin/venvUtils.ts
@@ -156,7 +156,10 @@ function getName(binPath: string): string {
     return path.basename(dir1);
 }
 
-async function getPythonInfo(env: NativeEnvInfo): Promise<PythonEnvironmentInfo> {
+/** Controls how {@link getPythonInfo} formats an environment's user-facing name. */
+export type VenvNameStyle = 'default' | 'inlineScript';
+
+async function getPythonInfo(env: NativeEnvInfo, nameStyle: VenvNameStyle = 'default'): Promise<PythonEnvironmentInfo> {
     // Handle broken environments that have an error field
     if (env.error) {
         const venvName = env.name ?? (env.prefix ? path.basename(env.prefix) : 'Unknown');
@@ -185,7 +188,12 @@ async function getPythonInfo(env: NativeEnvInfo): Promise<PythonEnvironmentInfo>
     if (env.executable && env.version && env.prefix) {
         const venvName = env.name ?? getName(env.executable);
         const sv = shortenVersionString(env.version);
-        const name = `${venvName} (${sv})`;
+        // Inline-script (PEP 723) environments live in content-addressed cache folders whose names
+        // are hashes. Surface a human-readable label instead of leaking that hash: the short form
+        // leads with the version (compact for the status bar), the full name reads "script env".
+        const isInlineScript = nameStyle === 'inlineScript';
+        const name = isInlineScript ? l10n.t('script env ({0})', sv) : `${venvName} (${sv})`;
+        const shortDisplayName = isInlineScript ? l10n.t('{0} (script)', sv) : `${sv} (${venvName})`;
         let description = undefined;
         if (env.kind === NativePythonEnvironmentKind.venvUv) {
             description = l10n.t('uv');
@@ -200,7 +208,7 @@ async function getPythonInfo(env: NativeEnvInfo): Promise<PythonEnvironmentInfo>
         return {
             name: name,
             displayName: name,
-            shortDisplayName: `${sv} (${venvName})`,
+            shortDisplayName: shortDisplayName,
             displayPath: env.executable,
             version: env.version,
             description: description,
@@ -351,6 +359,13 @@ export async function getGlobalVenvLocation(): Promise<Uri | undefined> {
     return undefined;
 }
 
+export interface CreateWithProgressOptions {
+    /** Overrides the progress-notification title shown while the environment is created. */
+    readonly progressTitle?: string;
+    /** Controls how the created environment's user-facing name is formatted. */
+    readonly nameStyle?: VenvNameStyle;
+}
+
 export async function createWithProgress(
     nativeFinder: NativePythonFinder,
     api: PythonEnvironmentApi,
@@ -361,17 +376,20 @@ export async function createWithProgress(
     envPath: string,
     packages?: PipPackages,
     trackUvEnvironment = true,
+    options?: CreateWithProgressOptions,
 ): Promise<CreateEnvironmentResult | undefined> {
     const pythonPath = getVenvPythonPath(envPath);
 
     return await withProgress(
         {
             location: ProgressLocation.Notification,
-            title: l10n.t(
-                'Creating virtual environment named {0} using python version {1}.',
-                path.basename(envPath),
-                basePython.version,
-            ),
+            title:
+                options?.progressTitle ??
+                l10n.t(
+                    'Creating virtual environment named {0} using python version {1}.',
+                    path.basename(envPath),
+                    basePython.version,
+                ),
         },
         async () => {
             const result: CreateEnvironmentResult = {};
@@ -400,7 +418,7 @@ export async function createWithProgress(
 
                 // handle admin of new env
                 const resolved = await nativeFinder.resolve(pythonPath);
-                const env = api.createPythonEnvironmentItem(await getPythonInfo(resolved), manager);
+                const env = api.createPythonEnvironmentItem(await getPythonInfo(resolved, options?.nameStyle), manager);
 
                 if (
                     trackUvEnvironment &&
@@ -622,6 +640,7 @@ export async function resolveVenvPythonEnvironmentPath(
     api: PythonEnvironmentApi,
     manager: EnvironmentManager,
     baseManager: EnvironmentManager,
+    nameStyle: VenvNameStyle = 'default',
 ): Promise<PythonEnvironment | undefined> {
     try {
         const resolved = await nativeFinder.resolve(fsPath);
@@ -631,7 +650,7 @@ export async function resolveVenvPythonEnvironmentPath(
             resolved.kind === NativePythonEnvironmentKind.venvUv ||
             resolved.kind === NativePythonEnvironmentKind.uvWorkspace
         ) {
-            const envInfo = await getPythonInfo(resolved);
+            const envInfo = await getPythonInfo(resolved, nameStyle);
             return api.createPythonEnvironmentItem(envInfo, manager);
         }
     } catch (ex) {

--- a/src/test/features/inlineScript/setupEnvironment.unit.test.ts
+++ b/src/test/features/inlineScript/setupEnvironment.unit.test.ts
@@ -44,11 +44,15 @@ suite('setUpInlineScriptEnvironment', () => {
     let em: typemoq.IMock<EnvironmentManagers>;
     let manager: typemoq.IMock<InternalEnvironmentManager>;
     let routing: InlineScriptRoutingRegistry;
+    let readMetadataStub: sinon.SinonStub;
+    let openDocumentsStub: sinon.SinonStub;
 
     setup(() => {
         em = typemoq.Mock.ofType<EnvironmentManagers>();
         manager = typemoq.Mock.ofType<InternalEnvironmentManager>();
         routing = new InlineScriptRoutingRegistry();
+        readMetadataStub = sinon.stub(metadataApi, 'readInlineScriptMetadataFromFile').resolves(undefined);
+        openDocumentsStub = sinon.stub(wapi, 'getOpenTextDocuments').returns([]);
         em.setup((m) => m.getEnvironmentManager(INLINE_SCRIPT_MANAGER_ID)).returns(() => manager.object);
     });
 
@@ -85,6 +89,49 @@ suite('setUpInlineScriptEnvironment', () => {
 
         assert.strictEqual(result, env);
         em.verify((m) => m.setEnvironment(scriptUri, env), typemoq.Times.once());
+    });
+
+    test('publishes saved metadata for a closed script so its project can route', async () => {
+        // The lazy detector only observes open documents, so bulk setup of a closed script would
+        // otherwise leave the registry with no metadata and the script permanently non-routeable.
+        const metadata = makeMetadata(['requests']);
+        readMetadataStub.resolves(metadata);
+        const env = makeEnv();
+        manager.setup((m) => m.create(scriptUri, undefined)).returns(() => Promise.resolve(env));
+        em.setup((m) => m.setEnvironment(scriptUri, env)).returns(() => Promise.resolve());
+
+        const result = await setUpInlineScriptEnvironment(scriptUri, em.object, routing);
+
+        assert.strictEqual(result, env);
+        assert.deepStrictEqual(routing.getMetadata(scriptUri), metadata);
+        sinon.assert.calledOnceWithExactly(readMetadataStub, scriptUri);
+    });
+
+    test('leaves an open document to the detector instead of publishing from disk', async () => {
+        openDocumentsStub.returns([{ uri: scriptUri, isDirty: true }]);
+        readMetadataStub.resolves(makeMetadata(['requests']));
+        const env = makeEnv();
+        manager.setup((m) => m.create(scriptUri, undefined)).returns(() => Promise.resolve(env));
+        em.setup((m) => m.setEnvironment(scriptUri, env)).returns(() => Promise.resolve());
+
+        await setUpInlineScriptEnvironment(scriptUri, em.object, routing);
+
+        assert.strictEqual(routing.getMetadata(scriptUri), undefined);
+        sinon.assert.notCalled(readMetadataStub);
+    });
+
+    test('does not overwrite metadata the detector already published', async () => {
+        const observed = makeMetadata(['observed']);
+        routing.setMetadata(scriptUri, observed);
+        readMetadataStub.resolves(makeMetadata(['from-disk']));
+        const env = makeEnv();
+        manager.setup((m) => m.create(scriptUri, undefined)).returns(() => Promise.resolve(env));
+        em.setup((m) => m.setEnvironment(scriptUri, env)).returns(() => Promise.resolve());
+
+        await setUpInlineScriptEnvironment(scriptUri, em.object, routing);
+
+        assert.deepStrictEqual(routing.getMetadata(scriptUri), observed);
+        sinon.assert.notCalled(readMetadataStub);
     });
 
     test('skips association when the script metadata changes during creation', async () => {
@@ -124,6 +171,7 @@ suite('setUpInlineScriptEnvironmentsInWorkspace', () => {
 
         findFilesStub = sinon.stub(wapi, 'findFiles');
         sinon.stub(wapi, 'asRelativePath').callsFake((p) => (p instanceof Uri ? p.fsPath : String(p)));
+        sinon.stub(wapi, 'getOpenTextDocuments').returns([]);
         readMetadataStub = sinon.stub(metadataApi, 'readInlineScriptMetadataFromFile');
         quickPickStub = sinon.stub(winapi, 'showQuickPickWithButtons');
         infoStub = sinon.stub(winapi, 'showInformationMessage');

--- a/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
+++ b/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
@@ -4916,6 +4916,91 @@ suite('InlineScriptEnvManager', () => {
             restarted.dispose();
         });
 
+        test('routes a persisted association after restart without opening the script', async () => {
+            // Regression: the lazy detector only publishes metadata for open documents, so a script
+            // set up in an earlier session stayed non-routeable after a reload and its project
+            // resolved through the default manager (wrong environment in the project view).
+            const uri = scriptUri();
+            const environment = await createOwnedEnvironment();
+            persistedAssociations = {
+                [normalizePath(uri.fsPath)]: matchedAssociationRecord(environment.environmentPath.fsPath),
+            };
+            const restartRoutingRegistry = new InlineScriptRoutingRegistry();
+
+            const restarted = new InlineScriptEnvManager(
+                nativeFinder,
+                api,
+                baseManager,
+                globalStorageUri,
+                makeFakeLog(),
+                workspaceMemento,
+                restartRoutingRegistry,
+            );
+
+            await waitForCondition(
+                () => restartRoutingRegistry.shouldRoute(uri),
+                'Expected the persisted association to route without the script being opened',
+            );
+            assert.strictEqual(await restarted.get(uri), environment);
+            restarted.dispose();
+        });
+
+        test('does not seed routing metadata for a persisted script that is open', async () => {
+            // Open documents belong to the detector, which withholds metadata while the block is
+            // being edited; seeding from disk would publish content the user has already changed.
+            const uri = scriptUri();
+            const environment = await createOwnedEnvironment();
+            persistedAssociations = {
+                [normalizePath(uri.fsPath)]: matchedAssociationRecord(environment.environmentPath.fsPath),
+            };
+            (workspaceApis.getOpenTextDocuments as sinon.SinonStub).returns([
+                { uri, isDirty: true } as unknown as TextDocument,
+            ]);
+            const restartRoutingRegistry = new InlineScriptRoutingRegistry();
+
+            const restarted = new InlineScriptEnvManager(
+                nativeFinder,
+                api,
+                baseManager,
+                globalStorageUri,
+                makeFakeLog(),
+                workspaceMemento,
+                restartRoutingRegistry,
+            );
+            await nextTurn();
+            await nextTurn();
+
+            assert.strictEqual(restartRoutingRegistry.getMetadata(uri), undefined);
+            assert.strictEqual(restartRoutingRegistry.shouldRoute(uri), false);
+            restarted.dispose();
+        });
+
+        test('does not seed routing metadata when the saved script no longer declares metadata', async () => {
+            const uri = scriptUri();
+            const environment = await createOwnedEnvironment();
+            persistedAssociations = {
+                [normalizePath(uri.fsPath)]: matchedAssociationRecord(environment.environmentPath.fsPath),
+            };
+            readMetadataStub.resolves(undefined);
+            const restartRoutingRegistry = new InlineScriptRoutingRegistry();
+
+            const restarted = new InlineScriptEnvManager(
+                nativeFinder,
+                api,
+                baseManager,
+                globalStorageUri,
+                makeFakeLog(),
+                workspaceMemento,
+                restartRoutingRegistry,
+            );
+            await nextTurn();
+            await nextTurn();
+
+            assert.strictEqual(restartRoutingRegistry.getMetadata(uri), undefined);
+            assert.strictEqual(restartRoutingRegistry.shouldRoute(uri), false);
+            restarted.dispose();
+        });
+
         test('does not rewrite or notify when a restart reselects the same persisted executable', async () => {
             const uri = scriptUri();
             const environment = await createOwnedEnvironment();
@@ -4930,6 +5015,15 @@ suite('InlineScriptEnvManager', () => {
                 workspaceMemento,
                 restartRoutingRegistry,
             );
+            // Startup now seeds routing metadata for persisted associations from the saved file and
+            // validates them, so a closed script routes without being opened first. Let that settle so
+            // the assertions below measure only the work done by reselecting the same executable.
+            await waitForCondition(
+                () => restartRoutingRegistry.hasValidatedAssociation(uri),
+                'Expected startup validation to make the persisted association routeable',
+            );
+            resolveVenvStub.resetHistory();
+            workspaceState.update.resetHistory();
             const listener = sinon.spy();
             restarted.onDidChangeEnvironment(listener);
 

--- a/src/test/smoke/registration.smoke.test.ts
+++ b/src/test/smoke/registration.smoke.test.ts
@@ -113,22 +113,29 @@ suite('Smoke: Registration Checks', function () {
         );
     });
 
-    test('Internal inline clear command is not publicly contributed', function () {
+    test('Inline clear command is contributed but palette-gated behind the inline-scripts flag', function () {
         const extension = vscode.extensions.getExtension<PythonEnvironmentApi>(ENVS_EXTENSION_ID);
         assert.ok(extension, `Extension ${ENVS_EXTENSION_ID} not found`);
 
         const contributedCommands = (extension.packageJSON?.contributes?.commands ?? []) as Array<{ command: string }>;
         const commandPaletteEntries = (extension.packageJSON?.contributes?.menus?.commandPalette ?? []) as Array<{
             command: string;
+            when?: string;
         }>;
 
         assert.ok(
-            !contributedCommands.some((entry) => entry.command === 'python-envs.clearScriptEnvCache'),
-            'python-envs.clearScriptEnvCache should not be publicly contributed before rollout',
+            contributedCommands.some((entry) => entry.command === 'python-envs.clearScriptEnvCache'),
+            'python-envs.clearScriptEnvCache should be contributed so it can appear in the palette',
         );
+        const paletteEntry = commandPaletteEntries.find((entry) => entry.command === 'python-envs.clearScriptEnvCache');
         assert.ok(
-            !commandPaletteEntries.some((entry) => entry.command === 'python-envs.clearScriptEnvCache'),
-            'python-envs.clearScriptEnvCache should not appear in contributed menus before rollout',
+            paletteEntry,
+            'python-envs.clearScriptEnvCache should have a commandPalette entry that gates its visibility',
+        );
+        assert.strictEqual(
+            paletteEntry.when,
+            'pythonEnvsInlineScriptsEnabled',
+            'python-envs.clearScriptEnvCache should only appear when the inline-scripts feature flag is enabled',
         );
     });
 

--- a/src/test/smoke/registration.smoke.test.ts
+++ b/src/test/smoke/registration.smoke.test.ts
@@ -139,7 +139,35 @@ suite('Smoke: Registration Checks', function () {
         );
     });
 
-    test('Internal inline clear command is not registered while the feature flag is off', async function () {
+    test('Inline bulk setup command is contributed but palette-gated behind the inline-scripts flag', function () {
+        const extension = vscode.extensions.getExtension<PythonEnvironmentApi>(ENVS_EXTENSION_ID);
+        assert.ok(extension, `Extension ${ENVS_EXTENSION_ID} not found`);
+
+        const contributedCommands = (extension.packageJSON?.contributes?.commands ?? []) as Array<{ command: string }>;
+        const commandPaletteEntries = (extension.packageJSON?.contributes?.menus?.commandPalette ?? []) as Array<{
+            command: string;
+            when?: string;
+        }>;
+
+        assert.ok(
+            contributedCommands.some((entry) => entry.command === 'python-envs.setupInlineScriptEnvs'),
+            'python-envs.setupInlineScriptEnvs should be contributed so it can appear in the palette',
+        );
+        const paletteEntry = commandPaletteEntries.find(
+            (entry) => entry.command === 'python-envs.setupInlineScriptEnvs',
+        );
+        assert.ok(
+            paletteEntry,
+            'python-envs.setupInlineScriptEnvs should have a commandPalette entry that gates its visibility',
+        );
+        assert.strictEqual(
+            paletteEntry.when,
+            'pythonEnvsInlineScriptsEnabled',
+            'python-envs.setupInlineScriptEnvs should only appear when the inline-scripts feature flag is enabled',
+        );
+    });
+
+    test('Internal inline-script commands are not registered while the feature flag is off', async function () {
         const allCommands = await vscode.commands.getCommands(true);
 
         assert.ok(
@@ -148,6 +176,15 @@ suite('Smoke: Registration Checks', function () {
         );
         await assert.rejects(
             () => Promise.resolve(vscode.commands.executeCommand('python-envs.clearScriptEnvCache')),
+            /not found/i,
+        );
+
+        assert.ok(
+            !allCommands.includes('python-envs.setupInlineScriptEnvs'),
+            'python-envs.setupInlineScriptEnvs should not be registered by default',
+        );
+        await assert.rejects(
+            () => Promise.resolve(vscode.commands.executeCommand('python-envs.setupInlineScriptEnvs')),
             /not found/i,
         );
     });


### PR DESCRIPTION
Five independent fixes and polish items for the PEP 723 inline-script feature, found while exercising it end to end. Every change is behind the existing internal `python-envs.inlineScripts.enabled` flag (undeclared, defaults to `false`), so there is **no behavior change for users who do not opt in**.

## 1. Closed inline scripts resolved to the wrong environment

**Issue.** With two or more scripts that have inline-script environments, the Python Projects view showed the correct environment only for the file that happened to be open. Every other script displayed the default/venv environment — and its packages — until you clicked the file open, at which point the row suddenly corrected itself.

**Cause.** `InlineScriptRoutingRegistry.setMetadata()` had exactly one caller: the lazy detector, which only observes documents on open/save. So the registry only ever knew about open files. `shouldRoute()` requires metadata, so a closed script could never route; `getExactProjectEnvironmentManager` deliberately declines to use the exact project setting for inline-registered projects, so resolution fell through to the project's persisted `envManager` — which is written as the *default* manager, not the inline one.

**A second instance of the same bug:** the bulk setup command operates on scripts that are typically closed. `updateValidatedStateForSelection` compares `routing.getMetadataIdentity(uri)` (undefined for a closed file) against the saved identity, so bulk setup built the environment and persisted a `matched` association that could **never** become routeable. This also explains why the picker's "environment already set up" hint never appeared for closed scripts.

**Fix.** Seed the routing registry from the *saved file* at the two points that already know an inline association exists — `initializePersistedAssociations` (reload) and `setUpInlineScriptEnvironment` (setup/bulk). No metadata is invented; it is read from disk exactly as the detector would, and it re-enters the existing validation pipeline rather than adding a parallel one. Both paths skip open documents (the detector owns those and deliberately withholds metadata while the block is being edited) and re-check the registry after the async read so they cannot race it.

Detection telemetry is unaffected: seeding calls the registry directly rather than going through the detector, so `inlineScript.detected` keeps its "files the user has shown intent in" meaning.

## 2. Environment name leaked the internal cache-key hash

**Issue.** Inline-script environments live in content-addressed cache folders, so the UI showed users a meaningless hash such as `0f3a91c4d5e2b7a8 (3.12.4)`, and the creation progress notification read `Creating virtual environment named 0f3a91c4d5e2b7a8 using python version 3.12.4.`

**Fix.** Setup progress now names the script being set up, and the environment shows `script env (3.12.4)` (short form `3.12.4 (script)`) across every resolution path — build, reuse, discovery, validation and rehydration. Implemented as an optional `nameStyle`/`progressTitle` on `createWithProgress` and a `nameStyle` argument on `resolveVenvPythonEnvironmentPath`; regular venv naming and progress are unchanged.

## 3. Environment Managers label was inconsistent

**Improvement.** Renamed the manager label from `Inline script environments` to `Inline scripts`, matching the terse style of the sibling managers (`venv`, `Conda`, `Global`).

## 4. Clear Cache command was unreachable

**Issue.** `python-envs.clearScriptEnvCache` was registered but never contributed, so there was no way to invoke it.

**Fix.** Contributed it and gated Command Palette visibility on a `pythonEnvsInlineScriptsEnabled` context key set at activation from the same latched flag that gates registration. Keying visibility off the activation-time flag rather than a live `config.` when-clause keeps the two in lockstep — otherwise the command would appear before the required window reload had registered it, and invoking it would fail with "command not found".

## 5. Bulk setup command was unreachable

**Issue.** `python-envs.setupInlineScriptEnvs` was registered by `registerInlineScriptUx` but not contributed, so the bulk flow could not be reached from the palette.

**Fix.** Contributed it behind the same context key, titled **Set Up Environments for Inline Script Files** to match the QuickPick it opens. Also corrected doc comments that still described it as hidden.

## Testing

- Full unit suite green: **1984 passing, 6 pending, 0 failing** (1978 before, plus 6 new tests).
- `tsc` compile and `npm run lint` across `src` are clean.
- New regression tests for the routing fix:
  - restart: a persisted association routes without the script being opened
  - restart: an open document is left to the detector (no seeding)
  - restart: a script that no longer declares metadata is not seeded
  - setup: a closed script gets its saved metadata published
  - setup: an open document is skipped and disk is never read
  - setup: metadata the detector already published is not overwritten
- Smoke tests for both newly contributed commands: contributed-but-palette-gated, and not registered when the flag is off.
- One existing test (`does not rewrite or notify when a restart reselects the same persisted executable`) now lets startup validation settle before measuring, because persisted associations are validated eagerly. All four of its original assertions still hold for the reselection itself.

## Notes for reviewers

- `envManager.ts` shows a large diff in the final commit, but that is overwhelmingly an import-sort/Prettier reformat; the functional change is about 29 lines (`seedRoutingMetadataFromSavedFile`, `isDocumentOpen`, and one call site).
- The one genuinely new runtime behavior is eager validation of persisted associations at activation: N header reads (≤ 8 KiB each) plus N environment resolutions, where N is the number of scripts explicitly set up in the workspace. This is mostly *moved* rather than added work — the tree view and Pylance call `getEnvironment()` moments later anyway — and it runs off the activation critical path.
