### PR TITLE
Add pre-release and stable Azure DevDiv pipeline configurations

### DIFF
--- a/build/azure-devdiv-pipeline.pre-release.yml
+++ b/build/azure-devdiv-pipeline.pre-release.yml
@@ -1,0 +1,183 @@
+# Run on a schedule
+trigger: none
+pr: none
+
+schedules:
+  - cron: '0 10 * * 1-5' # 10AM UTC (2AM PDT) MON-FRI (VS Code Pre-release builds at 9PM PDT)
+    displayName: Nightly Pre-Release Schedule
+    always: false # only run if there are source code changes
+    branches:
+      include:
+        - main
+
+resources:
+  repositories:
+    - repository: MicroBuildTemplate
+      type: git
+      name: 1ESPipelineTemplates/MicroBuildTemplate
+      ref: refs/tags/release
+
+    - repository: templates
+      type: git
+      name: DevDiv/Pylance-Eng
+      ref: refs/heads/main
+
+variables:
+  - name: TeamName
+    value: VSCode-python-environments
+  - name: VsixName
+    value: python-environments.vsix
+  - name: NodeVersion
+    value: '22.21.1'
+  - name: AZURE_ARTIFACTS_FEED
+    value: 'https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Pylance_PublicPackages/npm/registry/'
+
+parameters:
+  - name: publishExtension
+    displayName: 🚀 Publish Extension
+    type: boolean
+    default: true
+
+  - name: buildPlatforms
+    type: object
+    default:
+      - name: Linux
+        vsceTarget: web
+      - name: Linux
+        packageArch: arm64
+        vsceTarget: linux-arm64
+      - name: Linux
+        packageArch: arm
+        vsceTarget: linux-armhf
+      - name: Linux
+        packageArch: x64
+        vsceTarget: linux-x64
+      - name: Linux
+        packageArch: arm64
+        vsceTarget: alpine-arm64
+      - name: Linux
+        packageArch: x64
+        vsceTarget: alpine-x64
+      - name: MacOS
+        packageArch: arm64
+        vsceTarget: darwin-arm64
+      - name: MacOS
+        packageArch: x64
+        vsceTarget: darwin-x64
+      - name: Windows
+        packageArch: arm
+        vsceTarget: win32-arm64
+      - name: Windows
+        packageArch: x64
+        vsceTarget: win32-x64
+
+  - name: buildSteps
+    type: stepList
+    default:
+      - script: npm ci
+        displayName: Install NPM dependencies
+
+      - script: python ./build/update_package_json.py
+        displayName: Update telemetry in package.json
+
+      - script: python ./build/update_ext_version.py --for-publishing
+        displayName: Validate version number
+
+      - bash: |
+          mkdir -p $(Build.SourcesDirectory)/python-env-tools/bin
+          chmod +x $(Build.SourcesDirectory)/python-env-tools/bin
+        displayName: Make Directory for python-env-tool binary
+
+      - bash: |
+          if [ "$(vsceTarget)" == "win32-x64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]x86_64-pc-windows-msvc"
+          elif [ "$(vsceTarget)" == "win32-arm64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]aarch64-pc-windows-msvc"
+          elif [ "$(vsceTarget)" == "linux-x64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]x86_64-unknown-linux-musl"
+          elif [ "$(vsceTarget)" == "linux-arm64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]aarch64-unknown-linux-gnu"
+          elif [ "$(vsceTarget)" == "linux-armhf" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]armv7-unknown-linux-gnueabihf"
+          elif [ "$(vsceTarget)" == "darwin-x64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]x86_64-apple-darwin"
+          elif [ "$(vsceTarget)" == "darwin-arm64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]aarch64-apple-darwin"
+          elif [ "$(vsceTarget)" == "alpine-x64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]x86_64-unknown-linux-musl"
+          elif [ "$(vsceTarget)" == "alpine-arm64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]aarch64-unknown-linux-gnu"
+          elif [ "$(vsceTarget)" == "web" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]x86_64-unknown-linux-musl"
+          else
+            echo "##vso[task.setvariable variable=buildTarget]x86_64-unknown-linux-musl"
+          fi
+        displayName: Set buildTarget variable
+
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          buildType: specific
+          project: Monaco
+          definition: 591
+          buildVersionToDownload: latest
+          branchName: refs/heads/main
+          targetPath: $(Build.SourcesDirectory)/python-env-tools/bin
+          artifactName: bin-$(buildTarget)
+          itemPattern: |
+            pet.exe
+            pet
+            ThirdPartyNotices.txt
+
+      - bash: |
+          ls -l ./python-env-tools/bin
+          chmod +x ./python-env-tools/bin/pet*
+          ls -l ./python-env-tools/bin
+        displayName: Set chmod for pet binary
+
+      - script: npm run package
+        displayName: Build extension
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
+      codeSignValidation:
+        enabled: true
+      sbom:
+        enabled: false # Disable global SBOM generation; enable it on the signed artifact.
+    pool:
+      name: AzurePipelines-EO
+      os: windows
+
+    customBuildTags:
+      - ES365AIMigrationTooling
+
+    stages:
+      - stage: Build
+        displayName: Build & Package Extension
+        jobs:
+          - template: azure-pipelines/extension/templates/jobs/package.yml@templates
+            parameters:
+              buildPlatforms: ${{ parameters.buildPlatforms }}
+              buildSteps: ${{ parameters.buildSteps }}
+              isPreRelease: true
+              standardizedVersioning: true
+              customNPMRegistry: $(AZURE_ARTIFACTS_FEED)
+              nodeVersion: $(NodeVersion)
+
+      - stage: Publish
+        displayName: Publish Extension
+        dependsOn: Build
+        jobs:
+          - template: azure-pipelines/extension/templates/jobs/publish-extension.yml@templates
+            parameters:
+              buildPlatforms: ${{ parameters.buildPlatforms }}
+              publishExtension: ${{ parameters.publishExtension }}
+              preRelease: true
+              teamName: $(TeamName)
+              ghCreateTag: true
+              ghCreateRelease: true
+              ghReleaseAddChangeLog: true
+              customNPMRegistry: $(AZURE_ARTIFACTS_FEED)
+              nodeVersion: $(NodeVersion)

--- a/build/azure-devdiv-pipeline.stable.yml
+++ b/build/azure-devdiv-pipeline.stable.yml
@@ -1,0 +1,198 @@
+name: Publish Release
+trigger:
+  branches:
+    include:
+      - 'release/*'
+pr: none
+
+resources:
+  repositories:
+    - repository: MicroBuildTemplate
+      type: git
+      name: 1ESPipelineTemplates/MicroBuildTemplate
+      ref: refs/tags/release
+
+    - repository: templates
+      type: git
+      name: DevDiv/Pylance-Eng
+      ref: refs/heads/main
+
+variables:
+  - name: TeamName
+    value: VSCode-python-environments
+  - name: VsixName
+    value: python-environments.vsix
+  - name: NodeVersion
+    value: '22.21.1'
+  - name: AZURE_ARTIFACTS_FEED
+    value: 'https://devdiv.pkgs.visualstudio.com/DevDiv/_packaging/Pylance_PublicPackages/npm/registry/'
+
+parameters:
+  - name: publishExtension
+    displayName: 🚀 Publish Extension
+    type: boolean
+    default: true
+
+  - name: petBranch
+    displayName: PET artifact branch
+    type: string
+    default: refs/heads/release/2026.12
+
+  - name: buildPlatforms
+    type: object
+    default:
+      - name: Linux
+        vsceTarget: web
+      - name: Linux
+        packageArch: arm64
+        vsceTarget: linux-arm64
+      - name: Linux
+        packageArch: arm
+        vsceTarget: linux-armhf
+      - name: Linux
+        packageArch: x64
+        vsceTarget: linux-x64
+      - name: Linux
+        packageArch: arm64
+        vsceTarget: alpine-arm64
+      - name: Linux
+        packageArch: x64
+        vsceTarget: alpine-x64
+      - name: MacOS
+        packageArch: arm64
+        vsceTarget: darwin-arm64
+      - name: MacOS
+        packageArch: x64
+        vsceTarget: darwin-x64
+      - name: Windows
+        packageArch: arm
+        vsceTarget: win32-arm64
+      - name: Windows
+        packageArch: x64
+        vsceTarget: win32-x64
+
+  - name: buildSteps
+    type: stepList
+    default:
+      - script: npm ci
+        displayName: Install NPM dependencies
+
+      - script: python ./build/update_package_json.py
+        displayName: Update telemetry in package.json
+
+      - script: python ./build/update_ext_version.py --release --for-publishing
+        displayName: Update build number
+
+      - bash: |
+          mkdir -p $(Build.SourcesDirectory)/python-env-tools/bin
+          chmod +x $(Build.SourcesDirectory)/python-env-tools/bin
+        displayName: Make Directory for python-env-tool binary
+
+      - bash: |
+          if [ "$(vsceTarget)" == "win32-x64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]x86_64-pc-windows-msvc"
+          elif [ "$(vsceTarget)" == "win32-arm64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]aarch64-pc-windows-msvc"
+          elif [ "$(vsceTarget)" == "linux-x64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]x86_64-unknown-linux-musl"
+          elif [ "$(vsceTarget)" == "linux-arm64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]aarch64-unknown-linux-gnu"
+          elif [ "$(vsceTarget)" == "linux-armhf" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]armv7-unknown-linux-gnueabihf"
+          elif [ "$(vsceTarget)" == "darwin-x64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]x86_64-apple-darwin"
+          elif [ "$(vsceTarget)" == "darwin-arm64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]aarch64-apple-darwin"
+          elif [ "$(vsceTarget)" == "alpine-x64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]x86_64-unknown-linux-musl"
+          elif [ "$(vsceTarget)" == "alpine-arm64" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]aarch64-unknown-linux-gnu"
+          elif [ "$(vsceTarget)" == "web" ]; then
+            echo "##vso[task.setvariable variable=buildTarget]x86_64-unknown-linux-musl"
+          else
+            echo "##vso[task.setvariable variable=buildTarget]x86_64-unknown-linux-musl"
+          fi
+        displayName: Set buildTarget variable
+
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          buildType: specific
+          project: Monaco
+          definition: 593
+          buildVersionToDownload: latestFromBranch
+          branchName: ${{ parameters.petBranch }}
+          targetPath: $(Build.SourcesDirectory)/python-env-tools/bin
+          artifactName: bin-$(buildTarget)
+          itemPattern: |
+            pet.exe
+            pet
+            ThirdPartyNotices.txt
+
+      - bash: |
+          ls -lf ./python-env-tools/bin
+          chmod +x ./python-env-tools/bin/pet*
+          ls -lf ./python-env-tools/bin
+        displayName: Set chmod for pet binary
+
+      - script: npm run package
+        displayName: Build extension
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    sdl:
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
+      codeSignValidation:
+        enabled: true
+      sbom:
+        enabled: false # Disable global SBOM generation; enable it on the signed artifact.
+    pool:
+      name: AzurePipelines-EO
+      os: windows
+
+    customBuildTags:
+      - ES365AIMigrationTooling
+
+    stages:
+      - stage: Build
+        displayName: Build & Package Extension
+        jobs:
+          - template: azure-pipelines/extension/templates/jobs/package.yml@templates
+            parameters:
+              buildPlatforms: ${{ parameters.buildPlatforms }}
+              buildSteps: ${{ parameters.buildSteps }}
+              isPreRelease: false
+              standardizedVersioning: true
+              customNPMRegistry: $(AZURE_ARTIFACTS_FEED)
+              nodeVersion: $(NodeVersion)
+
+      - stage: WaitForValidation
+        displayName: Wait for Validation
+        dependsOn: Build
+        jobs:
+          - job: wait_for_validation
+            displayName: Wait for manual validation
+            pool: server
+            steps:
+              - task: ManualValidation@0
+                timeoutInMinutes: 1440 # task times out in 1 day
+                inputs:
+                  notifyUsers: 'plseng@microsoft.com'
+                  instructions: 'please test the latest draft release then publish it.'
+                  onTimeout: reject
+
+      - stage: Publish
+        displayName: Publish Extension
+        dependsOn: WaitForValidation
+        jobs:
+          - template: azure-pipelines/extension/templates/jobs/publish-extension.yml@templates
+            parameters:
+              buildPlatforms: ${{ parameters.buildPlatforms }}
+              publishExtension: ${{ parameters.publishExtension }}
+              preRelease: false
+              teamName: $(TeamName)
+              ghCreateTag: true
+              ghCreateRelease: true
+              ghReleaseAddChangeLog: true
+              customNPMRegistry: $(AZURE_ARTIFACTS_FEED)
+              nodeVersion: $(NodeVersion)

--- a/build/azure-pipeline.npm.yml
+++ b/build/azure-pipeline.npm.yml
@@ -41,7 +41,7 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.Publish.yml@MicroBuildTemplate
   parameters:
     sdl:
-      sourceAnalysisPool: VSEngSS-MicroBuild2022-1ES
+      sourceAnalysisPool: VSEng-MicroBuildVSStable
       codeSignValidation:
         enabled: true
       sbom:


### PR DESCRIPTION
This pull request introduces two new Azure DevOps pipeline YAML files for pre-release and stable builds, and updates the SDL pool for the existing npm pipeline. The changes modernize and standardize the CI/CD process for building and publishing the Python Environments extension, supporting multiple platforms and improving release management.

**New Azure DevOps pipelines:**

* Added `build/azure-devdiv-pipeline.pre-release.yml` to automate nightly pre-release builds and publishing, supporting multiple platforms and artifact downloads, and integrating with shared pipeline templates.
* Added `build/azure-devdiv-pipeline.stable.yml` to handle stable release builds, including manual validation before publishing, platform matrix builds, artifact handling, and integration with shared templates.

**Pipeline configuration improvements:**

* Updated the SDL `sourceAnalysisPool` in `build/azure-pipeline.npm.yml` to use `VSEng-MicroBuildVSStable`, aligning with the pools used in the new pipelines for consistency and stability.