### PR TITLE
Fix PEP 723 cache drift and support deleting individual script environments

### DIFF
--- a/docs/managing-python-projects.md
+++ b/docs/managing-python-projects.md
@@ -101,6 +101,8 @@ An inline-script environment is built from the script's `# /// script` block and
 
 Setup records which distributions it installed. If that record and the environment's contents later disagree — for example after installing a package into it from a terminal — every script sharing the environment needs setup again. Saving or reopening a script does not repair it; use the script's setup action to rebuild from its declared dependencies.
 
+Once a mismatch is confirmed during an environment lookup, the affected scripts' setup actions return without requiring a save.
+
 An environment whose recorded inventory is unknown, or cannot be read, is left alone rather than treated as modified.
 
 On Windows, changing only the letter casing of a script's filename keeps its existing environment association. A rename does not validate unsaved dependency edits or install packages.

--- a/docs/managing-python-projects.md
+++ b/docs/managing-python-projects.md
@@ -105,6 +105,10 @@ Once a mismatch is confirmed during an environment lookup, the affected scripts'
 
 An environment whose recorded inventory is unknown, or cannot be read, is left alone rather than treated as modified.
 
+**Delete Environment** on an inline-script environment deletes that single cached environment without a confirmation dialog and clears its known associations in the current workspace. All scripts sharing it will need setup again. Python files, project entries and settings, the base Python installation, and other cached environments are kept. Other windows discover the missing environment when they revalidate it.
+
+Stop runs or debug sessions using the environment before deleting it. The extension refuses deletion while script environments are being created; files held open by other processes may also prevent deletion. Failures are reported rather than treated as successful removal. If deletion begins but cannot finish, affected scripts need setup again; remaining files can be removed by retrying Delete.
+
 On Windows, changing only the letter casing of a script's filename keeps its existing environment association. A rename does not validate unsaved dependency edits or install packages.
 
 ## Assigning Environments to Projects

--- a/docs/managing-python-projects.md
+++ b/docs/managing-python-projects.md
@@ -97,6 +97,14 @@ my_package_project/
 
 When you create a script, the extension generates a single `.py` file with PEP 723 inline script metadata, which allows you to specify dependencies directly in the file.
 
+An inline-script environment is built from the script's `# /// script` block and stored in the extension's cache, where it is shared by every script with the same dependencies and base interpreter. Because editing one would silently change the others, these environments are not user-managed: the Python Environments views do not offer install, uninstall, or version-change actions for them. Their package list remains visible.
+
+Setup records which distributions it installed. If that record and the environment's contents later disagree — for example after installing a package into it from a terminal — every script sharing the environment needs setup again. Saving or reopening a script does not repair it; use the script's setup action to rebuild from its declared dependencies.
+
+An environment whose recorded inventory is unknown, or cannot be read, is left alone rather than treated as modified.
+
+On Windows, changing only the letter casing of a script's filename keeps its existing environment association. A rename does not validate unsaved dependency edits or install packages.
+
 ## Assigning Environments to Projects
 
 Each project can have its own Python environment. This is the core benefit of project management.

--- a/package.json
+++ b/package.json
@@ -523,7 +523,7 @@
                 {
                     "command": "python-envs.packages",
                     "group": "inline",
-                    "when": "view == env-managers && viewItem =~ /.*pythonEnvironment.*/"
+                    "when": "view == env-managers && viewItem =~ /;managePackages;/"
                 },
                 {
                     "command": "python-envs.copyEnvPath",

--- a/src/common/inlineScript/cacheLayout.ts
+++ b/src/common/inlineScript/cacheLayout.ts
@@ -23,6 +23,7 @@ export const META_JSON_FILENAME = '.meta.json';
  */
 export const META_SCHEMA_VERSION = 1 as const;
 export const SOURCE_METADATA_IDENTITY_HASH_HEX_LENGTH = 64;
+export const INSTALLED_PACKAGES_HASH_HEX_LENGTH = 64;
 export const MAX_SOURCE_METADATA_IDENTITY_HASHES = 128;
 
 const MAX_META_JSON_BYTES = 1024 * 1024;
@@ -44,6 +45,11 @@ export interface InlineScriptEnvMeta {
     readonly lastUsedAt: string;
     /** Set when packages changed outside setup; the entry no longer matches its declared dependencies. */
     readonly manuallyModified?: boolean;
+    /**
+     * SHA-256 of the distributions this extension installed into the entry, as recorded under the
+     * cache-entry lock. Absent when never recorded — which means "unknown", never "changed".
+     */
+    readonly installedPackagesHash?: string;
     /** Bounded SHA-256 hashes of metadata identities proven for this cache entry. */
     readonly sourceMetadataIdentityHashes?: readonly string[];
 }
@@ -325,6 +331,90 @@ export function hashSourceMetadataIdentity(identity: string): string {
     return crypto.createHash('sha256').update(identity, 'utf8').digest('hex');
 }
 
+/**
+ * Outcome of comparing an entry's recorded distributions against what is on disk.
+ *
+ * `unknown` is deliberately distinct from `changed`. Treating "no record" as "everything was
+ * added" is exactly the mistake that made merely listing packages invalidate a working
+ * environment; callers must never invalidate on `unknown`.
+ */
+export type InstalledPackagesComparison = 'unknown' | 'unchanged' | 'changed';
+
+/**
+ * The only place this decision is made. Keep it that way.
+ */
+export function compareInstalledPackages(
+    recordedHash: string | undefined,
+    actualHash: string | undefined,
+): InstalledPackagesComparison {
+    if (recordedHash === undefined || actualHash === undefined) {
+        return 'unknown';
+    }
+    return recordedHash === actualHash ? 'unchanged' : 'changed';
+}
+
+export function hashInstalledDistributions(distributions: readonly string[]): string {
+    const normalized = Array.from(new Set(distributions.map((name) => name.toLowerCase()))).sort();
+    return crypto.createHash('sha256').update(normalized.join('\n'), 'utf8').digest('hex');
+}
+
+/**
+ * `site-packages` locations inside a cached environment. Windows keeps a single `Lib/site-packages`;
+ * POSIX nests it under a version directory (`lib/python3.12/site-packages`), so that level is
+ * enumerated rather than guessed.
+ */
+async function getSitePackagesDirs(envDir: Uri): Promise<string[]> {
+    if (isWindows()) {
+        return [path.join(envDir.fsPath, 'Lib', 'site-packages')];
+    }
+    const libPath = path.join(envDir.fsPath, 'lib');
+    let entries: string[];
+    try {
+        entries = await fsapi.readdir(libPath);
+    } catch {
+        return [];
+    }
+    return entries.filter((entry) => entry.startsWith('python')).map((entry) => path.join(libPath, entry, 'site-packages'));
+}
+
+/**
+ * Names of the installed distributions in a cached environment, derived from `*.dist-info`
+ * directory names (which carry both name and version). Returns `undefined` when the inventory
+ * cannot be read, so callers see `unknown` rather than a false `changed`.
+ *
+ * Distributions that only ship legacy `.egg-info` are not observed here, matching the scope the
+ * package watcher previously treated as authoritative.
+ */
+export async function readInstalledDistributions(envDir: Uri): Promise<string[] | undefined> {
+    const sitePackagesDirs = await getSitePackagesDirs(envDir);
+    if (sitePackagesDirs.length === 0) {
+        return undefined;
+    }
+    const distributions: string[] = [];
+    let readAny = false;
+    for (const sitePackages of sitePackagesDirs) {
+        let entries: string[];
+        try {
+            entries = await fsapi.readdir(sitePackages);
+        } catch (error) {
+            if (isFileNotFoundError(error)) {
+                continue;
+            }
+            traceWarn(`inline-script env: failed to list ${sitePackages}:`, error);
+            return undefined;
+        }
+        readAny = true;
+        distributions.push(...entries.filter((entry) => entry.endsWith('.dist-info')));
+    }
+    return readAny ? distributions : undefined;
+}
+
+/** Current inventory hash for an entry, or `undefined` when it cannot be determined. */
+export async function readInstalledPackagesHash(envDir: Uri): Promise<string | undefined> {
+    const distributions = await readInstalledDistributions(envDir);
+    return distributions === undefined ? undefined : hashInstalledDistributions(distributions);
+}
+
 export function mergeSourceMetadataIdentityHashes(
     existing: readonly string[] | undefined,
     current: string | undefined,
@@ -470,6 +560,9 @@ function validateMeta(value: unknown): InlineScriptEnvMeta | 'unsupported' | und
     if (obj.manuallyModified !== undefined && typeof obj.manuallyModified !== 'boolean') {
         return undefined;
     }
+    if (obj.installedPackagesHash !== undefined && !isInstalledPackagesHash(obj.installedPackagesHash)) {
+        return undefined;
+    }
     const sourceMetadataIdentityHashes = validateSourceMetadataIdentityHashes(obj.sourceMetadataIdentityHashes);
     if (obj.sourceMetadataIdentityHashes !== undefined && sourceMetadataIdentityHashes === undefined) {
         return undefined;
@@ -481,8 +574,19 @@ function validateMeta(value: unknown): InlineScriptEnvMeta | 'unsupported' | und
         baseInterpreterVersion: obj.baseInterpreterVersion,
         lastUsedAt: obj.lastUsedAt,
         ...(obj.manuallyModified === true ? { manuallyModified: true } : {}),
+        ...(isInstalledPackagesHash(obj.installedPackagesHash)
+            ? { installedPackagesHash: obj.installedPackagesHash }
+            : {}),
         ...(sourceMetadataIdentityHashes ? { sourceMetadataIdentityHashes } : {}),
     };
+}
+
+function isInstalledPackagesHash(value: unknown): value is string {
+    return (
+        typeof value === 'string' &&
+        value.length === INSTALLED_PACKAGES_HASH_HEX_LENGTH &&
+        /^[0-9a-f]+$/.test(value)
+    );
 }
 
 function validateSourceMetadataIdentityHashes(value: unknown): readonly string[] | undefined {

--- a/src/common/inlineScript/errors.ts
+++ b/src/common/inlineScript/errors.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { l10n } from 'vscode';
+
+export class InlineScriptEnvironmentModifiedError extends Error {
+    constructor() {
+        super(l10n.t(
+            'This inline-script environment has modified packages. Set up the script environment again before selecting it.',
+        ));
+        this.name = 'InlineScriptEnvironmentModifiedError';
+    }
+}
+
+/**
+ * Raised when a package-management command targets an inline-script environment.
+ *
+ * These environments are built from a script's `# /// script` block and are shared by every
+ * script with the same dependencies and base interpreter, so editing their packages by hand
+ * would silently change other scripts. The tree view hides the actions; this covers the command
+ * palette, which can still resolve one from the active script.
+ */
+export class InlineScriptPackagesNotManagedError extends Error {
+    constructor() {
+        super(l10n.t(
+            'Packages of an inline-script environment are managed by its "# /// script" block. Edit the script\'s dependencies and set up its environment again.',
+        ));
+        this.name = 'InlineScriptPackagesNotManagedError';
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import {
 import { PythonEnvironment, PythonEnvironmentApi, PythonProjectCreator } from './api';
 import { ENVS_EXTENSION_ID } from './common/constants';
 import { ensureCorrectVersion } from './common/extVersion';
+import { InlineScriptPackagesNotManagedError } from './common/inlineScript/errors';
 import { registerLogger, traceError, traceInfo, traceWarn } from './common/logging';
 import { setPersistentState } from './common/persistentState';
 import { newProjectSelection } from './common/pickers/managers';
@@ -346,13 +347,20 @@ export async function activate(context: ExtensionContext): Promise<PythonEnviron
             await removeEnvironmentCommand(item, envManagers);
         }),
         commands.registerCommand('python-envs.packages', async (options: unknown) => {
-            const { environment, packageManager } = await getPackageCommandOptions(
-                options,
-                envManagers,
-                projectManager,
-            );
+            let resolved;
             try {
-                packageManager.manage(environment, { install: [] });
+                resolved = await getPackageCommandOptions(options, envManagers, projectManager);
+            } catch (err) {
+                if (!(err instanceof InlineScriptPackagesNotManagedError)) {
+                    // Preserve the existing contract: other resolution failures still surface.
+                    throw err;
+                }
+                traceError('Rejected a package command for an inline-script environment:', err);
+                await window.showErrorMessage(err.message);
+                return;
+            }
+            try {
+                resolved.packageManager.manage(resolved.environment, { install: [] });
             } catch (err) {
                 traceError('Error when running command python-envs.packages', err);
             }

--- a/src/features/envCommands.ts
+++ b/src/features/envCommands.ts
@@ -22,6 +22,7 @@ import {
     isPackageVersionLookupNotSupportedError,
 } from '../api';
 import { traceError, traceInfo, traceVerbose } from '../common/logging';
+import { InlineScriptEnvironmentModifiedError, InlineScriptPackagesNotManagedError } from '../common/inlineScript/errors';
 import * as persistentState from '../common/persistentState';
 import {
     EnvironmentManagers,
@@ -439,6 +440,22 @@ export async function setEnvironmentCommand(
     em: EnvironmentManagers,
     wm: PythonProjectManager,
 ): Promise<void> {
+    try {
+        await setEnvironmentCommandInternal(context, em, wm);
+    } catch (error) {
+        if (!(error instanceof InlineScriptEnvironmentModifiedError)) {
+            throw error;
+        }
+        traceError('Cannot select a modified inline-script environment:', error);
+        await showErrorMessage(error.message);
+    }
+}
+
+async function setEnvironmentCommandInternal(
+    context: unknown,
+    em: EnvironmentManagers,
+    wm: PythonProjectManager,
+): Promise<void> {
     if (context instanceof PythonEnvTreeItem) {
         try {
             const view = context as PythonEnvTreeItem;
@@ -734,10 +751,27 @@ export async function getPackageCommandOptions(
     packageManager: InternalPackageManager;
     environment: PythonEnvironment;
 }> {
+    const options = await resolvePackageCommandOptions(e, em, pm);
+    // The tree view hides package actions for inline-script environments, but the command palette
+    // can still resolve one from the active script. Refuse here so every entry point agrees.
+    if (options.environment.envId.managerId === INLINE_SCRIPT_MANAGER_ID) {
+        throw new InlineScriptPackagesNotManagedError();
+    }
+    return options;
+}
+
+async function resolvePackageCommandOptions(
+    e: unknown,
+    em: EnvironmentManagers,
+    pm: PythonProjectManager,
+): Promise<{
+    packageManager: InternalPackageManager;
+    environment: PythonEnvironment;
+}> {
     if (e === undefined) {
         const project = await pickProject(pm.getProjects());
         if (project) {
-            return getPackageCommandOptions(project.uri, em, pm);
+            return resolvePackageCommandOptions(project.uri, em, pm);
         }
     }
 

--- a/src/features/envCommands.ts
+++ b/src/features/envCommands.ts
@@ -312,7 +312,13 @@ export async function removeEnvironmentCommand(context: unknown, managers: Envir
         }
     } else if (context instanceof ProjectEnvironment) {
         const view = context as ProjectEnvironment;
-        const manager = managers.getEnvironmentManager(view.parent.project.uri);
+        const inlineScript = view.environment.envId.managerId === INLINE_SCRIPT_MANAGER_ID;
+        const manager = managers.getEnvironmentManager(
+            inlineScript ? view.environment : view.parent.project.uri,
+        );
+        if (inlineScript && !manager) {
+            throw new Error(l10n.t('The inline-script environment manager is not available to delete this environment.'));
+        }
         await manager?.remove(view.environment);
     } else {
         traceError(`Invalid context for remove command: ${context}`);

--- a/src/features/inlineScript/lazyDetector.ts
+++ b/src/features/inlineScript/lazyDetector.ts
@@ -40,10 +40,10 @@ import {
  */
 export class InlineScriptLazyDetector implements Disposable {
     private readonly subscriptions: Disposable[] = [];
-    // In-flight reads keyed by `uri.toString()` so rapid open events
-    // don't double-process the same file.
+    // Routing reads use the canonical script key so case aliases share invalidation.
+    // Telemetry-only reads retain their original URI-based coalescing.
     private readonly inFlight = new Map<string, Promise<void>>();
-    // Routing reads have a generation per URI. A save that arrives while
+    // Routing reads have a generation per script. A save that arrives while
     // an older read is in flight advances its generation and queues a
     // post-save read, preventing the stale read from publishing metadata.
     private readonly routingReadGenerations = new Map<string, number>();
@@ -96,7 +96,9 @@ export class InlineScriptLazyDetector implements Disposable {
         if (this.routingRegistry) {
             this.subscriptions.push(
                 onDidDeleteFiles((e) => e.files.forEach((uri) => this.clearRouteability(uri))),
-                onDidRenameFiles((e) => e.files.forEach((file) => this.clearRouteability(file.oldUri))),
+                onDidRenameFiles((e) =>
+                    Promise.all(e.files.map((file) => this.handleRename(file.oldUri, file.newUri))),
+                ),
             );
         }
         // Defer the catch-up pass so we observe `workspace.textDocuments`
@@ -137,7 +139,37 @@ export class InlineScriptLazyDetector implements Disposable {
         this.routingReadGenerations.clear();
     }
 
-    private async handleDocument(doc: TextDocument, trigger: 'open' | 'save'): Promise<void> {
+    private async handleRename(oldUri: Uri, newUri: Uri): Promise<void> {
+        if (this.disposed || !this.routingRegistry) {
+            return;
+        }
+        const scriptPath = getInlineScriptRoutingKey(oldUri);
+        if (!scriptPath || scriptPath !== getInlineScriptRoutingKey(newUri)) {
+            this.clearRouteability(oldUri);
+            return;
+        }
+
+        if (this.inFlight.has(scriptPath)) {
+            this.advanceRoutingReadGeneration(scriptPath);
+        }
+        const metadata = this.routingRegistry.getMetadata(oldUri);
+        this.routingRegistry.setMetadata(newUri, metadata);
+        if (!metadata) {
+            this.routingRegistry.setValidatedAssociation(newUri, false);
+        }
+        if (getOpenTextDocuments().some(
+            (document) => document.isDirty && getInlineScriptRoutingKey(document.uri) === scriptPath,
+        )) {
+            return;
+        }
+        await this.handleDocument({ uri: newUri, isDirty: false }, 'open', true);
+    }
+
+    private async handleDocument(
+        doc: Pick<TextDocument, 'uri' | 'isDirty'>,
+        trigger: 'open' | 'save',
+        forceRead = false,
+    ): Promise<void> {
         const uri = doc.uri;
         // Diagnostic: trace every event entering the detector. This
         // is high-frequency (fires on every keystroke-triggered save
@@ -158,10 +190,10 @@ export class InlineScriptLazyDetector implements Disposable {
             this.clearRouteability(uri);
             return;
         }
-        const key = uri.toString();
+        const key = this.getReadKey(uri);
         const existing = this.inFlight.get(key);
         if (existing) {
-            if (this.routingRegistry && trigger === 'save') {
+            if (this.routingRegistry && (trigger === 'save' || forceRead)) {
                 const routingGeneration = this.advanceRoutingReadGeneration(key);
                 const work = existing.then(() =>
                     this.processOnce(uri, trigger, shouldHandleUri(uri), routingGeneration),
@@ -193,7 +225,7 @@ export class InlineScriptLazyDetector implements Disposable {
                 return;
             }
             if (this.routingRegistry) {
-                if (this.routingReadGenerations.get(uri.toString()) === routingGeneration) {
+                if (this.routingReadGenerations.get(this.getReadKey(uri)) === routingGeneration) {
                     this.routingRegistry.setMetadata(uri, metadata);
                 }
                 if (!shouldEmitTelemetry || metadata === undefined) {
@@ -244,7 +276,7 @@ export class InlineScriptLazyDetector implements Disposable {
             return;
         }
         if (this.routingRegistry) {
-            const key = e.document.uri.toString();
+            const key = this.getReadKey(e.document.uri);
             const metadata = this.routingRegistry.getMetadata(e.document.uri);
             if (
                 (metadata &&
@@ -284,12 +316,16 @@ export class InlineScriptLazyDetector implements Disposable {
         if (!this.routingRegistry || !shouldTrackRoutingUri(uri)) {
             return;
         }
-        const key = uri.toString();
+        const key = this.getReadKey(uri);
         if (this.inFlight.has(key)) {
             this.advanceRoutingReadGeneration(key);
         }
         this.routingRegistry.clearMetadata(uri);
         this.routingRegistry.setValidatedAssociation(uri, false);
+    }
+
+    private getReadKey(uri: Uri): string {
+        return this.routingRegistry ? getInlineScriptRoutingKey(uri) ?? uri.toString() : uri.toString();
     }
 
     private currentRoutingReadGeneration(key: string): number {

--- a/src/features/views/treeViewItems.ts
+++ b/src/features/views/treeViewItems.ts
@@ -1,9 +1,31 @@
 import { Command, MarkdownString, ThemeIcon, TreeItem, TreeItemCollapsibleState, l10n } from 'vscode';
 import { EnvironmentGroupInfo, IconPath, Package, PythonEnvironment, PythonProject } from '../../api';
+import { INLINE_SCRIPT_MANAGER_ID } from '../../common/constants';
 import { EnvViewStrings, UvInstallStrings, VenvManagerStrings } from '../../common/localize';
 import { InternalEnvironmentManager, InternalPackageManager } from '../../internal.api';
 import { isActivatableEnvironment } from '../common/activation';
 import { removable } from './utils';
+
+/**
+ * Inline-script environments are built from a script's `# /// script` block and live in the
+ * extension's cache, shared by every script with the same dependencies and base interpreter.
+ * Editing their packages by hand would silently change other scripts' environments, so the
+ * package management actions are not offered for them.
+ */
+function supportsPackageManagement(environment: PythonEnvironment | undefined): boolean {
+    return environment?.envId?.managerId !== INLINE_SCRIPT_MANAGER_ID;
+}
+
+/**
+ * Context value for a package node. Read-only packages use a distinct value so the existing
+ * `viewItem == python-package` menu clauses simply do not match them.
+ */
+function getPackageContextValue(pkg: Package, environment: PythonEnvironment | undefined): string {
+    if (pkg.isTransitive) {
+        return 'python-package-transitive';
+    }
+    return supportsPackageManagement(environment) ? 'python-package' : 'python-package-readonly';
+}
 
 /**
  * Extracts the parent folder name from an environment path for disambiguation.
@@ -162,7 +184,9 @@ export class PythonEnvTreeItem implements EnvTreeItem {
         }
         // Use different base context for broken environments so normal actions don't show
         const baseContext = isBroken ? 'pythonBrokenEnvironment' : 'pythonEnvironment';
-        const parts = [baseContext, remove, activatable].filter(Boolean);
+        // Positive marker so the install-packages menu matches only environments a user may edit.
+        const managePackages = !isBroken && supportsPackageManagement(this.environment) ? 'managePackages' : '';
+        const parts = [baseContext, remove, activatable, managePackages].filter(Boolean);
         return parts.join(';') + ';';
     }
 }
@@ -212,7 +236,7 @@ export class PackageTreeItem implements EnvTreeItem {
         const item = new TreeItem(pkg.displayName);
         const defaultIcon = pkg.isTransitive ? new ThemeIcon('list-tree') : new ThemeIcon('package');
         item.iconPath = pkg.iconPath ?? defaultIcon;
-        item.contextValue = pkg.isTransitive ? 'python-package-transitive' : 'python-package';
+        item.contextValue = getPackageContextValue(pkg, parent.environment);
         item.description = (pkg.isTransitive ? l10n.t('(transitive) ') : '') + (pkg.description ?? pkg.version ?? '');
         item.tooltip = pkg.isTransitive
             ? l10n.t('This package is a dependency of another installed package. It may also have been explicitly installed.')
@@ -435,7 +459,7 @@ export class ProjectPackage implements ProjectTreeItem {
         const item = new TreeItem(this.pkg.displayName, TreeItemCollapsibleState.None);
         const defaultIcon = this.pkg.isTransitive ? new ThemeIcon('list-tree') : new ThemeIcon('package');
         item.iconPath = this.pkg.iconPath ?? defaultIcon;
-        item.contextValue = this.pkg.isTransitive ? 'python-package-transitive' : 'python-package';
+        item.contextValue = getPackageContextValue(this.pkg, parent.environment);
         item.description =
             (this.pkg.isTransitive ? l10n.t('(transitive) ') : '') + (this.pkg.description ?? this.pkg.version ?? '');
         item.tooltip = this.pkg.isTransitive

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -28,6 +28,7 @@ import {
     PythonEnvironment,
     PythonEnvironmentApi,
     RefreshEnvironmentsScope,
+    RemoveEnvironmentOptions,
     ResolveEnvironmentContext,
     SetEnvironmentScope,
 } from '../../../api';
@@ -169,6 +170,7 @@ interface MergeCacheEntrySourceMetadataIdentityHashResult {
 
 interface CacheEntryRemovalOptions {
     readonly shouldRemove?: (entryPath: string) => Promise<boolean>;
+    readonly beforeRemove?: (entryPath: string) => Promise<void>;
     readonly afterRemove?: () => void;
     readonly reclaimRetainedLock?: boolean;
 }
@@ -551,6 +553,17 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         const activeCreatesAtStart = this.activeCreateOperations;
         return this.enqueueCacheMaintenance(() =>
             this.enqueueSelection(() => this.clearCacheInternal(activeCreatesAtStart)),
+        );
+    }
+
+    /** Delete one cached environment and its associations without a confirmation prompt. */
+    async remove(environment: PythonEnvironment, _options?: RemoveEnvironmentOptions): Promise<void> {
+        if (!environment) {
+            throw new Error(l10n.t('An inline-script environment is required for deletion.'));
+        }
+        const activeCreatesAtStart = this.activeCreateOperations;
+        return this.enqueueCacheMaintenance(() =>
+            this.enqueueSelection(() => this.clearCacheInternal(activeCreatesAtStart, environment)),
         );
     }
 
@@ -3384,7 +3397,36 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         }
     }
 
-    private async clearCacheInternal(activeCreatesAtStart: number): Promise<void> {
+    private getRemovalEntryName(
+        environment: PythonEnvironment,
+        cacheRoot: Uri,
+        physicalCacheRootPath: string | undefined,
+    ): string {
+        const prefix = environment.sysPrefix;
+        const parent = path.dirname(path.resolve(prefix));
+        const entryName = path.basename(path.resolve(prefix));
+        const insideCache = [cacheRoot.fsPath, physicalCacheRootPath].some(
+            (root) => root !== undefined && normalizePath(parent) === normalizePath(path.resolve(root)),
+        );
+        if (
+            environment.envId.managerId !== INLINE_SCRIPT_MANAGER_ID ||
+            !path.isAbsolute(prefix) ||
+            !insideCache ||
+            entryName.toLowerCase().endsWith(FILE_LOCK_DIR_SUFFIX) ||
+            environment.environmentPath.scheme !== 'file' ||
+            !isSameOrParentPath(prefix, environment.environmentPath.fsPath)
+        ) {
+            const message = l10n.t('Refusing to delete an environment that is not an owned inline-script cache entry.');
+            this.log.error(`${message} ${prefix}`);
+            throw new Error(message);
+        }
+        return entryName;
+    }
+
+    private async clearCacheInternal(
+        activeCreatesAtStart: number,
+        environment?: PythonEnvironment,
+    ): Promise<void> {
         if (activeCreatesAtStart > 0) {
             const message = l10n.t(
                 'Cannot clear the script environment cache while script environments are being created.',
@@ -3395,16 +3437,34 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
 
         const cacheRoot = getScriptEnvCacheRoot(this.globalStorageUri);
         const physicalCacheRootPath = await this.getPhysicalOwnedCacheRootPath(cacheRoot);
+        const selectedEntry = environment
+            ? this.getRemovalEntryName(environment, cacheRoot, physicalCacheRootPath)
+            : undefined;
+        const selectedEntryPath = selectedEntry === undefined ? undefined : Uri.joinPath(cacheRoot, selectedEntry).fsPath;
+        const selectedEntryKeys = new Set<string>();
+        if (selectedEntry !== undefined && selectedEntryPath !== undefined) {
+            selectedEntryKeys.add(normalizePath(selectedEntryPath));
+            if (physicalCacheRootPath) {
+                selectedEntryKeys.add(normalizePath(path.join(physicalCacheRootPath, selectedEntry)));
+            }
+        }
         const persistedAssociations = await this.getPersistedAssociationSnapshot();
-        const scriptPaths = this.getTrackedScriptPaths(persistedAssociations);
+        const trackedScriptPaths = this.getTrackedScriptPaths(persistedAssociations);
+        const scriptPaths = selectedEntry === undefined ? trackedScriptPaths : new Set(
+            [...trackedScriptPaths].filter((scriptPath) =>
+                [...this.getReferencedCacheEntryDirs(persistedAssociations, new Set([scriptPath]))]
+                    .some((entryPath) => selectedEntryKeys.has(entryPath)),
+            ),
+        );
         const priorSelections = this.getPriorSelections(scriptPaths);
 
         const removedCacheEntries = new Set<string>();
         const deletionErrors: unknown[] = [];
+        let selectedDeletionStarted = false;
         if (physicalCacheRootPath) {
             let entryNames: string[];
             try {
-                entryNames = await fs.readdir(physicalCacheRootPath);
+                entryNames = selectedEntry === undefined ? await fs.readdir(physicalCacheRootPath) : [selectedEntry];
             } catch (error) {
                 if (isFileNotFoundError(error)) {
                     entryNames = [];
@@ -3432,7 +3492,27 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
 
             for (const entryName of cacheEntryNames) {
                 try {
-                    const removed = await this.removeCacheEntryForClear(cacheRoot, physicalCacheRootPath, entryName);
+                    const removed = await this.removeCacheEntryForClear(
+                        cacheRoot,
+                        physicalCacheRootPath,
+                        entryName,
+                        selectedEntry === undefined ? undefined : {
+                            beforeRemove: async (entryPath) => {
+                                const sidecar = await inspectMetaJson(Uri.file(entryPath));
+                                if (sidecar.kind === 'unavailable') {
+                                    throw new Error(l10n.t('Cannot delete the cached environment because its metadata is unreadable.'));
+                                }
+                                // If removal stops partway through, never reuse the remaining
+                                // files as a healthy environment. Explicit setup can rebuild it.
+                                if (sidecar.kind === 'valid') {
+                                    await writeMetaJson(Uri.file(entryPath), { ...sidecar.metadata, manuallyModified: true });
+                                }
+                                selectedDeletionStarted = true;
+                                this.cacheMutationRevision += 1;
+                            },
+                            afterRemove: () => { this.cacheMutationRevision += 1; },
+                        },
+                    );
                     if (removed) {
                         removedCacheEntries.add(normalizePath(removed));
                     }
@@ -3445,6 +3525,15 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             }
         }
 
+        if (selectedEntryPath !== undefined &&
+            (removedCacheEntries.size > 0 || await this.isCacheEntryDefinitelyMissing(selectedEntryPath))) {
+            this.cacheMutationRevision += 1;
+            selectedEntryKeys.forEach((entryPath) => removedCacheEntries.add(entryPath));
+            this.replaceDiscoveredEnvironments(
+                this.collection.filter((entry) => !selectedEntryKeys.has(normalizePath(entry.sysPrefix))),
+            );
+        }
+
         const invalidatedScriptPaths = await this.getInvalidatedAssociationPaths(
             scriptPaths,
             persistedAssociations,
@@ -3454,11 +3543,21 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             invalidatedScriptPaths,
             persistedAssociations,
             priorSelections,
+            selectedEntry === undefined,
         );
         if (persistenceError) {
             deletionErrors.push(persistenceError);
         }
+        if (selectedDeletionStarted && deletionErrors.length > 0 && environment) {
+            this.unrouteScriptsUsingEnvironment(environment.sysPrefix);
+        }
         if (deletionErrors.length > 0) {
+            if (selectedEntry !== undefined) {
+                throw new Error(l10n.t(
+                    'Failed to delete the cached script environment: {0}',
+                    deletionErrors.map(getErrorMessage).join('; '),
+                ));
+            }
             throw new Error(
                 `Failed to completely clear the inline-script environment cache: ${deletionErrors
                     .map((error) => getErrorMessage(error))
@@ -3499,6 +3598,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             if (options.shouldRemove && !(await options.shouldRemove(entryPath))) {
                 return undefined;
             }
+            await options.beforeRemove?.(entryPath);
             await this.deleteCacheEntryForClear(entryPath);
             options.afterRemove?.();
             return entryPath;
@@ -3762,9 +3862,10 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         invalidatedScriptPaths: ReadonlySet<string>,
         persistedAssociations: PersistedInlineScriptEnvironments,
         priorSelections: ReadonlyMap<string, PythonEnvironment | undefined>,
+        allowClearingStore = true,
     ): Promise<unknown | undefined> {
         if (invalidatedScriptPaths.size === 0) {
-            if (Object.keys(persistedAssociations).length > 0) {
+            if (!allowClearingStore || Object.keys(persistedAssociations).length > 0) {
                 return undefined;
             }
             try {
@@ -3781,7 +3882,8 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             (scriptPath) => persistedAssociations[scriptPath] !== undefined,
         );
         try {
-            if (persistedPathsToClear.length === Object.keys(persistedAssociations).length) {
+            // A single-entry deletion must preserve unrecognized records belonging to other entries.
+            if (allowClearingStore && persistedPathsToClear.length === Object.keys(persistedAssociations).length) {
                 await this.clearPersistedAssociations();
             } else if (persistedPathsToClear.length > 0) {
                 await this.updatePersistedAssociations(

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -20,7 +20,6 @@ import {
     CreateEnvironmentScope,
     DidChangeEnvironmentEventArgs,
     DidChangeEnvironmentsEventArgs,
-    DidChangePackagesEventArgs,
     EnvironmentChangeKind,
     EnvironmentManager,
     GetEnvironmentScope,
@@ -40,20 +39,24 @@ import {
 } from '../../../common/constants';
 import { getErrorMessage } from '../../../common/errors/utils';
 import { computeCacheKey, normalizeDependency } from '../../../common/inlineScript/cacheKey';
+import { InlineScriptEnvironmentModifiedError } from '../../../common/inlineScript/errors';
 import {
     CacheEntrySummary,
     CacheEnvironmentInspection,
+    compareInstalledPackages,
     getBaseInterpreterStatus,
     getScriptEnvCacheRoot,
     getScriptEnvDir,
     hashSourceMetadataIdentity,
     INLINE_SCRIPT_CACHE_DIR_NAME,
     InlineScriptEnvMeta,
+    InlineScriptMetaReadResult,
     inspectMetaJson,
     inspectOwnedCacheEntry,
     mergeSourceMetadataIdentityHashes,
     META_JSON_FILENAME,
     META_SCHEMA_VERSION,
+    readInstalledPackagesHash,
     resolveCacheEntryPath,
     restoreMetaJsonBackupUnderLock,
     selectStaleEntries,
@@ -271,16 +274,9 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                 });
             }),
             onDidRenameFiles((event) => {
-                void this.handleRenamedScripts(event.files).catch((error) => {
+                return this.handleRenamedScripts(event.files).catch((error) => {
                     this.log.warn(
                         `Failed to update inline-script associations for renamed files: ${getErrorMessage(error)}`,
-                    );
-                });
-            }),
-            this.api.onDidChangePackages((event) => {
-                void this.handlePackagesChanged(event).catch((error) => {
-                    this.log.warn(
-                        `Failed to record an inline-script package change: ${getErrorMessage(error)}`,
                     );
                 });
             }),
@@ -966,6 +962,13 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                 this.log.warn(message);
                 throw new Error(message);
             }
+            const sidecar = await this.readCurrentCacheEntrySidecar(environment);
+            if (sidecar?.manuallyModified || (sidecar && (await this.hasInstalledPackagesChanged(sidecar, environment)))) {
+                this.unrouteScriptsUsingEnvironment(environment.sysPrefix);
+                const error = new InlineScriptEnvironmentModifiedError();
+                this.log.warn(`${error.message} ${environment.environmentPath.fsPath}`);
+                throw error;
+            }
             environmentPath = environment.environmentPath.fsPath;
         }
 
@@ -1226,8 +1229,17 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                 if (metadataMatch === 'mismatched') {
                     return undefined;
                 }
-                const sidecar = await this.readCurrentCacheEntrySidecar(resolved);
+                const sidecarResult = await this.inspectCurrentCacheEntrySidecar(resolved);
+                if (sidecarResult.kind === 'unavailable') {
+                    return undefined;
+                }
+                const sidecar = sidecarResult.kind === 'valid' ? sidecarResult.metadata : undefined;
+                // Legacy/future metadata can retain an API candidate, but cannot prove routing.
+                // A transient read failure above must not bypass the modification check.
                 if (sidecar && !this.cacheEntryMatchesRuntimeAndMetadata(sidecar, resolved, metadata)) {
+                    return undefined;
+                }
+                if (sidecar && (await this.hasInstalledPackagesChanged(sidecar, resolved))) {
                     return undefined;
                 }
                 const metadataIdentityProven =
@@ -1409,8 +1421,17 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         if (metadataMatch === 'mismatched') {
             return undefined;
         }
-        const sidecar = await this.readCurrentCacheEntrySidecar(resolved);
+        const sidecarResult = await this.inspectCurrentCacheEntrySidecar(resolved);
+        if (sidecarResult.kind === 'unavailable') {
+            return undefined;
+        }
+        const sidecar = sidecarResult.kind === 'valid' ? sidecarResult.metadata : undefined;
+        // Retain compatibility candidates without proof, not unreadable entries.
+        // Routing still requires metadataIdentityProven even when this API returns a candidate.
         if (sidecar && !this.cacheEntryMatchesRuntimeAndMetadata(sidecar, resolved, metadata)) {
+            return undefined;
+        }
+        if (sidecar && (await this.hasInstalledPackagesChanged(sidecar, resolved))) {
             return undefined;
         }
         const metadataIdentityProven =
@@ -1592,6 +1613,30 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                     normalizePath(currentAssociation.environmentPath) ===
                         normalizePath(environment.environmentPath.fsPath)
                 ) {
+                    // The revision may have changed because packages were edited, not just
+                    // because another selection won the queue. Never carry its old proof forward.
+                    const currentEnvironment = await this.getAssociationForMetadata(scriptPath, uri, metadata);
+                    if (!this.isCurrentMetadataRefreshTask(
+                        uri, metadataIdentity, metadataRevision, scriptPath, currentAssociationRevision,
+                    )) {
+                        return;
+                    }
+                    if (!currentEnvironment) {
+                        this.clearValidatedRouteableState(uri);
+                        return;
+                    }
+                    const currentProof = await this.currentCacheEntryProvesSourceMetadataIdentity(
+                        currentEnvironment, metadataIdentity, metadata,
+                    );
+                    if (!this.isCurrentMetadataRefreshTask(
+                        uri, metadataIdentity, metadataRevision, scriptPath, currentAssociationRevision,
+                    )) {
+                        return;
+                    }
+                    if (!currentProof) {
+                        this.clearValidatedRouteableState(uri);
+                        return;
+                    }
                     bindResult = await this.bindPendingMetadataIdentity(
                         scriptPath,
                         environment.environmentPath.fsPath,
@@ -1635,12 +1680,29 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
     }
 
     private async updateValidatedStateForSelection(script: ScriptReference): Promise<void> {
+        const revision = this.associationRevisions.get(script.scriptPath) ?? 0;
+        const environment = this.fsPathToEnv.get(script.scriptPath);
         const savedMetadata = await this.getSavedMetadataForPersistence(script.uri);
-        if (!savedMetadata.identity) {
+        if (!this.isCurrentAssociationRevision(script.scriptPath, revision)) {
+            return;
+        }
+        if (!environment || !savedMetadata.identity || !savedMetadata.metadata) {
             this.clearValidatedRouteableState(script.uri);
             return;
         }
         if (this.inspectAssociationMetadata(script.scriptPath, savedMetadata.identity, false) !== 'matched') {
+            this.clearValidatedRouteableState(script.uri);
+            return;
+        }
+        const proven = await this.currentCacheEntryProvesSourceMetadataIdentity(
+            environment,
+            savedMetadata.identity,
+            savedMetadata.metadata,
+        );
+        if (!this.isCurrentAssociationRevision(script.scriptPath, revision)) {
+            return;
+        }
+        if (!proven) {
             this.clearValidatedRouteableState(script.uri);
             return;
         }
@@ -1653,8 +1715,10 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
     }
 
     private async getSavedMetadataForPersistence(uri: Uri): Promise<SavedMetadataSnapshot> {
+        const scriptPath = normalizePath(uri.fsPath);
         for (const document of getOpenTextDocuments()) {
-            if (document.uri.toString() === uri.toString() && document.isDirty) {
+            if (document.uri.scheme === 'file' &&
+                normalizePath(document.uri.fsPath) === scriptPath && document.isDirty) {
                 return {};
             }
         }
@@ -1675,21 +1739,47 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         metadata: InlineScriptMetadata,
     ): Promise<boolean> {
         const sidecar = await this.readCurrentCacheEntrySidecar(environment);
-        return (
-            !!sidecar && this.cacheEntryProvesSourceMetadataIdentity(sidecar, environment, metadataIdentity, metadata)
-        );
+        if (!sidecar || (await this.hasInstalledPackagesChanged(sidecar, environment))) {
+            return false;
+        }
+        return this.cacheEntryProvesSourceMetadataIdentity(sidecar, environment, metadataIdentity, metadata);
     }
 
     private async readCurrentCacheEntrySidecar(
         environment: PythonEnvironment,
     ): Promise<InlineScriptEnvMeta | undefined> {
-        let sidecarResult;
-        try {
-            sidecarResult = await inspectMetaJson(Uri.file(environment.sysPrefix));
-        } catch {
-            return undefined;
-        }
+        const sidecarResult = await this.inspectCurrentCacheEntrySidecar(environment);
         return sidecarResult.kind === 'valid' ? sidecarResult.metadata : undefined;
+    }
+
+    /**
+     * Whether an entry's packages no longer match what setup recorded for it.
+     *
+     * Only a definite mismatch returns `true`. An entry with no recorded inventory, or one whose
+     * inventory cannot be read, is unknown — and unknown must never invalidate a working
+     * environment. Treating "no record" as "everything was added" is precisely what once let
+     * merely listing an environment's packages force it through setup again.
+     */
+    private async hasInstalledPackagesChanged(
+        sidecar: InlineScriptEnvMeta,
+        environment: PythonEnvironment,
+    ): Promise<boolean> {
+        if (sidecar.installedPackagesHash === undefined) {
+            return false;
+        }
+        const actualHash = await readInstalledPackagesHash(Uri.file(environment.sysPrefix));
+        return compareInstalledPackages(sidecar.installedPackagesHash, actualHash) === 'changed';
+    }
+
+    private async inspectCurrentCacheEntrySidecar(
+        environment: PythonEnvironment,
+    ): Promise<InlineScriptMetaReadResult> {
+        try {
+            return await inspectMetaJson(Uri.file(environment.sysPrefix));
+        } catch (error) {
+            this.log.warn(`Unable to read inline-script cache metadata: ${getErrorMessage(error)}`);
+            return { kind: 'unavailable' };
+        }
     }
 
     private cacheEntryProvesSourceMetadataIdentity(
@@ -1712,7 +1802,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         environment: PythonEnvironment,
         metadata: InlineScriptMetadata,
     ): boolean {
-        if (!this.areEqualPythonReleases(environment.version, sidecar.baseInterpreterVersion)) {
+        if (sidecar.manuallyModified || !this.areEqualPythonReleases(environment.version, sidecar.baseInterpreterVersion)) {
             return false;
         }
         const requiresPython = metadata.requiresPython?.trim();
@@ -1760,7 +1850,7 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
     }
 
     private sidecarProvesSourceMetadataIdentity(sidecar: InlineScriptEnvMeta, metadataIdentity: string): boolean {
-        if (sidecar.sourceMetadataIdentityHashes === undefined) {
+        if (sidecar.manuallyModified || sidecar.sourceMetadataIdentityHashes === undefined) {
             return false;
         }
         const expectedHash = hashSourceMetadataIdentity(metadataIdentity);
@@ -2281,75 +2371,18 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         return run;
     }
 
-    /**
-     * Editing packages outside setup silently affects every script sharing the entry, so mark the
-     * entry non-reusable and un-route each of them; the next setup rebuilds from declared metadata.
-     */
-    private async handlePackagesChanged(event: DidChangePackagesEventArgs): Promise<void> {
-        if (this.disposed || event.environment.envId.managerId !== INLINE_SCRIPT_MANAGER_ID) {
-            return;
-        }
-        if (event.changes.length === 0) {
-            return;
-        }
-        const envDirPath = event.environment.sysPrefix;
-        // Setup installs through `managePackages`, which fires this event too. The emitter is
-        // synchronous, so a build still registered here owns this change and must not self-mark.
-        if (this.isBuildInFlightFor(envDirPath)) {
-            return;
-        }
-        const cacheRoot = getScriptEnvCacheRoot(this.globalStorageUri);
-        const envDir = Uri.file(envDirPath);
-        if ((await inspectOwnedCacheEntry(event.environment, cacheRoot, envDir)) !== 'expected') {
-            return;
-        }
-        if (!(await this.markCacheEntryManuallyModified(envDir))) {
-            return;
-        }
-        this.unrouteScriptsUsingEnvironment(envDirPath);
-    }
-
-    private isBuildInFlightFor(envDirPath: string): boolean {
-        return this.pendingCreations.has(path.basename(envDirPath));
-    }
-
-    /** Mark under the entry lock so it cannot race a concurrent build. */
-    private async markCacheEntryManuallyModified(envDir: Uri): Promise<boolean> {
-        try {
-            return await this.withCacheEntryLock(envDir, async () => {
-                // Re-check now that the build, if any, has released the lock.
-                if (this.isBuildInFlightFor(envDir.fsPath)) {
-                    return false;
-                }
-                const sidecar = await inspectMetaJson(envDir);
-                if (sidecar.kind !== 'valid' || sidecar.metadata.manuallyModified) {
-                    return false;
-                }
-                await writeMetaJson(envDir, { ...sidecar.metadata, manuallyModified: true });
-                this.cacheMutationRevision += 1;
-                this.log.info(
-                    `Inline-script environment packages were modified outside setup; it will be rebuilt on next setup: ${envDir.fsPath}`,
-                );
-                return true;
-            });
-        } catch (error) {
-            // A build holding the lock rewrites the sidecar anyway.
-            this.log.warn(
-                `Failed to record an inline-script package modification for ${envDir.fsPath}: ${getErrorMessage(error)}`,
-            );
-            return false;
-        }
-    }
-
     /** Un-route every script associated with the given cache entry. */
     private unrouteScriptsUsingEnvironment(envDirPath: string): void {
         for (const [scriptPath, association] of this.fsPathToPersistedAssociation.entries()) {
             if (!isSameOrParentPath(envDirPath, association.environmentPath)) {
                 continue;
             }
-            this.invalidateCachedAssociationValidation(scriptPath);
+            this.bumpAssociationRevision(scriptPath);
+            this.pendingRehydrations.delete(scriptPath);
+            this.pendingMetadataRefreshes.delete(scriptPath);
+            this.fsPathToEnv.delete(scriptPath);
             const uri = this.routingRegistry.getUri(scriptPath) ?? Uri.file(scriptPath);
-            this.routingRegistry.setValidatedAssociation(uri, false);
+            this.clearValidatedRouteableState(uri);
             this.log.info(`Inline-script association for ${scriptPath} needs setup again after a package change.`);
         }
     }
@@ -2392,7 +2425,11 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                 // Only follow the rename when the destination is still a routable local `.py` file;
                 // renaming to another extension (or off the local filesystem) drops the association.
                 const newPath = getInlineScriptRoutingKey(newUri);
-                if (!record || newPath === undefined || newPath === oldPath) {
+                if (record && newPath === oldPath) {
+                    // The association key is unchanged; the detector updates the URI and saved metadata.
+                    continue;
+                }
+                if (!record || newPath === undefined) {
                     clears.push({ uri: oldUri, scriptPath: oldPath });
                     continue;
                 }
@@ -3039,15 +3076,30 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         if (requiresPython && !this.matchesInstallConstraint(requiresPython, environment.version)) {
             return { kind: 'stale' };
         }
+        // Packages are compared here, under the entry lock, so a rebuild is chosen deliberately
+        // rather than reusing an entry whose contents no longer match what setup installed.
+        const actualPackagesHash = await readInstalledPackagesHash(envDir);
+        const packagesComparison = compareInstalledPackages(sidecar.installedPackagesHash, actualPackagesHash);
+        if (packagesComparison === 'changed') {
+            this.log.info(
+                `Rebuilding an inline-script cache entry whose packages changed outside setup: ${envDir.fsPath}`,
+            );
+            return { kind: 'stale' };
+        }
         try {
             pendingCreation.hasStartedRecordingSourceMetadataIdentityHashes = true;
             const sourceMetadataIdentityHashes = this.mergePendingCreationSourceMetadataIdentityHashes(
                 sidecar.sourceMetadataIdentityHashes,
                 pendingCreation,
             );
+            // An entry with no recorded inventory is unknown, not modified. Record it now so later
+            // comparisons have a baseline, and never treat the absent record as evidence of a change.
+            const installedPackagesHash =
+                packagesComparison === 'unknown' ? actualPackagesHash : sidecar.installedPackagesHash;
             await writeMetaJson(envDir, {
                 ...sidecar,
                 lastUsedAt: new Date().toISOString(),
+                ...(installedPackagesHash ? { installedPackagesHash } : {}),
                 ...(sourceMetadataIdentityHashes ? { sourceMetadataIdentityHashes } : {}),
             });
             pendingCreation.recordedSourceMetadataIdentityHashes = sourceMetadataIdentityHashes;
@@ -3123,11 +3175,16 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                 undefined,
                 pendingCreation,
             );
+            // Recorded inside the cache-entry lock, alongside the build that produced it. Keeping
+            // this write in the same locked section is what makes it impossible for the extension
+            // to later mistake its own installation for an edit made outside setup.
+            const installedPackagesHash = await readInstalledPackagesHash(envDir);
             await writeMetaJson(envDir, {
                 schemaVersion: META_SCHEMA_VERSION,
                 baseInterpreterPath: selectedBase.canonicalPath,
                 baseInterpreterVersion: selectedBase.environment.version,
                 lastUsedAt: new Date().toISOString(),
+                ...(installedPackagesHash ? { installedPackagesHash } : {}),
                 ...(sourceMetadataIdentityHashes ? { sourceMetadataIdentityHashes } : {}),
             });
             pendingCreation.recordedSourceMetadataIdentityHashes = sourceMetadataIdentityHashes;

--- a/src/managers/builtin/inlineScript/envManager.ts
+++ b/src/managers/builtin/inlineScript/envManager.ts
@@ -1240,7 +1240,10 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
                     return undefined;
                 }
                 if (sidecar && (await this.hasInstalledPackagesChanged(sidecar, resolved))) {
-                    return undefined;
+                    await this.invalidateCurrentPackageDrift(resolved);
+                    return this.isCurrentAssociationRevision(scriptPath, revision)
+                        ? undefined
+                        : this.fsPathToEnv.get(scriptPath);
                 }
                 const metadataIdentityProven =
                     !!sidecar &&
@@ -1432,7 +1435,10 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
             return undefined;
         }
         if (sidecar && (await this.hasInstalledPackagesChanged(sidecar, resolved))) {
-            return undefined;
+            await this.invalidateCurrentPackageDrift(resolved);
+            return this.isCurrentAssociationRevision(scriptPath, revision)
+                ? undefined
+                : this.fsPathToEnv.get(scriptPath);
         }
         const metadataIdentityProven =
             !!sidecar && this.cacheEntryProvesSourceMetadataIdentity(sidecar, resolved, metadataIdentity, metadata);
@@ -1739,7 +1745,11 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         metadata: InlineScriptMetadata,
     ): Promise<boolean> {
         const sidecar = await this.readCurrentCacheEntrySidecar(environment);
-        if (!sidecar || (await this.hasInstalledPackagesChanged(sidecar, environment))) {
+        if (!sidecar) {
+            return false;
+        }
+        if (await this.hasInstalledPackagesChanged(sidecar, environment)) {
+            await this.invalidateCurrentPackageDrift(environment);
             return false;
         }
         return this.cacheEntryProvesSourceMetadataIdentity(sidecar, environment, metadataIdentity, metadata);
@@ -1769,6 +1779,34 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
         }
         const actualHash = await readInstalledPackagesHash(Uri.file(environment.sysPrefix));
         return compareInstalledPackages(sidecar.installedPackagesHash, actualHash) === 'changed';
+    }
+
+    private async invalidateCurrentPackageDrift(environment: PythonEnvironment): Promise<void> {
+        const envDir = Uri.file(environment.sysPrefix);
+        if (this.disposed || this.pendingCreations.has(path.basename(envDir.fsPath))) {
+            return;
+        }
+        try {
+            // The first observation may predate a repair. Confirm against the current sidecar
+            // under the build lock, without waiting for another installer on a read path.
+            await this.withCacheEntryLock(envDir, async () => {
+                const current = await this.inspectCurrentCacheEntrySidecar(environment);
+                if (current.kind !== 'valid') {
+                    return;
+                }
+                const changed = current.metadata.manuallyModified ||
+                    await this.hasInstalledPackagesChanged(current.metadata, environment);
+                if (changed && !this.disposed) {
+                    this.unrouteScriptsUsingEnvironment(envDir.fsPath);
+                }
+            }, 0);
+        } catch (error) {
+            if (this.isLockContentionError(error)) {
+                this.log.debug(`Deferred inline-script drift invalidation for busy entry ${envDir.fsPath}.`);
+            } else {
+                this.log.warn(`Unable to confirm inline-script package drift: ${getErrorMessage(error)}`);
+            }
+        }
     }
 
     private async inspectCurrentCacheEntrySidecar(
@@ -2373,18 +2411,24 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
 
     /** Un-route every script associated with the given cache entry. */
     private unrouteScriptsUsingEnvironment(envDirPath: string): void {
+        const changes: DidChangeEnvironmentEventArgs[] = [];
         for (const [scriptPath, association] of this.fsPathToPersistedAssociation.entries()) {
             if (!isSameOrParentPath(envDirPath, association.environmentPath)) {
                 continue;
             }
+            const old = this.fsPathToEnv.get(scriptPath);
             this.bumpAssociationRevision(scriptPath);
             this.pendingRehydrations.delete(scriptPath);
             this.pendingMetadataRefreshes.delete(scriptPath);
             this.fsPathToEnv.delete(scriptPath);
             const uri = this.routingRegistry.getUri(scriptPath) ?? Uri.file(scriptPath);
             this.clearValidatedRouteableState(uri);
+            if (old) {
+                changes.push({ uri, old, new: undefined });
+            }
             this.log.info(`Inline-script association for ${scriptPath} needs setup again after a package change.`);
         }
+        changes.forEach((change) => this._onDidChangeEnvironment.fire(change));
     }
 
     /**
@@ -2859,9 +2903,13 @@ export class InlineScriptEnvManager implements EnvironmentManager, Disposable {
      * this callback or reachable only through `createOrReuseEnvironment`,
      * which invokes it under this lock.
      */
-    private async withCacheEntryLock<T>(envDir: Uri, action: (lock: AcquiredFileLock) => Promise<T>): Promise<T> {
+    private async withCacheEntryLock<T>(
+        envDir: Uri,
+        action: (lock: AcquiredFileLock) => Promise<T>,
+        timeoutMs = CACHE_LOCK_TIMEOUT_MS,
+    ): Promise<T> {
         const lock = await acquireFileLock(envDir.fsPath, {
-            timeoutMs: CACHE_LOCK_TIMEOUT_MS,
+            timeoutMs,
             retryIntervalMs: CACHE_LOCK_RETRY_MS,
         });
         try {

--- a/src/test/features/envCommands.inlineSelectionErrors.unit.test.ts
+++ b/src/test/features/envCommands.inlineSelectionErrors.unit.test.ts
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import assert from 'assert';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { QuickInputButtons, Uri } from 'vscode';
+import { EnvironmentManager, PythonEnvironment, PythonProject } from '../../api';
+import { INLINE_SCRIPT_MANAGER_ID } from '../../common/constants';
+import {
+    InlineScriptEnvironmentModifiedError,
+    InlineScriptPackagesNotManagedError,
+} from '../../common/inlineScript/errors';
+import * as logging from '../../common/logging';
+import * as environmentPickers from '../../common/pickers/environments';
+import * as projectPickers from '../../common/pickers/projects';
+import * as windowApis from '../../common/window.apis';
+import { getPackageCommandOptions, setEnvironmentCommand } from '../../features/envCommands';
+import { EnvManagerTreeItem, ProjectItem, PythonEnvTreeItem } from '../../features/views/treeViewItems';
+import {
+    EnvironmentManagers,
+    InternalEnvironmentManager,
+    InternalPackageManager,
+    PythonProjectManager,
+} from '../../internal.api';
+import { createMockPythonEnvironment } from '../mocks/pythonEnvironment';
+
+suite('Inline environment selection error feedback', () => {
+    const uri = Uri.file(path.join(process.cwd(), 'selection-script.py'));
+    const project: PythonProject = { uri, name: 'script' };
+    const environment = createMockPythonEnvironment({
+        envPath: path.join(process.cwd(), 'inline-selection-env'),
+        managerId: INLINE_SCRIPT_MANAGER_ID,
+    });
+    let setEnvironments: sinon.SinonStub;
+    let pickEnvironment: sinon.SinonStub;
+    let showError: sinon.SinonStub;
+    let managers: EnvironmentManagers;
+    let projects: PythonProjectManager;
+
+    setup(() => {
+        setEnvironments = sinon.stub().rejects(new InlineScriptEnvironmentModifiedError());
+        pickEnvironment = sinon.stub(environmentPickers, 'pickEnvironment').resolves(environment);
+        sinon.stub(projectPickers, 'pickProjectMany').resolves([project]);
+        showError = sinon.stub(windowApis, 'showErrorMessage').resolves(undefined);
+        sinon.stub(logging, 'traceError');
+        const managerMock: Partial<EnvironmentManagers> = {
+            managers: [],
+            getEnvironment: async () => undefined,
+            getEnvironmentManager: () => undefined,
+            getProjectEnvManagers: () => [],
+            setEnvironments,
+        };
+        const projectMock: Partial<PythonProjectManager> = { getProjects: () => [project] };
+        managers = managerMock as EnvironmentManagers;
+        projects = projectMock as PythonProjectManager;
+    });
+
+    teardown(() => sinon.restore());
+
+    for (const kind of ['uri', 'array', 'project', 'environment'] as const) {
+        test(`shows actionable guidance once for a ${kind} selection`, async () => {
+            let context: unknown = uri;
+            if (kind === 'array') {
+                context = [uri];
+            } else if (kind === 'project') {
+                context = new ProjectItem(project);
+            } else if (kind === 'environment') {
+                const provider: EnvironmentManager = {
+                    name: 'inline-script',
+                    preferredPackageManagerId: 'ms-python.python:pip',
+                    get: async () => environment,
+                    set: async () => undefined,
+                    getEnvironments: async () => [environment],
+                    refresh: async () => undefined,
+                    resolve: async () => undefined,
+                };
+                const parent = new EnvManagerTreeItem(new InternalEnvironmentManager(INLINE_SCRIPT_MANAGER_ID, provider));
+                context = new PythonEnvTreeItem(environment, parent);
+            }
+
+            await setEnvironmentCommand(context, managers, projects);
+
+            assert.ok(setEnvironments.calledOnce);
+            assert.ok(showError.calledOnceWithExactly(new InlineScriptEnvironmentModifiedError().message));
+        });
+    }
+
+    test('does not swallow unrelated provider failures', async () => {
+        const failure = new Error('Unexpected provider failure');
+        setEnvironments.rejects(failure);
+
+        await assert.rejects(setEnvironmentCommand(uri, managers, projects), (error: unknown) => error === failure);
+
+        assert.ok(showError.notCalled);
+    });
+
+    test('does not show an error when the user cancels the picker', async () => {
+        pickEnvironment.resolves(undefined);
+
+        await setEnvironmentCommand(uri, managers, projects);
+
+        assert.ok(setEnvironments.notCalled);
+        assert.ok(showError.notCalled);
+    });
+
+    test('does not consume the Back navigation sentinel', async () => {
+        pickEnvironment.rejects(QuickInputButtons.Back);
+
+        await assert.rejects(
+            setEnvironmentCommand(uri, managers, projects),
+            (error: unknown) => error === QuickInputButtons.Back,
+        );
+        assert.ok(showError.notCalled);
+    });
+});
+
+suite('Inline environment package command guard', () => {
+    const uri = Uri.file(path.join(process.cwd(), 'guarded-script.py'));
+    const project: PythonProject = { uri, name: 'script' };
+    const packageManager = {} as InternalPackageManager;
+
+    teardown(() => sinon.restore());
+
+    function createManagers(environment: PythonEnvironment): EnvironmentManagers {
+        const managerMock: Partial<EnvironmentManagers> = {
+            getEnvironmentManager: () => ({ get: async () => environment } as unknown as InternalEnvironmentManager),
+            getPackageManager: () => packageManager,
+        };
+        return managerMock as EnvironmentManagers;
+    }
+
+    const projects = { getProjects: () => [project] } as unknown as PythonProjectManager;
+
+    // The tree view hides package actions for these environments, but the command palette can
+    // still resolve one from the active script, so the chokepoint must refuse it too.
+    test('refuses a package command that resolves to an inline-script environment', async () => {
+        const environment = createMockPythonEnvironment({
+            envPath: path.join(process.cwd(), 'inline-package-env'),
+            managerId: INLINE_SCRIPT_MANAGER_ID,
+        });
+
+        await assert.rejects(
+            getPackageCommandOptions(uri, createManagers(environment), projects),
+            (error: unknown) => error instanceof InlineScriptPackagesNotManagedError,
+        );
+    });
+
+    test('still resolves package commands for ordinary environments', async () => {
+        const environment = createMockPythonEnvironment({
+            envPath: path.join(process.cwd(), 'venv-package-env'),
+            managerId: 'ms-python.python:venv',
+        });
+
+        const options = await getPackageCommandOptions(uri, createManagers(environment), projects);
+
+        assert.strictEqual(options.environment, environment);
+        assert.strictEqual(options.packageManager, packageManager);
+    });
+});

--- a/src/test/features/envCommands.unit.test.ts
+++ b/src/test/features/envCommands.unit.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as path from 'path';
 import * as sinon from 'sinon';
 import * as typeMoq from 'typemoq';
 import { Memento, Terminal, Uri } from 'vscode';
@@ -13,6 +14,7 @@ import {
     clearEnvironmentCachesCommand,
     clearScriptEnvironmentCacheCommand,
     createAnyEnvironmentCommand,
+    removeEnvironmentCommand,
     removePythonProject,
     revealEnvInManagerView,
     runInDedicatedTerminalCommand,
@@ -28,6 +30,67 @@ import { ProjectEnvironment, ProjectItem } from '../../features/views/treeViewIt
 import { EnvironmentManagers, InternalEnvironmentManager, PythonProjectManager } from '../../internal.api';
 import { setupNonThenable } from '../mocks/helper';
 import { createMockPythonEnvironment } from '../mocks/pythonEnvironment';
+
+suite('Environment removal command ownership', () => {
+    for (const managerId of [INLINE_SCRIPT_MANAGER_ID, 'ms-python.python:venv']) {
+        test(`routes a ${managerId} project environment without changing ordinary removal`, async () => {
+            const project: PythonProject = {
+                name: 'script',
+                uri: Uri.file(path.join(process.cwd(), 'removal-script.py')),
+            };
+            const environment = createMockPythonEnvironment({
+                managerId,
+                envPath: path.join(process.cwd(), 'removal-env'),
+            });
+            const remove = sinon.stub().resolves();
+            const owner = new InternalEnvironmentManager(managerId, {
+                name: 'test',
+                preferredPackageManagerId: 'ms-python.python:pip',
+                get: async () => environment,
+                set: async () => undefined,
+                getEnvironments: async () => [environment],
+                refresh: async () => undefined,
+                resolve: async () => environment,
+                remove,
+            });
+            const expectedContext = managerId === INLINE_SCRIPT_MANAGER_ID ? environment : project.uri;
+            const getEnvironmentManager = sinon.stub().callsFake((context) =>
+                context === expectedContext ? owner : undefined,
+            );
+            const managers: Partial<EnvironmentManagers> = { getEnvironmentManager };
+
+            await removeEnvironmentCommand(
+                new ProjectEnvironment(new ProjectItem(project), environment),
+                managers as EnvironmentManagers,
+            );
+
+            assert.ok(getEnvironmentManager.calledOnceWithExactly(expectedContext));
+            assert.ok(remove.calledOnceWithExactly(environment, undefined));
+        });
+    }
+
+    test('reports an unavailable inline owner instead of removing through a fallback manager', async () => {
+        const project: PythonProject = {
+            name: 'script',
+            uri: Uri.file(path.join(process.cwd(), 'removal-script.py')),
+        };
+        const environment = createMockPythonEnvironment({
+            managerId: INLINE_SCRIPT_MANAGER_ID,
+            envPath: path.join(process.cwd(), 'removal-env'),
+        });
+        const getEnvironmentManager = sinon.stub().returns(undefined);
+        const managers: Partial<EnvironmentManagers> = { getEnvironmentManager };
+
+        await assert.rejects(
+            removeEnvironmentCommand(
+                new ProjectEnvironment(new ProjectItem(project), environment),
+                managers as EnvironmentManagers,
+            ),
+            /not available to delete/,
+        );
+        assert.ok(getEnvironmentManager.calledOnceWithExactly(environment));
+    });
+});
 
 suite('Create Any Environment Command Tests', () => {
     let em: typeMoq.IMock<EnvironmentManagers>;

--- a/src/test/features/envManagers.packageEvents.unit.test.ts
+++ b/src/test/features/envManagers.packageEvents.unit.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import assert from 'assert';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { Disposable, EventEmitter } from 'vscode';
+import {
+    DidChangeEnvironmentVariablesEventArgs,
+    DidChangePackagesEventArgs,
+    PackageChangeKind,
+    PackageManager,
+    PythonProject,
+} from '../../api';
+import { InlineScriptRoutingRegistry } from '../../common/inlineScript/routingRegistry';
+import * as telemetry from '../../common/telemetry/sender';
+import * as frameUtils from '../../common/utils/frameUtils';
+import { PythonEnvironmentManagers } from '../../features/envManagers';
+import { PythonEnvironmentApiImpl } from '../../features/pythonApi';
+import { InternalDidChangePackagesEventArgs, PythonProjectManager } from '../../internal.api';
+import { createMockPythonEnvironment } from '../mocks/pythonEnvironment';
+
+for (const inlineEnabled of [false, true]) {
+    suite(`Package event forwarding - inline routing ${inlineEnabled ? 'enabled' : 'disabled'}`, () => {
+        const environment = createMockPythonEnvironment({
+            envPath: path.join(process.cwd(), 'package-event-env'),
+            managerId: 'test.environments:venv',
+        });
+        let clock: sinon.SinonFakeTimers;
+        let managers: PythonEnvironmentManagers;
+        let api: PythonEnvironmentApiImpl;
+        let provider: PackageManager;
+        let emitter: EventEmitter<DidChangePackagesEventArgs>;
+        let routing: InlineScriptRoutingRegistry | undefined;
+        let disposables: Disposable[];
+        let internalEvents: InternalDidChangePackagesEventArgs[];
+        let publicEvents: DidChangePackagesEventArgs[];
+        let changes: DidChangePackagesEventArgs['changes'];
+
+        setup(() => {
+            clock = sinon.useFakeTimers({ toFake: ['setImmediate'] });
+            sinon.stub(telemetry, 'sendTelemetryEvent');
+            sinon.stub(frameUtils, 'getCallingExtension').returns('test.packages');
+            disposables = [];
+            internalEvents = [];
+            publicEvents = [];
+            const projectEvents = new EventEmitter<PythonProject[] | undefined>();
+            const variableEvents = new EventEmitter<DidChangeEnvironmentVariablesEventArgs>();
+            const projectManager: Partial<PythonProjectManager> = {
+                getProjects: () => [],
+                onDidChangeProjects: projectEvents.event,
+            };
+            routing = inlineEnabled ? new InlineScriptRoutingRegistry() : undefined;
+            managers = new PythonEnvironmentManagers(projectManager as PythonProjectManager, routing);
+            type ApiArgs = ConstructorParameters<typeof PythonEnvironmentApiImpl>;
+            const variables: Partial<ApiArgs[4]> = { onDidChangeEnvironmentVariables: variableEvents.event };
+            api = new PythonEnvironmentApiImpl(
+                managers, projectManager as PythonProjectManager,
+                {} as ApiArgs[2], {} as ApiArgs[3], variables as ApiArgs[4], disposables,
+            );
+            emitter = new EventEmitter<DidChangePackagesEventArgs>();
+            provider = {
+                name: 'custom',
+                manage: async () => undefined,
+                refresh: async () => undefined,
+                getPackages: async () => [],
+                onDidChangePackages: emitter.event,
+            };
+            disposables.push(
+                projectEvents, variableEvents, emitter,
+                api.registerPackageManager(provider, { extensionId: 'test.packages' }),
+                managers.onDidChangePackages((event) => internalEvents.push(event)),
+                api.onDidChangePackages((event) => publicEvents.push(event)),
+            );
+            changes = [{
+                kind: PackageChangeKind.add,
+                pkg: api.createPackageItem({ name: 'example', displayName: 'example', version: '1.0' }, environment, provider),
+            }];
+        });
+
+        teardown(() => {
+            disposables.forEach((disposable) => disposable.dispose());
+            managers.dispose();
+            routing?.dispose();
+            clock.runAll();
+            sinon.restore();
+        });
+
+        function verifyForwarding(event: DidChangePackagesEventArgs): void {
+            emitter.fire(event);
+            clock.runAll();
+
+            assert.strictEqual(publicEvents.length, 1);
+            assert.strictEqual(publicEvents[0], event, 'The public API must retain the original event and metadata');
+            assert.strictEqual(internalEvents.length, 1);
+            assert.strictEqual(internalEvents[0].environment, environment);
+            assert.strictEqual(internalEvents[0].changes, changes);
+            assert.strictEqual(internalEvents[0].manager, managers.packageManagers[0]);
+            assert.deepStrictEqual(Object.keys(internalEvents[0]).sort(), ['changes', 'environment', 'manager']);
+        }
+
+        test('preserves plain event fields', () => {
+            const event: DidChangePackagesEventArgs = { environment, manager: provider, changes };
+            verifyForwarding(event);
+        });
+
+        test('preserves event fields implemented as prototype accessors', () => {
+            const event = new class implements DidChangePackagesEventArgs {
+                get environment() { return environment; }
+                get manager() { return provider; }
+                get changes() { return changes; }
+            }();
+
+            verifyForwarding(event);
+        });
+
+        test('does not materialize unrelated extension-private event properties', () => {
+            const event: DidChangePackagesEventArgs = { environment, manager: provider, changes };
+            Object.defineProperty(event, 'extensionPrivate', {
+                enumerable: true,
+                get: () => { throw new Error('Unrelated provider state was accessed'); },
+            });
+
+            verifyForwarding(event);
+        });
+    });
+}

--- a/src/test/features/inlineScript/lazyDetector.unit.test.ts
+++ b/src/test/features/inlineScript/lazyDetector.unit.test.ts
@@ -10,6 +10,7 @@ import { InlineScriptRoutingRegistry } from '../../../common/inlineScript/routin
 import { EventNames } from '../../../common/telemetry/constants';
 import * as telemetrySender from '../../../common/telemetry/sender';
 import { createDeferred } from '../../../common/utils/deferred';
+import * as platformUtils from '../../../common/utils/platformUtils';
 import * as wapi from '../../../common/workspace.apis';
 import { InlineScriptLazyDetector, shouldHandleUri } from '../../../features/inlineScript/lazyDetector';
 
@@ -171,9 +172,9 @@ suite('InlineScriptLazyDetector', () => {
         deleteListener!({ files: uris });
     }
 
-    function fireRename(oldUri: Uri, newUri: Uri): void {
+    async function fireRename(oldUri: Uri, newUri: Uri): Promise<void> {
         assert.ok(renameListener, 'rename listener should be registered after activate()');
-        renameListener!({ files: [{ oldUri, newUri }] });
+        await renameListener!({ files: [{ oldUri, newUri }] });
     }
 
     function callsFor(name: EventNames): sinon.SinonSpyCall[] {
@@ -598,11 +599,156 @@ suite('InlineScriptLazyDetector', () => {
         const detector = createDetector();
         await fireOpen(oldUri);
 
-        fireRename(oldUri, newUri);
+        await fireRename(oldUri, newUri);
 
         assert.strictEqual(routingRegistry.getMetadata(oldUri), undefined);
         assert.strictEqual(routingRegistry.shouldRoute(oldUri), false);
         detector.dispose();
+    });
+
+    suite('case-only Windows renames', () => {
+        let oldUri: Uri;
+        let newUri: Uri;
+        let detector: InlineScriptLazyDetector;
+
+        setup(async () => {
+            sinon.stub(platformUtils, 'isWindows').returns(true);
+            oldUri = Uri.file(path.join(process.cwd(), 'rename-tests', 'script.py'));
+            newUri = Uri.file(path.join(process.cwd(), 'rename-tests', 'Script.py'));
+            readMetadataStub.resolves(VALID_METADATA);
+            detector = createDetector();
+            await flushImmediate();
+        });
+
+        teardown(() => detector.dispose());
+
+        for (const open of [false, true]) {
+            test(`preserves saved metadata and routing for a ${open ? 'clean open' : 'closed'} script`, async () => {
+                await fireOpen(oldUri);
+                routingRegistry.setValidatedAssociation(oldUri, true);
+                if (open) {
+                    getOpenTextDocumentsStub.returns([makeDoc(oldUri)]);
+                }
+
+                await fireRename(oldUri, newUri);
+
+                assert.strictEqual(routingRegistry.shouldRoute(newUri), true);
+                assert.deepStrictEqual(routingRegistry.getMetadata(newUri), VALID_METADATA);
+                assert.strictEqual(routingRegistry.getUri(newUri)?.toString(), newUri.toString());
+                assert.ok(readMetadataStub.calledWithExactly(newUri));
+            });
+        }
+
+        test('does not seed saved metadata over a dirty dependency edit through a case alias', async () => {
+            await fireOpen(oldUri);
+            routingRegistry.setValidatedAssociation(oldUri, true);
+            setDocDirty(oldUri, true);
+            getOpenTextDocumentsStub.returns([makeDoc(newUri), makeDoc(oldUri)]);
+            fireChange(oldUri);
+            const readsBefore = readMetadataStub.callCount;
+
+            await fireRename(oldUri, newUri);
+
+            assert.strictEqual(readMetadataStub.callCount, readsBefore);
+            assert.strictEqual(routingRegistry.getMetadata(newUri), undefined);
+            assert.strictEqual(routingRegistry.shouldRoute(newUri), false);
+
+            const changedMetadata = { ...VALID_METADATA, dependencies: ['changed'] };
+            readMetadataStub.resolves(changedMetadata);
+            setDocDirty(oldUri, false);
+            getOpenTextDocumentsStub.returns([makeDoc(newUri)]);
+            await fireSave(newUri);
+            assert.deepStrictEqual(routingRegistry.getMetadata(newUri), changedMetadata);
+            assert.strictEqual(routingRegistry.shouldRoute(newUri), false);
+        });
+
+        test('keeps an existing valid association during a dirty body-only edit', async () => {
+            await fireOpen(oldUri);
+            routingRegistry.setValidatedAssociation(oldUri, true);
+            setDocDirty(oldUri, true);
+            getOpenTextDocumentsStub.returns([makeDoc(newUri), makeDoc(oldUri)]);
+            fireChange(oldUri, makeContentChanges(VALID_METADATA.range.end + 20));
+            const readsBefore = readMetadataStub.callCount;
+
+            await fireRename(oldUri, newUri);
+
+            assert.strictEqual(readMetadataStub.callCount, readsBefore);
+            assert.strictEqual(routingRegistry.shouldRoute(newUri), true);
+            assert.strictEqual(routingRegistry.getUri(newUri)?.toString(), newUri.toString());
+        });
+
+        for (const useNewName of [false, true]) {
+            test(`re-reads after an in-flight ${useNewName ? 'new-name' : 'old-name'} read without publishing its stale metadata`, async () => {
+                const oldRead = createDeferred<ism.InlineScriptMetadata>();
+                const newRead = createDeferred<ism.InlineScriptMetadata>();
+                const freshMetadata = { ...VALID_METADATA, dependencies: ['fresh'] };
+                readMetadataStub.onFirstCall().returns(oldRead.promise);
+                readMetadataStub.onSecondCall().returns(newRead.promise);
+                const opening = fireOpen(useNewName ? newUri : oldUri);
+                const renaming = fireRename(oldUri, newUri);
+                assert.strictEqual(readMetadataStub.callCount, 1);
+
+                oldRead.resolve(VALID_METADATA);
+                await opening;
+                await flushImmediate();
+                assert.strictEqual(readMetadataStub.callCount, 2);
+                assert.strictEqual(routingRegistry.getMetadata(newUri), undefined);
+                newRead.resolve(freshMetadata);
+                await renaming;
+
+                assert.deepStrictEqual(routingRegistry.getMetadata(newUri), freshMetadata);
+                assert.strictEqual(routingRegistry.getUri(newUri)?.toString(), newUri.toString());
+            });
+        }
+
+        for (const useOldAlias of [false, true]) {
+            test(`an edit through the ${useOldAlias ? 'old' : 'new'} case alias invalidates a pending renamed-file read`, async () => {
+                await fireOpen(oldUri);
+                routingRegistry.setValidatedAssociation(oldUri, true);
+                const renamedRead = createDeferred<ism.InlineScriptMetadata>();
+                readMetadataStub.onSecondCall().returns(renamedRead.promise);
+                const renaming = fireRename(oldUri, newUri);
+
+                fireChange(useOldAlias ? oldUri : newUri);
+                renamedRead.resolve(VALID_METADATA);
+                await renaming;
+
+                assert.strictEqual(routingRegistry.getMetadata(newUri), undefined);
+                assert.strictEqual(routingRegistry.shouldRoute(newUri), false);
+            });
+        }
+
+        test('a saved requirement change discovered during rename is not treated as validated', async () => {
+            await fireOpen(oldUri);
+            routingRegistry.setValidatedAssociation(oldUri, true);
+            const changedMetadata = { ...VALID_METADATA, dependencies: ['changed'] };
+            readMetadataStub.resolves(changedMetadata);
+
+            await fireRename(oldUri, newUri);
+
+            assert.deepStrictEqual(routingRegistry.getMetadata(newUri), changedMetadata);
+            assert.strictEqual(routingRegistry.shouldRoute(newUri), false);
+        });
+    });
+
+    test('keeps case-distinct paths separate on case-sensitive platforms', async () => {
+        sinon.stub(platformUtils, 'isWindows').returns(false);
+        const oldUri = Uri.file(path.join(process.cwd(), 'rename-tests', 'script.py'));
+        const newUri = Uri.file(path.join(process.cwd(), 'rename-tests', 'Script.py'));
+        readMetadataStub.resolves(VALID_METADATA);
+        const detector = createDetector();
+        try {
+            await fireOpen(oldUri);
+            routingRegistry.setValidatedAssociation(oldUri, true);
+
+            await fireRename(oldUri, newUri);
+
+            assert.strictEqual(routingRegistry.getMetadata(oldUri), undefined);
+            assert.strictEqual(routingRegistry.shouldRoute(oldUri), false);
+            assert.strictEqual(routingRegistry.getMetadata(newUri), undefined);
+        } finally {
+            detector.dispose();
+        }
     });
 
     test('activate() replays already-open .py documents via setImmediate', async () => {

--- a/src/test/features/views/treeViewItems.unit.test.ts
+++ b/src/test/features/views/treeViewItems.unit.test.ts
@@ -213,10 +213,7 @@ suite('Test TreeView Items', () => {
             const item = new PythonEnvTreeItem(env, managerWithRemove);
 
             // Assert
-            assert.ok(
-                !item.treeItem.contextValue?.includes('managePackages'),
-                'Inline-script environments are built from script metadata and must not offer package edits',
-            );
+            assert.strictEqual(item.treeItem.contextValue, 'pythonEnvironment;remove;activatable;');
         });
 
         test('Packages of an inline-script environment use the read-only context value', () => {

--- a/src/test/features/views/treeViewItems.unit.test.ts
+++ b/src/test/features/views/treeViewItems.unit.test.ts
@@ -6,6 +6,7 @@ import {
     EnvManagerTreeItem,
     getEnvironmentParentDirName,
     NoPythonEnvTreeItem,
+    PackageTreeItem,
     ProjectEnvironment,
     ProjectPackage,
     PythonEnvTreeItem,
@@ -169,7 +170,7 @@ suite('Test TreeView Items', () => {
             const item = new PythonEnvTreeItem(env, managerWithoutRemove);
 
             // Assert
-            assert.strictEqual(item.treeItem.contextValue, 'pythonEnvironment;');
+            assert.strictEqual(item.treeItem.contextValue, 'pythonEnvironment;managePackages;');
         });
 
         test('Context value includes activatable when environment has activation', () => {
@@ -183,7 +184,7 @@ suite('Test TreeView Items', () => {
             const item = new PythonEnvTreeItem(env, managerWithoutRemove);
 
             // Assert
-            assert.strictEqual(item.treeItem.contextValue, 'pythonEnvironment;activatable;');
+            assert.strictEqual(item.treeItem.contextValue, 'pythonEnvironment;activatable;managePackages;');
         });
 
         test('Context value includes remove when manager supports it', () => {
@@ -197,7 +198,54 @@ suite('Test TreeView Items', () => {
             const item = new PythonEnvTreeItem(env, managerWithRemove);
 
             // Assert
-            assert.strictEqual(item.treeItem.contextValue, 'pythonEnvironment;remove;activatable;');
+            assert.strictEqual(item.treeItem.contextValue, 'pythonEnvironment;remove;activatable;managePackages;');
+        });
+
+        test('Inline-script environments do not advertise package management', () => {
+            // Arrange
+            const env = createMockEnvironment({
+                environmentPath: '/home/user/.cache/script-envs-v1/abc123/bin/python',
+                managerId: 'ms-python.python:inline-script',
+                hasActivation: true,
+            });
+
+            // Act
+            const item = new PythonEnvTreeItem(env, managerWithRemove);
+
+            // Assert
+            assert.ok(
+                !item.treeItem.contextValue?.includes('managePackages'),
+                'Inline-script environments are built from script metadata and must not offer package edits',
+            );
+        });
+
+        test('Packages of an inline-script environment use the read-only context value', () => {
+            // Arrange
+            const env = createMockEnvironment({
+                environmentPath: '/home/user/.cache/script-envs-v1/abc123/bin/python',
+                managerId: 'ms-python.python:inline-script',
+            });
+            const parent = new PythonEnvTreeItem(env, managerWithRemove);
+            const pkg = { name: 'requests', displayName: 'requests', version: '2.32.0' } as Package;
+
+            // Act
+            const item = new PackageTreeItem(pkg, parent, {} as InternalPackageManager);
+
+            // Assert
+            assert.strictEqual(item.treeItem.contextValue, 'python-package-readonly');
+        });
+
+        test('Packages of an ordinary environment keep the manageable context value', () => {
+            // Arrange
+            const env = createMockEnvironment({ environmentPath: '/home/user/envs/.venv/bin/python' });
+            const parent = new PythonEnvTreeItem(env, managerWithRemove);
+            const pkg = { name: 'requests', displayName: 'requests', version: '2.32.0' } as Package;
+
+            // Act
+            const item = new PackageTreeItem(pkg, parent, {} as InternalPackageManager);
+
+            // Assert
+            assert.strictEqual(item.treeItem.contextValue, 'python-package');
         });
 
         test('Uses environment displayName as tree item label', () => {

--- a/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
+++ b/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
@@ -7,8 +7,9 @@ import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { Disposable, LogOutputChannel, Memento, TextDocument, Uri } from 'vscode';
+import { CancellationTokenSource, Disposable, LogOutputChannel, Memento, TextDocument, Uri } from 'vscode';
 import {
+    DidChangeEnvironmentEventArgs,
     EnvironmentChangeKind,
     EnvironmentManager,
     PythonEnvironment,
@@ -24,13 +25,16 @@ import { EventNames } from '../../../../common/telemetry/constants';
 import * as telemetrySender from '../../../../common/telemetry/sender';
 import { isWindows } from '../../../../common/utils/platformUtils';
 import { normalizePath } from '../../../../common/utils/pathUtils';
+import { createDeferred } from '../../../../common/utils/deferred';
 import { getVenvPythonPath } from '../../../../common/utils/virtualEnvironment';
 import * as workspaceApis from '../../../../common/workspace.apis';
+import { InlineScriptCodeLensProvider } from '../../../../features/inlineScript/codeLens';
 import { InlineScriptEnvManager } from '../../../../managers/builtin/inlineScript/envManager';
 import * as builtinUtils from '../../../../managers/builtin/utils';
 import * as uvPythonInstaller from '../../../../managers/builtin/uvPythonInstaller';
 import * as venvUtils from '../../../../managers/builtin/venvUtils';
 import { NativePythonFinder } from '../../../../managers/common/nativePythonFinder';
+import { MockDocument } from '../../../mocks/mockDocument';
 
 const CACHE_KEY = '0123456789abcdef';
 const NOW = new Date('2026-07-21T12:00:00.000Z');
@@ -2363,7 +2367,7 @@ suite('InlineScriptEnvManager', () => {
             assert.strictEqual(routingRegistry.shouldRoute(uri), true);
         });
 
-        test('an external change to site-packages is detected on the next validation', async () => {
+        test('a lookup invalidates drift and restores the setup CodeLens without a save', async () => {
             const uri = scriptUri();
             const environment = await manager.create(uri);
             assert.ok(environment);
@@ -2375,10 +2379,189 @@ suite('InlineScriptEnvManager', () => {
             // Validation results are cached briefly, so drift is observed by the next validation
             // after that window rather than instantly.
             clock.tick(6_000);
+            assert.strictEqual(await manager.get(uri), undefined);
+            assert.strictEqual(routingRegistry.shouldRoute(uri), false);
+            const provider = new InlineScriptCodeLensProvider(routingRegistry, 'setup');
+            const tokenSource = new CancellationTokenSource();
+            try {
+                const document = new MockDocument(
+                    '# /// script\n# dependencies = ["requests"]\n# ///\n', uri.fsPath, async () => true,
+                );
+                assert.strictEqual(provider.provideCodeLenses(document, tokenSource.token).length, 1);
+            } finally {
+                tokenSource.dispose();
+                provider.dispose();
+            }
+        });
+
+        test('drift invalidates and notifies all sharing scripts but leaves another entry alone', async () => {
+            const first = scriptUri('first.py');
+            const second = scriptUri('second.py');
+            const unrelated = scriptUri('unrelated.py');
+            const environment = await manager.create(first);
+            assert.ok(environment);
+            const otherEnvironment = await createOwnedEnvironment('other-entry');
+            for (const [uri, selected] of [
+                [first, environment], [second, environment], [unrelated, otherEnvironment],
+            ] as const) {
+                await manager.set(uri, selected);
+                await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            }
+            const events: DidChangeEnvironmentEventArgs[] = [];
+            manager.onDidChangeEnvironment((event) => events.push(event));
+            await setInstalledDistributions(environment.sysPrefix, ['added-1.0.0.dist-info']);
+            clock.tick(6_000);
+
+            assert.strictEqual(await manager.get(first), undefined);
+
+            assert.strictEqual(routingRegistry.shouldRoute(first), false);
+            assert.strictEqual(routingRegistry.shouldRoute(second), false);
+            assert.strictEqual(routingRegistry.shouldRoute(unrelated), true);
+            assert.strictEqual(await manager.get(unrelated), otherEnvironment);
+            assert.deepStrictEqual(
+                events.map((event) => ({ uri: event.uri?.toString(), old: event.old, new: event.new })),
+                [first, second].map((uri) => ({ uri: uri.toString(), old: environment, new: undefined })),
+            );
+            assert.ok(persistedAssociations, 'invalidation must preserve associations for explicit repair');
+        });
+
+        test('cold rehydration invalidates previously advertised routing after drift', async () => {
+            const uri = scriptUri();
+            const environment = await manager.create(uri);
+            assert.ok(environment);
+            await manager.set(uri, environment);
             await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            await setInstalledDistributions(environment.sysPrefix, ['added-1.0.0.dist-info']);
+            manager.dispose();
+            manager = new InlineScriptEnvManager(
+                nativeFinder, api, baseManager, globalStorageUri, makeFakeLog(), workspaceMemento, routingRegistry,
+            );
+
+            assert.strictEqual(await manager.get(uri), undefined);
+            await waitForCondition(() => !routingRegistry.shouldRoute(uri), 'rehydration must clear stale routing');
+        });
+
+        test('a stale drift observation cannot invalidate a newer repair of the same entry', async () => {
+            const first = scriptUri('first.py');
+            const second = scriptUri('second.py');
+            const environment = await manager.create(first);
+            assert.ok(environment);
+            for (const uri of [first, second]) {
+                await manager.set(uri, environment);
+                await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            }
+            await setInstalledDistributions(environment.sysPrefix, ['added-1.0.0.dist-info']);
+            const oldHash = await cacheLayout.readInstalledPackagesHash(Uri.file(environment.sysPrefix));
+            const readHash = cacheLayout.readInstalledPackagesHash;
+            const delayedRead = createDeferred<string | undefined>();
+            const hashReadStub = sinon.stub(cacheLayout, 'readInstalledPackagesHash').callsFake(readHash);
+            hashReadStub.onFirstCall().returns(delayedRead.promise);
+            clock.tick(6_000);
+            const lookup = manager.get(first);
+            try {
+                await waitForStubCall(hashReadStub);
+                const repaired = await manager.create(second);
+                assert.ok(repaired);
+                await manager.set(second, repaired);
+            } finally {
+                delayedRead.resolve(oldHash);
+            }
+            await lookup;
+
+            assert.strictEqual(routingRegistry.shouldRoute(first), true);
+            assert.strictEqual(routingRegistry.shouldRoute(second), true);
+            assert.ok(await manager.get(first));
+        });
+
+        test('a newer selection wins when an old drift lookup finishes later', async () => {
+            const uri = scriptUri();
+            const environment = await manager.create(uri);
+            assert.ok(environment);
+            await manager.set(uri, environment);
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            const otherEnvironment = await createOwnedEnvironment('other-entry');
+            await setInstalledDistributions(environment.sysPrefix, ['added-1.0.0.dist-info']);
+            const oldHash = await cacheLayout.readInstalledPackagesHash(Uri.file(environment.sysPrefix));
+            const delayedRead = createDeferred<string | undefined>();
+            const hashReadStub = sinon.stub(cacheLayout, 'readInstalledPackagesHash').returns(delayedRead.promise);
+            clock.tick(6_000);
+            const lookup = manager.get(uri);
+            try {
+                await waitForStubCall(hashReadStub);
+                await manager.set(uri, otherEnvironment);
+            } finally {
+                delayedRead.resolve(oldHash);
+            }
+
+            assert.strictEqual(await lookup, otherEnvironment);
+            assert.strictEqual(routingRegistry.shouldRoute(uri), true);
+        });
+
+        test('a contended confirmation lock preserves routing and does not wait for an installer', async () => {
+            const uri = scriptUri();
+            const environment = await manager.create(uri);
+            assert.ok(environment);
+            await manager.set(uri, environment);
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            await setInstalledDistributions(environment.sysPrefix, ['added-1.0.0.dist-info']);
+            clock.tick(6_000);
+            lockStub.resetHistory();
+            lockStub.rejects(Object.assign(new Error('Entry is being rebuilt'), { code: 'ELOCKED' }));
+
+            assert.strictEqual(await manager.get(uri), undefined);
+
+            assert.ok(lockStub.calledOnce);
+            assert.strictEqual(lockStub.firstCall.args[1].timeoutMs, 0);
+            assert.strictEqual(routingRegistry.shouldRoute(uri), true);
+        });
+
+        test('unavailable inventory does not invalidate an otherwise usable environment', async () => {
+            const uri = scriptUri();
+            const environment = await manager.create(uri);
+            assert.ok(environment);
+            await manager.set(uri, environment);
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            sinon.stub(cacheLayout, 'readInstalledPackagesHash').resolves(undefined);
+            clock.tick(6_000);
+
+            assert.strictEqual(await manager.get(uri), environment);
+            assert.strictEqual(routingRegistry.shouldRoute(uri), true);
+        });
+
+        test('an unavailable confirmation read does not publish an old drift observation', async () => {
+            const uri = scriptUri();
+            const environment = await manager.create(uri);
+            assert.ok(environment);
+            await manager.set(uri, environment);
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            await setInstalledDistributions(environment.sysPrefix, ['added-1.0.0.dist-info']);
+            const oldHash = await cacheLayout.readInstalledPackagesHash(Uri.file(environment.sysPrefix));
+            const hashReadStub = sinon.stub(cacheLayout, 'readInstalledPackagesHash').resolves(undefined);
+            hashReadStub.onFirstCall().resolves(oldHash);
+            clock.tick(6_000);
+            const events: DidChangeEnvironmentEventArgs[] = [];
+            manager.onDidChangeEnvironment((event) => events.push(event));
+
+            assert.strictEqual(await manager.get(uri), undefined);
+            assert.ok(hashReadStub.calledTwice);
+            assert.strictEqual(routingRegistry.shouldRoute(uri), true);
+            assert.deepStrictEqual(events, []);
+        });
+
+        test('confirmed drift invalidation also works with the real cache-entry lock', async () => {
+            const uri = scriptUri();
+            const environment = await manager.create(uri);
+            assert.ok(environment);
+            await manager.set(uri, environment);
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            await setInstalledDistributions(environment.sysPrefix, ['added-1.0.0.dist-info']);
+            clock.tick(6_000);
+            lockStub.resetBehavior();
+            lockStub.callThrough();
 
             assert.strictEqual(await manager.get(uri), undefined);
             assert.strictEqual(routingRegistry.shouldRoute(uri), false);
+            assert.strictEqual(await fs.pathExists(lockfileApis.getFileLockPath(environment.sysPrefix)), false);
         });
 
         test('rebuilds instead of reusing an entry whose packages changed outside setup', async () => {

--- a/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
+++ b/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
@@ -28,6 +28,7 @@ import { normalizePath } from '../../../../common/utils/pathUtils';
 import { createDeferred } from '../../../../common/utils/deferred';
 import { getVenvPythonPath } from '../../../../common/utils/virtualEnvironment';
 import * as workspaceApis from '../../../../common/workspace.apis';
+import * as windowApis from '../../../../common/window.apis';
 import { InlineScriptCodeLensProvider } from '../../../../features/inlineScript/codeLens';
 import { InlineScriptEnvManager } from '../../../../managers/builtin/inlineScript/envManager';
 import * as builtinUtils from '../../../../managers/builtin/utils';
@@ -496,10 +497,10 @@ suite('InlineScriptEnvManager', () => {
     }
 
     suite('static metadata and deferred methods', () => {
-        test('exposes creation but leaves later-phase methods empty', async () => {
+        test('exposes creation and removal while leaving generic resolution empty', async () => {
             const asInterface: EnvironmentManager = manager;
             assert.strictEqual(typeof asInterface.create, 'function');
-            assert.strictEqual(asInterface.remove, undefined);
+            assert.strictEqual(typeof asInterface.remove, 'function');
             assert.strictEqual(asInterface.quickCreateConfig, undefined);
             assert.deepStrictEqual(await manager.getEnvironments('all'), []);
             assert.strictEqual(await manager.get(scriptUri()), undefined);
@@ -6548,6 +6549,309 @@ suite('InlineScriptEnvManager', () => {
 
             assert.ok(await manager.create(scriptUri('trigger.py')));
             assert.strictEqual(await fs.pathExists(orphan.sysPrefix), false);
+        });
+    });
+
+    suite('single cached environment removal', () => {
+        test('deletes one shared entry without prompting or touching other environments, scripts, or settings', async () => {
+            const first = scriptUri('first.py');
+            const second = scriptUri('second.py');
+            const unrelated = scriptUri('unrelated.py');
+            const environment = await createOwnedEnvironment();
+            const otherEnvironment = await createOwnedEnvironment('fedcba9876543210');
+            for (const [uri, selected] of [
+                [first, environment], [second, environment], [unrelated, otherEnvironment],
+            ] as const) {
+                await fs.outputFile(uri.fsPath, 'print("keep this script")');
+                await manager.set(uri, selected);
+                await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            }
+            const settingsPath = path.join(tempRoot, '.vscode', 'settings.json');
+            const settingsText = '{"python-envs.pythonProjects":[{"path":"first.py"},{"path":"unrelated.py"}]}';
+            await fs.outputFile(settingsPath, settingsText);
+            await manager.refresh(undefined);
+            const removed = sinon.spy();
+            const selectionChanges = sinon.spy();
+            manager.onDidChangeEnvironments(removed);
+            manager.onDidChangeEnvironment(selectionChanges);
+            const warning = sinon.stub(windowApis, 'showWarningMessage').resolves(undefined);
+            const information = sinon.stub(windowApis, 'showInformationMessage').resolves(undefined);
+
+            await manager.remove(environment);
+
+            assert.strictEqual(await fs.pathExists(environment.sysPrefix), false);
+            assert.strictEqual(await fs.pathExists(otherEnvironment.sysPrefix), true);
+            assert.strictEqual(await fs.pathExists(baseExecutable), true);
+            assert.strictEqual(await fs.readFile(settingsPath, 'utf8'), settingsText);
+            for (const uri of [first, second, unrelated]) {
+                assert.strictEqual(await fs.readFile(uri.fsPath, 'utf8'), 'print("keep this script")');
+            }
+            assert.strictEqual(routingRegistry.shouldRoute(first), false);
+            assert.strictEqual(routingRegistry.shouldRoute(second), false);
+            assert.strictEqual(routingRegistry.shouldRoute(unrelated), true);
+            assert.strictEqual(await manager.get(first), undefined);
+            assert.strictEqual(await manager.get(second), undefined);
+            assert.strictEqual(await manager.get(unrelated), otherEnvironment);
+            assert.deepStrictEqual(persistedAssociations, {
+                [normalizePath(unrelated.fsPath)]: matchedAssociationRecord(otherEnvironment.environmentPath.fsPath),
+            });
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [otherEnvironment]);
+            assert.deepStrictEqual(removed.firstCall.args[0], [{ kind: EnvironmentChangeKind.remove, environment }]);
+            assert.strictEqual(selectionChanges.callCount, 2);
+            assert.ok(warning.notCalled);
+            assert.ok(information.notCalled);
+        });
+
+        test('deletes an unshared entry and preserves unrelated future association records', async () => {
+            const uri = scriptUri();
+            const environment = await createOwnedEnvironment();
+            await manager.set(uri, environment);
+            const futureKey = normalizePath(scriptUri('future.py').fsPath);
+            const future = futureAssociationRecord(path.join(tempRoot, 'future-env', 'python'));
+            persistedAssociations = { ...persistedAssociations as Record<string, unknown>, [futureKey]: future };
+
+            await manager.remove(environment, { runHeadless: false });
+
+            assert.strictEqual(await fs.pathExists(environment.sysPrefix), false);
+            assert.deepStrictEqual(persistedAssociations, { [futureKey]: future });
+            assert.strictEqual(await manager.get(uri), undefined);
+        });
+
+        test('removing an already-missing entry clears only its stale associations and collection item', async () => {
+            const uri = scriptUri();
+            const otherUri = scriptUri('other.py');
+            const environment = await createOwnedEnvironment();
+            const otherEnvironment = await createOwnedEnvironment('fedcba9876543210');
+            await manager.set(uri, environment);
+            await manager.set(otherUri, otherEnvironment);
+            await manager.refresh(undefined);
+            await fs.remove(environment.sysPrefix);
+
+            await manager.remove(environment);
+
+            assert.deepStrictEqual(await manager.getEnvironments('all'), [otherEnvironment]);
+            assert.strictEqual(await manager.get(uri), undefined);
+            assert.strictEqual(await manager.get(otherUri), otherEnvironment);
+        });
+
+        test('does not clean unrelated stale associations during single-entry deletion', async () => {
+            const uri = scriptUri();
+            const otherUri = scriptUri('other.py');
+            const environment = await createOwnedEnvironment();
+            const otherEnvironment = await createOwnedEnvironment('fedcba9876543210');
+            await manager.set(uri, environment);
+            await manager.set(otherUri, otherEnvironment);
+            await fs.remove(otherEnvironment.sysPrefix);
+
+            await manager.remove(environment);
+
+            assert.deepStrictEqual(persistedAssociations, {
+                [normalizePath(otherUri.fsPath)]: matchedAssociationRecord(otherEnvironment.environmentPath.fsPath),
+            });
+        });
+
+        test('a missing removal argument cannot turn into a bulk cache clear', async () => {
+            const environment = await createOwnedEnvironment();
+
+            await assert.rejects(
+                async () => Reflect.apply(manager.remove, manager, [undefined]),
+                /environment is required/,
+            );
+            assert.strictEqual(await fs.pathExists(environment.sysPrefix), true);
+        });
+
+        for (const invalidTarget of ['foreign-manager', 'outside-cache', 'cache-root', 'outside-executable', 'lock-entry'] as const) {
+            test(`rejects a ${invalidTarget} target without deleting an owned entry`, async () => {
+                const environment = await createOwnedEnvironment();
+                const candidate = { ...environment };
+                if (invalidTarget === 'foreign-manager') {
+                    candidate.envId = { ...environment.envId, managerId: 'ms-python.python:venv' };
+                } else if (invalidTarget === 'outside-cache') {
+                    candidate.sysPrefix = path.join(tempRoot, 'outside', path.basename(environment.sysPrefix));
+                    candidate.environmentPath = Uri.file(getVenvPythonPath(candidate.sysPrefix));
+                } else if (invalidTarget === 'cache-root') {
+                    candidate.sysPrefix = cacheLayout.getScriptEnvCacheRoot(globalStorageUri).fsPath;
+                    candidate.environmentPath = Uri.file(getVenvPythonPath(candidate.sysPrefix));
+                } else if (invalidTarget === 'lock-entry') {
+                    candidate.sysPrefix = `${environment.sysPrefix}.LOCK`;
+                    candidate.environmentPath = Uri.file(getVenvPythonPath(candidate.sysPrefix));
+                } else {
+                    candidate.environmentPath = Uri.file(baseExecutable);
+                }
+
+                await assert.rejects(manager.remove(candidate), /not an owned inline-script cache entry/);
+                assert.strictEqual(await fs.pathExists(environment.sysPrefix), true);
+                assert.strictEqual(await fs.pathExists(baseExecutable), true);
+            });
+        }
+
+        test('refuses a locked entry and preserves its association', async () => {
+            const uri = scriptUri();
+            const environment = await createOwnedEnvironment();
+            await manager.set(uri, environment);
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            lockStub.restore();
+            const held = await lockfileApis.acquireFileLock(environment.sysPrefix, { timeoutMs: 0, retryIntervalMs: 1 });
+            try {
+                await assert.rejects(manager.remove(environment), /being created/);
+                assert.strictEqual(await fs.pathExists(environment.sysPrefix), true);
+                assert.strictEqual(routingRegistry.shouldRoute(uri), true);
+            } finally {
+                await held.release();
+            }
+            assert.strictEqual(await manager.get(uri), environment);
+        });
+
+        test('does not delete through a redirected cache entry', async function () {
+            const environment = await createOwnedEnvironment();
+            const outside = path.join(tempRoot, 'outside-environment');
+            const protectedFile = path.join(outside, 'keep.txt');
+            await fs.outputFile(protectedFile, 'keep');
+            await fs.remove(environment.sysPrefix);
+            try {
+                await fs.symlink(outside, environment.sysPrefix, isWindows() ? 'junction' : 'dir');
+            } catch (error) {
+                if ((error as NodeJS.ErrnoException).code === 'EPERM') {
+                    this.skip();
+                    return;
+                }
+                throw error;
+            }
+
+            await assert.rejects(manager.remove(environment), /not a normal directory/);
+            assert.strictEqual(await fs.readFile(protectedFile, 'utf8'), 'keep');
+        });
+
+        test('does not begin deletion if the sidecar cannot be invalidated safely', async () => {
+            const uri = scriptUri();
+            const environment = await createOwnedEnvironment();
+            await manager.set(uri, environment);
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            const internal = manager as unknown as { deleteCacheEntryForClear(entryPath: string): Promise<void> };
+            const deleting = sinon.spy(internal, 'deleteCacheEntryForClear');
+            writeMetaStub.rejects(new Error('Metadata is read-only'));
+
+            await assert.rejects(manager.remove(environment), /Metadata is read-only/);
+
+            assert.ok(deleting.notCalled);
+            assert.strictEqual(await fs.pathExists(environment.sysPrefix), true);
+            assert.strictEqual(routingRegistry.shouldRoute(uri), true);
+        });
+
+        test('reports an incomplete deletion and makes surviving files require setup again', async () => {
+            const uri = scriptUri();
+            const environment = await createOwnedEnvironment();
+            await manager.set(uri, environment);
+            const internal = manager as unknown as { deleteCacheEntryForClear(entryPath: string): Promise<void> };
+            sinon.stub(internal, 'deleteCacheEntryForClear').rejects(new Error('Access denied'));
+
+            await assert.rejects(manager.remove(environment), /Failed to delete.*Access denied/);
+
+            assert.strictEqual(await fs.pathExists(environment.sysPrefix), true);
+            assert.strictEqual(await manager.get(uri), undefined);
+            assert.strictEqual(routingRegistry.shouldRoute(uri), false);
+            assert.strictEqual(
+                (sidecarsByEnvDir.get(normalizePath(environment.sysPrefix)) as cacheLayout.InlineScriptEnvMeta).manuallyModified,
+                true,
+            );
+        });
+
+        test('clears partially removed associations without changing an unrelated environment', async () => {
+            const uri = scriptUri();
+            const otherUri = scriptUri('other.py');
+            const environment = await createOwnedEnvironment();
+            const otherEnvironment = await createOwnedEnvironment('fedcba9876543210');
+            await manager.set(uri, environment);
+            await manager.set(otherUri, otherEnvironment);
+            const events = sinon.spy();
+            manager.onDidChangeEnvironment(events);
+            const internal = manager as unknown as { deleteCacheEntryForClear(entryPath: string): Promise<void> };
+            sinon.stub(internal, 'deleteCacheEntryForClear').callsFake(async () => {
+                await fs.remove(environment.environmentPath.fsPath);
+                throw new Error('Some files remain locked');
+            });
+
+            await assert.rejects(manager.remove(environment), /Some files remain locked/);
+
+            assert.strictEqual(await manager.get(uri), undefined);
+            assert.strictEqual(await manager.get(otherUri), otherEnvironment);
+            assert.deepStrictEqual(persistedAssociations, {
+                [normalizePath(otherUri.fsPath)]: matchedAssociationRecord(otherEnvironment.environmentPath.fsPath),
+            });
+            assert.ok(events.calledOnce);
+        });
+
+        test('reports persistence failure but does not retain deleted entries in memory', async () => {
+            const uri = scriptUri();
+            const environment = await createOwnedEnvironment();
+            await manager.set(uri, environment);
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            await manager.refresh(undefined);
+            workspaceState.update.rejects(new Error('Memento unavailable'));
+
+            await assert.rejects(manager.remove(environment), /Memento unavailable/);
+
+            assert.strictEqual(await fs.pathExists(environment.sysPrefix), false);
+            assert.deepStrictEqual(await manager.getEnvironments('all'), []);
+            assert.strictEqual(routingRegistry.shouldRoute(uri), false);
+        });
+
+        test('refuses removal if a create started first', async () => {
+            const environment = await createOwnedEnvironment();
+            const delayedMetadata = createDeferred<metadataReader.InlineScriptMetadata | undefined>();
+            readMetadataStub.returns(delayedMetadata.promise);
+            const creating = manager.create(scriptUri());
+            try {
+                await assert.rejects(manager.remove(environment), /being created/);
+                assert.strictEqual(await fs.pathExists(environment.sysPrefix), true);
+            } finally {
+                delayedMetadata.resolve(undefined);
+                await creating;
+            }
+        });
+
+        test('a new create waits until the selected entry has been removed', async () => {
+            const environment = await createOwnedEnvironment();
+            const enteredDeletion = createDeferred<void>();
+            const finishDeletion = createDeferred<void>();
+            const internal = manager as unknown as { deleteCacheEntryForClear(entryPath: string): Promise<void> };
+            sinon.stub(internal, 'deleteCacheEntryForClear').callsFake(async (entryPath) => {
+                enteredDeletion.resolve();
+                await finishDeletion.promise;
+                await fs.remove(entryPath);
+            });
+            const removing = manager.remove(environment);
+            await enteredDeletion.promise;
+            readMetadataStub.resetHistory();
+            const creating = manager.create(scriptUri());
+            try {
+                await nextTurn();
+                assert.ok(readMetadataStub.notCalled);
+            } finally {
+                finishDeletion.resolve();
+            }
+            await removing;
+            assert.ok(await creating);
+            assert.strictEqual(await fs.pathExists(envDir().fsPath), true);
+        });
+
+        test('an in-flight rehydration cannot restore a deleted association', async () => {
+            const uri = scriptUri();
+            const environment = await createOwnedEnvironment();
+            persistedAssociations = { [normalizePath(uri.fsPath)]: environment.environmentPath.fsPath };
+            const delayedResolution = createDeferred<PythonEnvironment | undefined>();
+            resolveVenvStub.returns(delayedResolution.promise);
+            const getting = manager.get(uri);
+            try {
+                await waitForStubCall(resolveVenvStub);
+                await manager.remove(environment);
+            } finally {
+                delayedResolution.resolve(environment);
+            }
+
+            assert.strictEqual(await getting, undefined);
+            assert.strictEqual(await manager.get(uri), undefined);
+            assert.deepStrictEqual(persistedAssociations, {});
         });
     });
 

--- a/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
+++ b/src/test/managers/builtin/inlineScript/envManager.unit.test.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import { Disposable, LogOutputChannel, Memento, TextDocument, Uri } from 'vscode';
 import {
-    DidChangePackagesEventArgs,
     EnvironmentChangeKind,
     EnvironmentManager,
     PythonEnvironment,
@@ -102,7 +101,6 @@ suite('InlineScriptEnvManager', () => {
     let api: PythonEnvironmentApi;
     let apiGetEnvironmentsStub: sinon.SinonStub;
     let apiRefreshEnvironmentsStub: sinon.SinonStub;
-    let packagesChangedListener: ((e: DidChangePackagesEventArgs) => unknown) | undefined;
     let baseEnvironment: PythonEnvironment;
     let baseExecutable: string;
     let baseManager: EnvironmentManager;
@@ -130,6 +128,7 @@ suite('InlineScriptEnvManager', () => {
     let tempRoot: string;
     let baseInterpreterStatusStub: sinon.SinonStub;
     let writeMetaStub: sinon.SinonStub;
+    let openDocumentsStub: sinon.SinonStub;
     let deleteFilesListener: ((e: { files: readonly Uri[] }) => unknown) | undefined;
     let renameFilesListener: ((e: { files: readonly { oldUri: Uri; newUri: Uri }[] }) => unknown) | undefined;
     let workspaceState: {
@@ -152,8 +151,7 @@ suite('InlineScriptEnvManager', () => {
         api = {
             getEnvironments: apiGetEnvironmentsStub,
             refreshEnvironments: apiRefreshEnvironmentsStub,
-            onDidChangePackages: (listener: (e: DidChangePackagesEventArgs) => unknown) => {
-                packagesChangedListener = listener;
+            onDidChangePackages: () => {
                 return new Disposable(() => undefined);
             },
         } as unknown as PythonEnvironmentApi;
@@ -228,11 +226,18 @@ suite('InlineScriptEnvManager', () => {
                     renameFilesListener = undefined;
                 });
             });
-        sinon.stub(workspaceApis, 'getOpenTextDocuments').returns([]);
+        openDocumentsStub = sinon.stub(workspaceApis, 'getOpenTextDocuments').returns([]);
         createWithProgressStub = sinon.stub(venvUtils, 'createWithProgress').callsFake(async (...args: unknown[]) => {
             const envDir = args[6] as string;
             const selectedBase = args[4] as PythonEnvironment;
             await fs.outputFile(getVenvPythonPath(envDir), '');
+            // A real build produces a site-packages directory; the manager records its contents
+            // as the entry's baseline inventory.
+            await fs.ensureDir(
+                isWindows()
+                    ? path.join(envDir, 'Lib', 'site-packages')
+                    : path.join(envDir, 'lib', 'python3.12', 'site-packages'),
+            );
             const environment = makeEnvironment(
                 'ms-python.python:inline-script',
                 selectedBase.version,
@@ -378,9 +383,9 @@ suite('InlineScriptEnvManager', () => {
         deleteFilesListener!({ files });
     }
 
-    function fireRename(oldUri: Uri, newUri: Uri): void {
+    async function fireRename(oldUri: Uri, newUri: Uri): Promise<void> {
         assert.ok(renameFilesListener, 'rename listener should be registered');
-        renameFilesListener!({ files: [{ oldUri, newUri }] });
+        await renameFilesListener!({ files: [{ oldUri, newUri }] });
     }
 
     function workspaceStateSetCalls(key: string): readonly sinon.SinonSpyCall[] {
@@ -1301,6 +1306,7 @@ suite('InlineScriptEnvManager', () => {
                     baseInterpreterPath: baseExecutable,
                     baseInterpreterVersion: baseEnvironment.version,
                     lastUsedAt: NOW.toISOString(),
+                    installedPackagesHash: cacheLayout.hashInstalledDistributions([]),
                     sourceMetadataIdentityHashes: [
                         cacheLayout.hashSourceMetadataIdentity(VALID_METADATA_IDENTITY),
                     ],
@@ -2307,14 +2313,19 @@ suite('InlineScriptEnvManager', () => {
     });
 
     suite('package drift', () => {
-        // The listener is fire-and-forget, so wait for its async work rather than the call.
-        function firePackagesChanged(environment: PythonEnvironment): void {
-            assert.ok(packagesChangedListener, 'expected the manager to subscribe to package changes');
-            packagesChangedListener!({
-                environment,
-                manager: {} as never,
-                changes: [{ kind: 0 as never, pkg: {} as never }],
-            });
+        function sitePackagesDir(envPath: string): string {
+            return isWindows()
+                ? path.join(envPath, 'Lib', 'site-packages')
+                : path.join(envPath, 'lib', 'python3.12', 'site-packages');
+        }
+
+        async function setInstalledDistributions(envPath: string, distributions: readonly string[]): Promise<void> {
+            const dir = sitePackagesDir(envPath);
+            await fs.remove(dir);
+            await fs.ensureDir(dir);
+            for (const distribution of distributions) {
+                await fs.ensureDir(path.join(dir, distribution));
+            }
         }
 
         function sidecarFor(environment: PythonEnvironment): cacheLayout.InlineScriptEnvMeta | undefined {
@@ -2322,93 +2333,67 @@ suite('InlineScriptEnvManager', () => {
             return typeof entry === 'string' ? undefined : entry;
         }
 
-        test('marks an owned entry manually modified and un-routes every script using it', async () => {
-            const first = scriptUri('shared_one.py');
-            const second = scriptUri('shared_two.py');
-            const environment = await createOwnedEnvironment();
-            await manager.set(first, environment);
-            await manager.set(second, environment);
-            routingRegistry.setValidatedAssociation(first, true);
-            routingRegistry.setValidatedAssociation(second, true);
-
-            firePackagesChanged(environment);
-            await waitForCondition(
-                () => sidecarFor(environment)?.manuallyModified === true,
-                'the modified cache entry should be marked in its sidecar',
-            );
-
-            // Both scripts sharing the entry lose routing, not just the edited one.
-            assert.strictEqual(routingRegistry.hasValidatedAssociation(first), false);
-            assert.strictEqual(routingRegistry.hasValidatedAssociation(second), false);
-        });
-
-        test('rebuilds instead of reusing an entry whose packages were modified', async () => {
+        // Named for the defect it prevents: an entry with no recorded inventory once compared
+        // against an empty list, so simply listing its packages looked like a user installation
+        // and forced a working environment through setup again.
+        test('bug 1: an entry with no recorded inventory is never treated as modified', async () => {
             const uri = scriptUri();
             const environment = await createOwnedEnvironment();
+            await setInstalledDistributions(environment.sysPrefix, ['requests-2.32.0.dist-info']);
             await manager.set(uri, environment);
-            firePackagesChanged(environment);
-            await waitForCondition(
-                () => sidecarFor(environment)?.manuallyModified === true,
-                'the modified cache entry should be marked in its sidecar',
-            );
-            createWithProgressStub.resetHistory();
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
 
-            await manager.create(uri);
-
-            assert.strictEqual(
-                createWithProgressStub.callCount,
-                1,
-                'a drifted entry must be rebuilt, not reused',
-            );
+            assert.strictEqual(sidecarFor(environment)?.installedPackagesHash, undefined);
+            assert.strictEqual(await manager.get(uri), environment);
+            assert.strictEqual(routingRegistry.shouldRoute(uri), true);
         });
 
-        test('ignores package changes for environments it does not own', async () => {
+        // The record is written inside the cache-entry lock that already guards the build, so the
+        // extension cannot observe its own installation as an edit made outside setup.
+        test('bug 2: setup records its own installation, so a later check reports no drift', async () => {
             const uri = scriptUri();
-            const environment = await createOwnedEnvironment();
+
+            const environment = await manager.create(uri);
+            assert.ok(environment);
             await manager.set(uri, environment);
-            routingRegistry.setValidatedAssociation(uri, true);
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
 
-            firePackagesChanged({
-                ...environment,
-                envId: { managerId: 'ms-python.python:venv', id: 'some-venv' },
-            });
-            await nextTurn();
-            await nextTurn();
-            await nextTurn();
-
-            assert.strictEqual(sidecarFor(environment)?.manuallyModified, undefined);
-            assert.strictEqual(routingRegistry.hasValidatedAssociation(uri), true);
+            assert.ok(sidecarFor(environment)?.installedPackagesHash, 'setup must record what it installed');
+            assert.strictEqual(await manager.get(uri), environment);
+            assert.strictEqual(routingRegistry.shouldRoute(uri), true);
         });
-        test('does not mark an entry while its own build is in flight', async () => {
-            // The real createWithProgress installs through managePackages, which fires this same
-            // event while the build still holds the cache-entry lock, so setup must not mark the
-            // entry it is building. Two entries are used so the outcomes are distinguishable: the
-            // unguarded entry settling proves the guarded one had at least as long to settle.
-            const building = await createOwnedEnvironment();
-            const edited = await createOwnedEnvironment('bbbbbbbbbbbbbbbb');
-            const buildingScript = scriptUri('building.py');
-            await manager.set(buildingScript, building);
-            routingRegistry.setValidatedAssociation(buildingScript, true);
-            const pendingCreations = (
-                manager as unknown as { pendingCreations: Map<string, unknown> }
-            ).pendingCreations;
-            pendingCreations.set(CACHE_KEY, {});
 
-            firePackagesChanged(building);
-            firePackagesChanged(edited);
-            await waitForCondition(
-                () => sidecarFor(edited)?.manuallyModified === true,
-                'a package change outside a build should be recorded',
-            );
-            await nextTurn();
-            await nextTurn();
+        test('an external change to site-packages is detected on the next validation', async () => {
+            const uri = scriptUri();
+            const environment = await manager.create(uri);
+            assert.ok(environment);
+            await manager.set(uri, environment);
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            assert.strictEqual(routingRegistry.shouldRoute(uri), true);
 
-            assert.strictEqual(
-                sidecarFor(building)?.manuallyModified,
-                undefined,
-                'setup must not mark the entry it is building',
+            await setInstalledDistributions(environment.sysPrefix, ['left-pad-1.0.0.dist-info']);
+            // Validation results are cached briefly, so drift is observed by the next validation
+            // after that window rather than instantly.
+            clock.tick(6_000);
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
+
+            assert.strictEqual(await manager.get(uri), undefined);
+            assert.strictEqual(routingRegistry.shouldRoute(uri), false);
+        });
+
+        test('rebuilds instead of reusing an entry whose packages changed outside setup', async () => {
+            const uri = scriptUri();
+            const environment = await manager.create(uri);
+            assert.ok(environment);
+            const buildsAfterFirstCreate = createWithProgressStub.callCount;
+
+            await setInstalledDistributions(environment.sysPrefix, ['tampered-9.9.9.dist-info']);
+            assert.ok(await manager.create(uri));
+
+            assert.ok(
+                createWithProgressStub.callCount > buildsAfterFirstCreate,
+                'a drifted entry must be rebuilt rather than reused',
             );
-            assert.strictEqual(routingRegistry.hasValidatedAssociation(buildingScript), true);
         });
     });
 
@@ -4516,6 +4501,50 @@ suite('InlineScriptEnvManager', () => {
             restarted.dispose();
         });
 
+        test('retains a warm association but does not return it when its sidecar is temporarily unreadable', async () => {
+            const uri = scriptUri();
+            const environment = await createOwnedEnvironment();
+            await manager.set(uri, environment);
+            await triggerSavedMetadataChange(routingRegistry, manager, uri);
+            const savedAssociations = structuredClone(persistedAssociations);
+            clock.tick(5_001);
+            const nextRead = inspectMetaStub.callCount;
+            inspectMetaStub.onCall(nextRead).resolves({ kind: 'unavailable' });
+
+            assert.strictEqual(await manager.get(uri), undefined);
+            assert.deepStrictEqual(persistedAssociations, savedAssociations);
+            assert.strictEqual(await manager.get(uri), environment, 'a later successful read should recover without setup');
+            assert.ok(createWithProgressStub.notCalled);
+        });
+
+        test('does not bypass modification checks after an unreadable sidecar during restart', async () => {
+            const uri = scriptUri();
+            const environment = await createOwnedEnvironment();
+            await manager.set(uri, environment);
+            setSidecar(await makeSidecar({ manuallyModified: true }));
+            const savedAssociations = structuredClone(persistedAssociations);
+            inspectMetaStub.resolves({ kind: 'unavailable' });
+            const registry = new InlineScriptRoutingRegistry();
+            const restarted = new InlineScriptEnvManager(
+                nativeFinder, api, baseManager, globalStorageUri, makeFakeLog(),
+                workspaceMemento, registry,
+            );
+            try {
+                await triggerSavedMetadataChange(registry, restarted, uri);
+                assert.strictEqual(await restarted.get(uri), undefined);
+                assert.strictEqual(registry.shouldRoute(uri), false);
+                assert.deepStrictEqual(persistedAssociations, savedAssociations);
+
+                inspectMetaStub.resolves({ kind: 'valid', metadata: await makeSidecar({ manuallyModified: true }) });
+                await triggerSavedMetadataChange(registry, restarted, uri);
+                assert.strictEqual(await restarted.get(uri), undefined);
+                assert.strictEqual(registry.shouldRoute(uri), false);
+            } finally {
+                restarted.dispose();
+                registry.dispose();
+            }
+        });
+
         test('keeps a persisted matched additional-packages association non-routeable on restart when only an old sidecar remains', async () => {
             const uri = scriptUri();
             routingRegistry.setMetadata(uri, VALID_METADATA);
@@ -5394,7 +5423,7 @@ suite('InlineScriptEnvManager', () => {
             const environment = await createOwnedEnvironment();
             await manager.set(oldUri, environment);
 
-            fireRename(oldUri, newUri);
+            await fireRename(oldUri, newUri);
             await nextTurn();
             await nextTurn();
 
@@ -5406,13 +5435,83 @@ suite('InlineScriptEnvManager', () => {
             assert.strictEqual(await manager.get(newUri), environment);
         });
 
+        test('preserves a Windows case-only rename without rewriting the association or creating an environment', async function () {
+            if (!isWindows()) {
+                this.skip();
+                return;
+            }
+            const oldUri = scriptUri('script.py');
+            const newUri = scriptUri('Script.py');
+            const environment = await createOwnedEnvironment();
+            await manager.set(oldUri, environment);
+            await triggerSavedMetadataChange(routingRegistry, manager, oldUri);
+            const savedAssociations = structuredClone(persistedAssociations);
+            workspaceState.update.resetHistory();
+
+            await fireRename(oldUri, newUri);
+
+            assert.strictEqual(await manager.get(newUri), environment);
+            assert.deepStrictEqual(persistedAssociations, savedAssociations);
+            assert.ok(workspaceState.update.notCalled);
+            assert.ok(createWithProgressStub.notCalled);
+        });
+
+        test('rehydrates a case-renamed Windows script from the unchanged association key', async function () {
+            if (!isWindows()) {
+                this.skip();
+                return;
+            }
+            const oldUri = scriptUri('script.py');
+            const newUri = scriptUri('Script.py');
+            const environment = await createOwnedEnvironment();
+            await manager.set(oldUri, environment);
+            await fireRename(oldUri, newUri);
+            const restartedRegistry = new InlineScriptRoutingRegistry();
+            const restarted = new InlineScriptEnvManager(
+                nativeFinder, api, baseManager, globalStorageUri, makeFakeLog(),
+                workspaceMemento, restartedRegistry,
+            );
+            try {
+                await triggerSavedMetadataChange(restartedRegistry, restarted, newUri);
+
+                assert.strictEqual(await restarted.get(newUri), environment);
+                assert.strictEqual(restartedRegistry.shouldRoute(newUri), true);
+                assert.ok(createWithProgressStub.notCalled);
+            } finally {
+                restarted.dispose();
+                restartedRegistry.dispose();
+            }
+        });
+
+        test('does not validate a dirty Windows document through its new filename casing', async function () {
+            if (!isWindows()) {
+                this.skip();
+                return;
+            }
+            const oldUri = scriptUri('script.py');
+            const newUri = scriptUri('Script.py');
+            const environment = await createOwnedEnvironment();
+            await manager.set(oldUri, environment);
+            await triggerSavedMetadataChange(routingRegistry, manager, oldUri);
+            openDocumentsStub.returns([{ uri: oldUri, isDirty: true } as TextDocument]);
+
+            await fireRename(oldUri, newUri);
+            await manager.set(newUri, environment);
+
+            assert.strictEqual(routingRegistry.shouldRoute(newUri), false);
+            assert.deepStrictEqual(persistedAssociations, {
+                [normalizePath(newUri.fsPath)]: pendingAssociationRecord(environment.environmentPath.fsPath),
+            });
+            assert.ok(createWithProgressStub.notCalled);
+        });
+
         test('drops the association when a script is renamed to a non-python file', async () => {
             const oldUri = scriptUri('old.py');
             const newUri = scriptUri('old.txt');
             const environment = await createOwnedEnvironment();
             await manager.set(oldUri, environment);
 
-            fireRename(oldUri, newUri);
+            await fireRename(oldUri, newUri);
             await nextTurn();
             await nextTurn();
 
@@ -5429,7 +5528,7 @@ suite('InlineScriptEnvManager', () => {
             await manager.set(targetUri, replacedEnvironment);
             await manager.set(oldUri, movedEnvironment);
 
-            fireRename(oldUri, targetUri);
+            await fireRename(oldUri, targetUri);
             await nextTurn();
             await nextTurn();
 
@@ -5575,19 +5674,19 @@ suite('InlineScriptEnvManager', () => {
             const environment = await createOwnedEnvironment();
             await manager.set(uri, environment);
             const validationManager = manager as unknown as {
-                readCurrentCacheEntrySidecar(
+                inspectCurrentCacheEntrySidecar(
                     candidate: PythonEnvironment,
-                ): Promise<cacheLayout.InlineScriptEnvMeta | undefined>;
+                ): Promise<cacheLayout.InlineScriptMetaReadResult>;
             };
             const sidecar = await makeSidecar({
                 sourceMetadataIdentityHashes: [
                     cacheLayout.hashSourceMetadataIdentity(VALID_METADATA_IDENTITY),
                 ],
             });
-            let resolveSidecar: ((value: cacheLayout.InlineScriptEnvMeta) => void) | undefined;
-            const sidecarStub = sinon.stub(validationManager, 'readCurrentCacheEntrySidecar').callThrough();
+            let resolveSidecar: ((value: cacheLayout.InlineScriptMetaReadResult) => void) | undefined;
+            const sidecarStub = sinon.stub(validationManager, 'inspectCurrentCacheEntrySidecar').callThrough();
             sidecarStub.onFirstCall().returns(
-                new Promise<cacheLayout.InlineScriptEnvMeta>((resolve) => {
+                new Promise<cacheLayout.InlineScriptMetaReadResult>((resolve) => {
                     resolveSidecar = resolve;
                 }),
             );
@@ -5598,7 +5697,7 @@ suite('InlineScriptEnvManager', () => {
             const pendingGet = manager.get(uri);
             await waitForStubCall(sidecarStub);
             await manager.set(uri, undefined);
-            resolveSidecar!(sidecar);
+            resolveSidecar!({ kind: 'valid', metadata: sidecar });
 
             assert.strictEqual(await pendingGet, undefined);
             assert.strictEqual(await manager.get(uri), undefined);
@@ -5611,19 +5710,19 @@ suite('InlineScriptEnvManager', () => {
             const replacementEnvironment = await createOwnedEnvironment('fedcba9876543210');
             await manager.set(uri, oldEnvironment);
             const validationManager = manager as unknown as {
-                readCurrentCacheEntrySidecar(
+                inspectCurrentCacheEntrySidecar(
                     candidate: PythonEnvironment,
-                ): Promise<cacheLayout.InlineScriptEnvMeta | undefined>;
+                ): Promise<cacheLayout.InlineScriptMetaReadResult>;
             };
             const sidecar = await makeSidecar({
                 sourceMetadataIdentityHashes: [
                     cacheLayout.hashSourceMetadataIdentity(VALID_METADATA_IDENTITY),
                 ],
             });
-            let resolveSidecar: ((value: cacheLayout.InlineScriptEnvMeta) => void) | undefined;
-            const sidecarStub = sinon.stub(validationManager, 'readCurrentCacheEntrySidecar').callThrough();
+            let resolveSidecar: ((value: cacheLayout.InlineScriptMetaReadResult) => void) | undefined;
+            const sidecarStub = sinon.stub(validationManager, 'inspectCurrentCacheEntrySidecar').callThrough();
             sidecarStub.onFirstCall().returns(
-                new Promise<cacheLayout.InlineScriptEnvMeta>((resolve) => {
+                new Promise<cacheLayout.InlineScriptMetaReadResult>((resolve) => {
                     resolveSidecar = resolve;
                 }),
             );
@@ -5634,7 +5733,7 @@ suite('InlineScriptEnvManager', () => {
             const pendingGet = manager.get(uri);
             await waitForStubCall(sidecarStub);
             await manager.set(uri, replacementEnvironment);
-            resolveSidecar!(sidecar);
+            resolveSidecar!({ kind: 'valid', metadata: sidecar });
 
             assert.strictEqual(await pendingGet, replacementEnvironment);
             assert.strictEqual(await manager.get(uri), replacementEnvironment);


### PR DESCRIPTION
> Part of #1602. Design: #1601. Follow-up to #1772.

## Summary

Fix PEP 723 inline-script cache and routing issues, make cached environments read-only through the package-management UI, and support deleting one cached environment without clearing the entire script cache.

The feature remains behind the internal, undeclared `python-envs.inlineScripts.enabled` flag, which defaults to `false` and is latched at activation. This does not enable inline scripts by default or add automatic installation on Run/Debug.

## Commits and user-visible changes

| Commit | Problem or missing behavior | Change |
|---|---|---|
| `64960273` | The first package enumeration could be mistaken for an installation, so expanding Packages or refreshing inventory invalidated a working script environment. Case-only Windows renames could also lose the association. | Replace package-event-based drift detection with a recorded inventory hash; hide package mutation actions and reject the palette install path for inline environments; preserve Windows case-only rename associations, including dirty aliases and pending reads. |
| `669ffe18` | A lookup could detect drift and return no environment while routing still advertised the cache as valid and the setup CodeLens remained hidden. Other scripts sharing the entry could retain stale state. | Confirm drift against the current entry, invalidate affected routing/cached validation, and notify environment consumers without requiring a save. Protect newer repairs and selections from stale observations. |
| `1d3ea92a` | Delete Environment was offered in the Projects view, but the inline manager did not implement removal and returned "Remove Environment not supported". | Delete the selected cache entry without a confirmation dialog, clear its known workspace associations, and update the environment collection. Preserve script files, project entries/settings, the base interpreter, and unrelated cache entries. |

## Implementation and behavior notes

### Record package inventory instead of interpreting package events

- When inventory is readable, setup records an `installedPackagesHash` in the entry's `.meta.json`, under the existing cache-entry lock. The hash is computed from sorted, case-normalized `*.dist-info` names, which include distribution names and versions.
- Validation and reuse compare the recorded inventory with disk. Merely expanding or refreshing the package list no longer has authority to invalidate the environment.
- A missing baseline or unreadable inventory is **unknown**, not evidence that packages were added. Existing `manuallyModified` sidecars remain honored.
- The package list stays visible, but inline environments do not offer Install, Uninstall, or Change Version actions in the trees. The palette install command explains that dependencies should be edited in the script's metadata and setup rerun.
- No new package-provider event metadata, per-package operation queues, or provider opt-in interfaces are introduced. The pip, Conda, Poetry, shared package-change helper, and package-watcher implementations are unchanged.

### Keep routing and the setup action consistent

- A confirmed mismatch clears the affected scripts' cached environments and validation state, advances revisions, restores their setup CodeLenses, and publishes environment changes.
- Invalidation rechecks the current sidecar/inventory under a non-waiting cache-entry lock. An observation made before a repair must not invalidate the repaired entry.
- Busy entries and unavailable confirmation reads do not publish stale invalidations. A newer selection wins when an older lookup finishes later.
- Detection is on demand, after the existing five-second validation cache expires; this is not a new background polling service.

### Delete one cached environment

- Delete means physical deletion whether the entry has one associated script or several. It is not silently changed into "detach this script" for shared entries.
- The action has **no confirmation dialog**. Scripts sharing the deleted entry need setup again.
- Reuse the existing cache maintenance, ownership/path checks, locks, and association-cleanup machinery, with a single-entry target. Do not invoke the bulk project-settings cleanup.
- Route an inline Projects-view item through the manager owning the clicked environment, rather than the file's potentially changed fallback manager. Ordinary environment removal keeps its existing routing.
- Reject missing arguments, foreign/out-of-cache targets, redirected entries, and active creation conflicts. Preserve unrelated and unrecognized association records.
- Invalidate a valid sidecar before filesystem removal so an interrupted deletion does not leave surviving cache files trusted as healthy. Report filesystem/persistence failures and update local state for what was actually removed.

## Testing

Local validation before the rebase/signing update (`1afe4bc9`):

- `npm run compile-tests`: passed.
- `npm run compile` (webpack extension bundle): passed.
- `npm run lint`: passed.
- Full unit suite: **2,074 passing, 6 pending**.

Coverage includes get-only drift detection and CodeLens recovery, shared versus unrelated entries, stale observations after newer repairs/selections, real cache-entry locks, unavailable inventory, Windows case-only renames, palette restrictions, targeted deletion without prompting, protected source/settings/base-Python files, already-missing entries, unsafe paths, partial failures, and concurrent create/delete/rehydration.

### Suggested manual verification

These are reviewer checks, not a claim that a full live VS Code end-to-end pass has been completed:

1. Enable `python-envs.inlineScripts.enabled` and reload. Use the Python Environments integration and companion builds that support per-file interpreters.
2. Set up two scripts with the same metadata so they share a cached environment, plus a third script using a different cache entry.
3. Expand/refresh Packages: setup remains valid and inline package mutation actions are absent. The palette install action for an inline project should show guidance rather than install.
4. In a disposable test environment, change installed packages externally. After the validation cache expires, request the script's environment without saving. Verify the affected setup actions return and explicit setup repairs the entry.
5. On Windows, rename `job.py` to `Job.py`; verify the existing environment remains associated and unsaved metadata is not replaced with stale disk metadata.
6. Delete a shared inline environment from the Projects view. Verify there is no confirmation, only that cache entry is deleted, affected scripts need setup again, and the unrelated environment, scripts, project settings, and base Python remain.
7. Exercise a busy/failed deletion and verify it reports failure rather than success. Recheck normal package management/removal for an ordinary venv.

## Scope and known follow-ups

- Inventory comparison is not a full package-integrity audit: it does not inspect package contents or legacy `.egg-info`-only installations.
- Shared cache entries can be referenced by other workspaces. Association cleanup/notifications here are local to the current workspace; other windows notice deletion on revalidation. Cache locks do not track arbitrary running Python processes, so running jobs should be stopped before deletion.
- The current unknown-inventory behavior is retained. The case where an entirely missing `site-packages` directory is accepted during reuse remains a follow-up; deleting the cache entry and running setup provides a recovery path.
- A rejected inline selection can still briefly show the temporary "selected" badge; the actual selection is not changed. That feedback fix is separate from the routing invalidation addressed here.
- Companion-version guidance is covered separately by #1777. No installer-backend, retention-policy, or Run/Debug auto-setup changes are included.
